### PR TITLE
Refine shared header and footer chrome

### DIFF
--- a/docs/architecture/frontend-information-architecture.md
+++ b/docs/architecture/frontend-information-architecture.md
@@ -17,6 +17,7 @@ The public UI should treat these as first-order objects:
 
 ## Navigation model
 
+- `/overview` is the editorial systems-map entrypoint for the protocol workbench
 - `/plans` is the sponsor/operator view
 - `/capital` is the LP and capital-markets view
 - `/claims` is the liability and adjudication view
@@ -26,6 +27,17 @@ The public UI should treat these as first-order objects:
 - `/schemas` explains comparability and series versioning
 
 Legacy `/pools/*` routes are retained only as redirects to avoid carrying pool-first concepts forward in the main UX.
+
+## Overview route
+
+The overview route is not a generic dashboard. It is the protocol entry composition: a sticky editorial hero rail on the left and a flowing access stream on the right.
+
+- The left rail establishes protocol mood and orientation through one large headline, one aggregate network value, a signal-wave moment, and compact metric chips.
+- The right rail is the navigation surface. It stages the major workbench destinations as staggered route cards, then closes with a live field log.
+- Desktop keeps the hero rail visually stable while the document scroll moves the access stream beneath the floating top and bottom chrome.
+- Mobile collapses to one column, but keeps the same sequence and hierarchy instead of inventing a separate dashboard layout.
+
+The approved visual grammar for this route lives in the OmegaX design-system file `references/DESIGN_PROTOCOL_FRONTEND.md`. Treat that document as the source of truth when extending or redesigning `/overview`.
 
 ## Naming rules
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2169,7 +2169,6 @@
     overflow: visible;
   }
 
-  .protocol-footer-copy,
   .workbench-panel-eyebrow,
   .workbench-card-meta,
   .workbench-kpi-label {
@@ -2181,15 +2180,15 @@
   /* ── Protocol top bar ── */
 
   .protocol-topbar {
-    --protocol-topbar-control-height: 2.5rem;
+    --protocol-topbar-control-height: 2.25rem;
     position: sticky;
     top: 0;
     z-index: 60;
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
-    padding: calc(env(safe-area-inset-top, 0px) + 0.7rem) 0 0.5rem;
+    gap: 0.4rem;
+    padding: calc(env(safe-area-inset-top, 0px) + 0.65rem) 0 0.45rem;
     background: transparent;
     border-bottom: none;
     backdrop-filter: none;
@@ -2212,8 +2211,8 @@
     width: var(--protocol-chrome-width);
     margin-inline: auto;
     min-height: var(--protocol-topbar-control-height);
-    padding: 0.72rem 1.15rem;
-    border-radius: 1.75rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 1.6rem;
     border: 1px solid rgba(255, 255, 255, 0.42);
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(248, 249, 250, 0.36) 100%);
@@ -2238,7 +2237,7 @@
   .protocol-topbar-left {
     display: flex;
     align-items: center;
-    gap: 1.35rem;
+    gap: 1.85rem;
     min-height: var(--protocol-topbar-control-height);
     min-width: 0;
   }
@@ -2253,8 +2252,8 @@
   }
 
   .protocol-topbar-wordmark-image {
-    width: 16.5rem;
-    max-width: min(34vw, 16.5rem);
+    width: 11.25rem;
+    max-width: min(28vw, 11.25rem);
     height: auto;
     filter: brightness(0) saturate(100%);
   }
@@ -2266,7 +2265,7 @@
   .protocol-topbar-nav {
     display: flex;
     align-items: center;
-    gap: 1.1rem;
+    gap: 1.6rem;
     min-height: var(--protocol-topbar-control-height);
     flex: 0 1 auto;
     min-width: 0;
@@ -2282,14 +2281,14 @@
     padding: 0 0.08rem;
     border-radius: 0;
     font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
-    font-size: 0.6875rem;
-    font-weight: 700;
+    font-size: 0.7rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.18em;
     text-decoration: none;
     white-space: nowrap;
     color: var(--foreground);
-    opacity: 0.56;
+    opacity: 0.5;
     transition:
       opacity 180ms ease,
       color 180ms ease,
@@ -2299,19 +2298,20 @@
   .protocol-topbar-tab::after {
     content: "";
     position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0.36rem;
-    height: 2px;
+    left: 50%;
+    bottom: 0.32rem;
+    width: 1.25rem;
+    height: 1.5px;
+    margin-left: -0.625rem;
     border-radius: 999px;
-    background:
-      linear-gradient(90deg, rgba(51, 197, 244, 0.28), rgba(51, 197, 244, 0.96) 50%, rgba(51, 197, 244, 0.28));
+    background: var(--cyan-ink);
     opacity: 0;
-    transform: scaleX(0.72);
+    transform: scaleX(0.6);
     transform-origin: center;
     transition:
       opacity 180ms ease,
-      transform 180ms ease;
+      transform 180ms ease,
+      width 180ms ease;
   }
 
   .protocol-topbar-tab:hover,
@@ -2324,6 +2324,7 @@
   .protocol-topbar-tab-active {
     color: var(--foreground);
     opacity: 1;
+    font-weight: 600;
   }
 
   .protocol-topbar-tab-active::after {
@@ -2337,147 +2338,26 @@
   }
 
   .protocol-topbar-badge {
-    min-width: 1.15rem;
-    padding: 0.08rem 0.3rem;
+    min-width: 1.05rem;
+    padding: 0.06rem 0.32rem;
     border-radius: 999px;
-    background: rgba(51, 197, 244, 0.12);
+    background: rgba(51, 197, 244, 0.1);
     color: var(--cyan-ink);
-    font-size: 0.56rem;
-    font-weight: 700;
-    line-height: 1.1;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.54rem;
+    font-weight: 600;
+    line-height: 1.15;
+    letter-spacing: 0.04em;
     text-align: center;
-    border: 1px solid rgba(51, 197, 244, 0.2);
+    border: 1px solid rgba(51, 197, 244, 0.18);
   }
 
   .protocol-topbar-controls {
     display: flex;
     align-items: center;
-    gap: 0.85rem;
+    gap: 0.55rem;
     min-height: var(--protocol-topbar-control-height);
     flex-shrink: 0;
-  }
-
-  .protocol-topbar-icon-group {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    min-height: var(--protocol-topbar-control-height);
-    padding-right: 0.75rem;
-    border-right: 1px solid rgba(186, 201, 204, 0.3);
-    color: var(--muted-foreground);
-  }
-
-  .dark .protocol-topbar-icon-group {
-    border-right-color: rgba(148, 163, 184, 0.15);
-  }
-
-  .protocol-topbar-icon-group .material-symbols-outlined {
-    display: block;
-    font-size: 1.125rem;
-    line-height: 1;
-  }
-
-  .protocol-topbar-icon-link {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 999px;
-    color: inherit;
-    text-decoration: none;
-    background: rgba(255, 255, 255, 0.28);
-    border: 1px solid rgba(186, 201, 204, 0.22);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.55),
-      0 8px 18px -14px rgba(25, 28, 29, 0.22);
-    transition:
-      color 180ms ease,
-      background-color 180ms ease,
-      border-color 180ms ease,
-      box-shadow 180ms ease,
-      transform 180ms ease;
-  }
-
-  .dark .protocol-topbar-icon-link {
-    background: rgba(15, 23, 42, 0.48);
-    border-color: rgba(148, 163, 184, 0.16);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.04),
-      0 10px 24px -18px rgba(0, 0, 0, 0.5);
-  }
-
-  .protocol-topbar-icon-link:hover,
-  .protocol-topbar-icon-link:focus-visible {
-    color: var(--foreground);
-    background: rgba(51, 197, 244, 0.12);
-    border-color: rgba(51, 197, 244, 0.32);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.55),
-      0 0 0 1px rgba(51, 197, 244, 0.1),
-      0 14px 28px -22px rgba(51, 197, 244, 0.8);
-    outline: none;
-    transform: translateY(-1px);
-  }
-
-  .dark .protocol-topbar-icon-link:hover,
-  .dark .protocol-topbar-icon-link:focus-visible {
-    background: rgba(51, 197, 244, 0.14);
-    border-color: rgba(51, 197, 244, 0.28);
-  }
-
-  .protocol-topbar-icon-link-active {
-    color: var(--cyan-ink);
-    background: rgba(51, 197, 244, 0.14);
-    border-color: rgba(51, 197, 244, 0.28);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.55),
-      0 0 0 1px rgba(51, 197, 244, 0.08),
-      0 18px 32px -24px rgba(51, 197, 244, 0.9);
-  }
-
-  .dark .protocol-topbar-icon-link-active {
-    background: rgba(51, 197, 244, 0.16);
-  }
-
-  .protocol-topbar-icon-link::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    z-index: 24;
-    left: 50%;
-    top: calc(100% + max(0.45rem, env(safe-area-inset-top, 0px) * 0.15));
-    transform: translate(-50%, -0.2rem);
-    padding: 0.42rem 0.58rem;
-    border-radius: 999px;
-    border: 1px solid rgba(186, 201, 204, 0.3);
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--foreground);
-    font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
-    font-size: 0.625rem;
-    font-weight: 700;
-    letter-spacing: 0.16em;
-    line-height: 1;
-    text-transform: uppercase;
-    white-space: nowrap;
-    pointer-events: none;
-    opacity: 0;
-    box-shadow: 0 18px 32px -24px rgba(25, 28, 29, 0.3);
-    transition:
-      opacity 160ms ease,
-      transform 160ms ease;
-  }
-
-  .dark .protocol-topbar-icon-link::after {
-    background: rgba(10, 21, 37, 0.94);
-    border-color: rgba(148, 163, 184, 0.18);
-    color: var(--foreground);
-  }
-
-  .protocol-topbar-icon-link:hover::after,
-  .protocol-topbar-icon-link:focus-visible::after {
-    opacity: 1;
-    transform: translate(-50%, 0);
   }
 
   .protocol-topbar-status-row {
@@ -2494,8 +2374,8 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 0.46rem 1rem;
-    border-radius: 1.25rem;
+    padding: 0.4rem 1.05rem;
+    border-radius: 1.1rem;
     border: 1px solid rgba(255, 255, 255, 0.22);
     background:
       linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(248, 249, 250, 0.18) 100%);
@@ -2531,24 +2411,27 @@
 
   .protocol-topbar-status-item {
     display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
-    font-size: 0.625rem;
-    font-weight: 700;
-    letter-spacing: 0.2em;
+    align-items: baseline;
+    gap: 0.45rem;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.6rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
     white-space: nowrap;
   }
 
   .protocol-topbar-status-key {
     color: var(--muted-foreground);
-    opacity: 0.6;
+    opacity: 0.55;
+    font-weight: 500;
   }
 
   .protocol-topbar-status-val {
-    color: var(--accent);
+    color: var(--foreground);
     font-family: var(--font-mono), "Fira Code", monospace;
+    font-weight: 500;
+    opacity: 0.95;
   }
 
   .protocol-topbar-sync-dot {
@@ -2566,11 +2449,11 @@
   }
 
   .protocol-topbar-sync-label {
-    font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
-    font-size: 0.625rem;
-    font-weight: 700;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.6rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.18em;
     color: var(--cyan-ink);
   }
 
@@ -2626,16 +2509,17 @@
   .protocol-toolbar-button {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.45rem;
     min-height: var(--protocol-topbar-control-height);
-    padding: 0.5rem 1rem;
+    padding: 0.4rem 0.85rem;
     border-radius: 999px;
-    border: 1px solid rgba(186, 201, 204, 0.2);
-    background: rgba(241, 244, 247, 0.8);
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.6875rem;
+    border: 1px solid rgba(186, 201, 204, 0.22);
+    background: rgba(241, 244, 247, 0.62);
+    font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
+    font-size: 0.66rem;
     font-weight: 500;
-    letter-spacing: -0.02em;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
     color: var(--foreground);
     cursor: pointer;
     transition:
@@ -2661,8 +2545,8 @@
     width: var(--protocol-topbar-control-height);
     min-height: var(--protocol-topbar-control-height);
     border-radius: 999px;
-    border: 1px solid rgba(186, 201, 204, 0.2);
-    background: rgba(241, 244, 247, 0.8);
+    border: 1px solid rgba(186, 201, 204, 0.22);
+    background: rgba(241, 244, 247, 0.62);
     color: var(--foreground);
     cursor: pointer;
     transition:
@@ -2683,13 +2567,13 @@
 
   .protocol-topbar-wallet .wallet-control-button {
     min-height: var(--protocol-topbar-control-height);
-    padding: 0.28rem 0.72rem 0.28rem 0.44rem;
-    gap: 0.58rem;
+    padding: 0.22rem 0.7rem 0.22rem 0.36rem;
+    gap: 0.5rem;
   }
 
   .protocol-topbar-wallet .wallet-control-leading {
-    width: 1.55rem;
-    height: 1.55rem;
+    width: 1.4rem;
+    height: 1.4rem;
   }
 
   .protocol-topbar-wallet .wallet-control-copy {
@@ -2698,7 +2582,9 @@
   }
 
   .protocol-topbar-wallet .wallet-control-title {
-    font-size: 0.78rem;
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
     line-height: 1.05;
   }
 
@@ -2825,13 +2711,13 @@
     position: sticky;
     bottom: clamp(0.55rem, 1vw, 0.95rem);
     z-index: 45;
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: center;
-    justify-content: space-between;
     width: var(--protocol-chrome-width);
     margin-inline: auto;
-    gap: 1rem;
-    padding: 0.95rem 1.35rem calc(0.95rem + env(safe-area-inset-bottom, 0px));
+    gap: 1.25rem;
+    padding: 0.85rem 1.4rem calc(0.85rem + env(safe-area-inset-bottom, 0px));
     border-radius: 1.5rem;
     border-top: 1px solid rgba(255, 255, 255, 0.52);
     background:
@@ -2855,46 +2741,95 @@
       inset 0 -1px 20px rgba(0, 229, 255, 0.03);
   }
 
-  .protocol-footer-copy {
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.6875rem;
+  .protocol-footer-identity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.18rem;
+    min-width: 0;
+    justify-self: start;
+  }
+
+  .protocol-footer-mark {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    color: var(--foreground);
+  }
+
+  .protocol-footer-legal {
+    font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
+    font-size: 0.625rem;
     font-weight: 400;
-    text-transform: uppercase;
-    letter-spacing: 0.24em;
-    color: var(--muted-foreground);
-    line-height: 1.4;
+    line-height: 1.2;
+    letter-spacing: 0.01em;
+    color: color-mix(in oklab, var(--muted-foreground) 92%, transparent);
   }
 
   .protocol-footer-links {
     display: flex;
     align-items: center;
-    gap: 2rem;
+    gap: 1.65rem;
+    justify-self: center;
   }
 
   .protocol-footer-link {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.4rem;
     font-family: var(--font-sans), "Space Grotesk", system-ui, sans-serif;
-    font-size: 0.6875rem;
-    font-weight: 700;
+    font-size: 0.66rem;
+    font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: color-mix(in oklab, var(--foreground) 62%, transparent);
+    letter-spacing: 0.18em;
+    color: color-mix(in oklab, var(--foreground) 64%, transparent);
     text-decoration: none;
-    border-bottom: 1px solid rgba(0, 104, 117, 0.2);
-    padding-bottom: 0.125rem;
-    line-height: 1.1;
-    transition: color 180ms ease;
+    line-height: 1;
+    padding-bottom: 0.18rem;
+    border-bottom: 1px solid transparent;
+    transition:
+      color 180ms ease,
+      border-color 180ms ease;
     cursor: pointer;
   }
 
-  .protocol-footer-link-icon {
-    width: 0.85rem;
-    height: 0.85rem;
-    flex: 0 0 auto;
-    opacity: 0.75;
-    stroke-width: 2.1;
+  .protocol-footer-build {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    justify-self: end;
+    padding: 0.32rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    background: color-mix(in oklab, var(--surface-elevated) 55%, transparent);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.58rem;
+    font-weight: 500;
+    line-height: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: color-mix(in oklab, var(--muted-foreground) 95%, transparent);
+    white-space: nowrap;
+  }
+
+  .protocol-footer-build-version {
+    color: var(--foreground);
+    opacity: 0.85;
+  }
+
+  .protocol-footer-build-network {
+    color: var(--cyan-ink);
+    opacity: 0.95;
+  }
+
+  .protocol-footer-build-sep {
+    width: 1px;
+    height: 0.65rem;
+    background: color-mix(in oklab, var(--border) 70%, transparent);
   }
 
   .protocol-footer-overview {
@@ -2926,13 +2861,27 @@
   }
 
   .dark .protocol-footer-link {
-    border-bottom-color: rgba(51, 197, 244, 0.2);
+    color: color-mix(in oklab, var(--foreground) 68%, transparent);
+  }
+
+  .dark .protocol-footer-legal {
+    color: color-mix(in oklab, var(--muted-foreground) 88%, transparent);
+  }
+
+  .dark .protocol-footer-mark {
+    color: color-mix(in oklab, var(--foreground) 92%, transparent);
   }
 
   .protocol-footer-link:hover,
   .protocol-footer-link:focus-visible {
     color: var(--cyan-ink);
+    border-bottom-color: color-mix(in oklab, var(--cyan-ink) 60%, transparent);
     outline: none;
+  }
+
+  .dark .protocol-footer-build {
+    border-color: color-mix(in oklab, var(--border) 38%, transparent);
+    background: color-mix(in oklab, var(--surface-elevated) 38%, transparent);
   }
 
   .workbench-page {
@@ -5770,12 +5719,6 @@
     flex-shrink: 0;
   }
 
-  @media (max-width: 1320px) {
-    .protocol-topbar-icon-group {
-      display: none;
-    }
-  }
-
   @media (max-width: 1279px) {
     .workbench-page {
       grid-template-columns: 1fr;
@@ -5917,10 +5860,6 @@
       display: none;
     }
 
-    .protocol-topbar-icon-group {
-      display: none;
-    }
-
     .protocol-topbar {
       --protocol-chrome-gutter: 0.85rem;
       padding: calc(env(safe-area-inset-top, 0px) + 0.55rem) 0 0.45rem;
@@ -5928,21 +5867,54 @@
     }
 
     .protocol-topbar-row {
-      padding: 0.62rem 0.8rem;
+      padding: 0.55rem 0.7rem;
       border-radius: 1.4rem;
+      gap: 0.55rem;
+    }
+
+    .protocol-topbar-controls {
+      gap: 0.35rem;
+    }
+
+    .protocol-topbar-left {
+      gap: 0.65rem;
     }
 
     .protocol-topbar-status-pill {
-      padding-inline: 0.8rem;
+      padding: 0.4rem 0.85rem;
     }
 
     .protocol-topbar-wordmark-image {
-      width: 12.5rem;
-      max-width: min(52vw, 12.5rem);
+      width: 8.5rem;
+      max-width: min(38vw, 8.5rem);
     }
 
     .protocol-topbar-status-left {
-      gap: 1rem;
+      gap: 0.9rem;
+    }
+
+    .protocol-topbar-status-item {
+      font-size: 0.55rem;
+      gap: 0.35rem;
+    }
+
+    .protocol-topbar-sync-label {
+      display: none;
+    }
+
+    .protocol-topbar-sync-icon {
+      margin-left: 0.25rem;
+    }
+
+    .protocol-topbar-status-right {
+      gap: 0.35rem;
+    }
+
+    .protocol-toolbar-button {
+      padding: 0.4rem 0.65rem;
+      font-size: 0.6rem;
+      letter-spacing: 0.1em;
+      gap: 0.35rem;
     }
 
     .protocol-mobile-nav {
@@ -5988,6 +5960,32 @@
 
     .protocol-mobile-wallet {
       padding-top: 0.15rem;
+    }
+
+    .protocol-footer {
+      grid-template-columns: 1fr;
+      justify-items: center;
+      text-align: center;
+      gap: 0.75rem;
+      padding: 0.85rem 0.95rem calc(0.85rem + env(safe-area-inset-bottom, 0px));
+      border-radius: 1.2rem;
+    }
+
+    .protocol-footer-identity {
+      align-items: center;
+      justify-self: center;
+      gap: 0.22rem;
+    }
+
+    .protocol-footer-links {
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.85rem 1.15rem;
+      justify-self: center;
+    }
+
+    .protocol-footer-build {
+      justify-self: center;
     }
 
     .wallet-surface-shell {
@@ -6181,17 +6179,6 @@
 
     .wallet-segment-row {
       grid-template-columns: 1fr;
-    }
-
-    .protocol-footer {
-      flex-wrap: wrap;
-      gap: 0.75rem 1rem;
-      padding: 0.8rem 0.85rem calc(0.8rem + env(safe-area-inset-bottom, 0px));
-      border-radius: 1.2rem;
-    }
-
-    .protocol-footer-links {
-      gap: 1rem;
     }
 
     .workbench-kpi-grid,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2042,12 +2042,12 @@
       inset 0 2px 4px rgba(0,0,0,0.1);
   }
   .micro-etch {
-    background-image: radial-gradient(circle, rgba(0, 104, 117, 0.08) 0.9px, transparent 1.4px);
+    background-image: radial-gradient(circle, rgba(0, 104, 117, 0.11) 0.9px, transparent 1.4px);
     background-size: 26px 26px;
   }
 
   .dark .micro-etch {
-    background-image: radial-gradient(circle, rgba(0, 229, 255, 0.08) 0.9px, transparent 1.4px);
+    background-image: radial-gradient(circle, rgba(0, 229, 255, 0.11) 0.9px, transparent 1.4px);
   }
   .misty-cyan-glow {
     background: radial-gradient(circle at center, rgba(0,229,255,0.12) 0%, transparent 70%);
@@ -2112,6 +2112,8 @@
   .protocol-workbench-shell {
     --protocol-chrome-gutter: clamp(0.85rem, 1.7vw, 1.5rem);
     --protocol-chrome-width: min(calc(100vw - (var(--protocol-chrome-gutter) * 2)), var(--app-max-width));
+    --protocol-workbench-top-overlap: calc(env(safe-area-inset-top, 0px) + 8.25rem);
+    --protocol-workbench-bottom-overlap: calc(env(safe-area-inset-bottom, 0px) + 4.75rem);
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -2136,12 +2138,13 @@
       linear-gradient(180deg, #07111e 0%, var(--background) 45%, #081420 100%);
   }
 
-  .protocol-workbench-shell-overview {
-    --protocol-overview-top-overlap: calc(env(safe-area-inset-top, 0px) + 8.25rem);
-    --protocol-overview-bottom-overlap: calc(env(safe-area-inset-bottom, 0px) + 4.75rem);
+  .protocol-workbench-shell-fullscreen {
     height: auto;
     min-height: 100vh;
     overflow: visible;
+  }
+
+  .protocol-workbench-shell-overview {
     background:
       radial-gradient(circle at 14% 0%, rgba(51, 197, 244, 0.06), transparent 24%),
       radial-gradient(circle at 84% 0%, rgba(0, 104, 117, 0.05), transparent 20%),
@@ -2157,12 +2160,12 @@
       linear-gradient(180deg, #06101b 0%, var(--background) 46%, #07111d 100%);
   }
 
-  .protocol-workbench-shell-overview .protocol-topbar {
+  .protocol-workbench-shell-fullscreen .protocol-topbar {
     position: fixed;
     inset: 0 0 auto;
   }
 
-  .protocol-workbench-shell-overview .protocol-workbench-content {
+  .protocol-workbench-shell-fullscreen .protocol-workbench-content {
     overflow: visible;
   }
 
@@ -2785,15 +2788,15 @@
     overflow: hidden;
   }
 
-  .protocol-workbench-content-overview {
+  .protocol-workbench-content-fullscreen {
     display: block;
     min-height: auto;
     margin-top: 0;
     margin-bottom: 0;
     padding:
-      calc(var(--protocol-overview-top-overlap) + 0.8rem)
+      calc(var(--protocol-workbench-top-overlap) + 0.8rem)
       1.15rem
-      calc(var(--protocol-overview-bottom-overlap) + 2rem);
+      calc(var(--protocol-workbench-bottom-overlap) + 2rem);
     overflow: visible;
     scroll-padding-top: 0;
     scroll-padding-bottom: 0;
@@ -2801,11 +2804,18 @@
     scrollbar-width: auto;
   }
 
-  .protocol-workbench-content-overview::-webkit-scrollbar {
+  .protocol-workbench-content-overview {
+    padding:
+      calc(var(--protocol-workbench-top-overlap) + 0.8rem)
+      1.15rem
+      calc(var(--protocol-workbench-bottom-overlap) + 2rem);
+  }
+
+  .protocol-workbench-content-fullscreen::-webkit-scrollbar {
     display: initial;
   }
 
-  .protocol-workbench-content-overview > * {
+  .protocol-workbench-content-fullscreen > * {
     min-height: auto;
   }
 
@@ -2907,7 +2917,7 @@
       inset 0 -1px 18px rgba(0, 229, 255, 0.025);
   }
 
-  .protocol-workbench-shell-overview .protocol-footer-overview {
+  .protocol-footer-fullscreen {
     position: fixed;
     left: 50%;
     bottom: clamp(0.55rem, 1vw, 0.95rem);
@@ -4072,7 +4082,7 @@
       margin-right: 0;
     }
 
-    .protocol-workbench-shell-overview .protocol-topbar {
+    .protocol-workbench-shell-fullscreen .protocol-topbar {
       position: sticky;
       inset: auto;
       top: 0;
@@ -4463,317 +4473,914 @@
     text-align: right;
   }
 
-  /* ── Plans Dashboard ── */
+  /* ── Plans Workbench ─────────────────────────────── */
 
-  .plans-dashboard {
-    display: grid;
-    gap: 1rem;
+  .plans-shell {
+    position: relative;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
   }
 
-  .plans-header {
+  .plans-scroll {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    padding: 1.25rem 1.5rem;
-    border-radius: 1.25rem;
-    background: rgba(255, 255, 255, 0.7);
-    backdrop-filter: blur(25px);
-    -webkit-backdrop-filter: blur(25px);
-    border: 1px solid rgba(255, 255, 255, 0.8);
-    box-shadow:
-      0 30px 60px -15px rgba(25, 28, 29, 0.08),
-      inset 0 0 0 1px rgba(255, 255, 255, 1);
-  }
-  .dark .plans-header {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    box-shadow:
-      0 30px 60px -15px rgba(0, 0, 0, 0.2),
-      inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    gap: clamp(1.1rem, 1.8vw, 1.65rem);
+    width: min(100%, 92rem);
+    height: 100%;
+    margin: 0 auto;
+    padding: clamp(0.35rem, 0.8vw, 0.65rem) clamp(0.1rem, 0.8vw, 0.5rem) clamp(2rem, 3vw, 3rem);
+    overflow-y: auto;
+    overflow-x: hidden;
+    scroll-behavior: smooth;
   }
 
-  /* Keep old class for backwards compat */
-  .plans-hero { display: none; }
+  .plans-scroll::-webkit-scrollbar {
+    width: 8px;
+  }
+  .plans-scroll::-webkit-scrollbar-track { background: transparent; }
+  .plans-scroll::-webkit-scrollbar-thumb {
+    background: color-mix(in oklab, var(--border) 50%, transparent);
+    border-radius: 999px;
+  }
 
-  .plans-selector-row {
+  /* ── Hero ── */
+
+  .plans-hero {
+    position: relative;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.75rem;
-    max-width: 42rem;
+    grid-template-columns: minmax(0, 1.05fr) minmax(22rem, 0.95fr);
+    gap: clamp(1.5rem, 3vw, 2.75rem);
+    align-items: end;
+    padding: clamp(0.6rem, 1.2vw, 1.1rem) clamp(0.75rem, 1vw, 1.1rem) 0;
+    isolation: isolate;
   }
 
-  .plans-metrics-strip {
-    display: flex;
-    align-items: stretch;
-    gap: 0;
+  .plans-hero-glow {
+    position: absolute;
+    inset: -2rem -2rem auto -2rem;
+    height: 18rem;
+    background: radial-gradient(
+      ellipse 72% 60% at 22% 35%,
+      rgba(0, 229, 255, 0.12) 0%,
+      transparent 60%
+    );
+    pointer-events: none;
+    z-index: -1;
   }
 
-  .plans-strip-metric {
+  .dark .plans-hero-glow {
+    background: radial-gradient(
+      ellipse 72% 60% at 22% 35%,
+      rgba(0, 229, 255, 0.09) 0%,
+      transparent 65%
+    );
+  }
+
+  .plans-hero-copy {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: 0.15rem;
-    padding: 0 1.25rem;
-    border-left: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+    gap: 0.85rem;
+    min-width: 0;
   }
-  .plans-strip-metric:first-child { border-left: none; padding-left: 0; }
 
-  .plans-strip-metric-val {
+  .plans-hero-eyebrow {
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--foreground);
-    line-height: 1;
-  }
-  .plans-strip-metric-primary .plans-strip-metric-val {
-    color: var(--accent);
-  }
-
-  .plans-strip-metric-label {
-    font-size: 0.625rem;
-    font-weight: 700;
+    font-size: 0.62rem;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.28em;
     color: var(--muted-foreground);
   }
 
+  .plans-hero-title {
+    margin: 0;
+    max-width: 12ch;
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: clamp(2.8rem, 6vw, 5.4rem);
+    font-weight: 500;
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+    color: var(--foreground);
+    text-wrap: balance;
+  }
+
+  .plans-hero-title em {
+    color: var(--cyan-ink);
+    font-style: italic;
+    font-weight: 500;
+  }
+
+  .plans-hero-subtitle {
+    margin: 0;
+    max-width: 42ch;
+    font-size: 0.88rem;
+    line-height: 1.55;
+    color: var(--muted-foreground);
+  }
+
+  .plans-hero-selectors {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: stretch;
+    gap: 0;
+    padding: 0.85rem 0.95rem;
+    border-radius: 1.25rem;
+    min-height: 5.4rem;
+  }
+
+  .plans-hero-selectors-divider {
+    align-self: stretch;
+    width: 1px;
+    margin: 0.25rem 0.4rem;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      color-mix(in oklab, var(--border-strong) 55%, transparent) 50%,
+      transparent 100%
+    );
+  }
+
+  .plans-hero-select {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.4rem 0.65rem;
+    border-radius: 0.85rem;
+    cursor: pointer;
+    min-width: 0;
+    transition: background-color 160ms ease;
+  }
+
+  .plans-hero-select:hover,
+  .plans-hero-select:focus-within {
+    background: color-mix(in oklab, var(--signal-soft) 60%, transparent);
+  }
+
+  .plans-hero-select-disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+  .plans-hero-select-disabled:hover,
+  .plans-hero-select-disabled:focus-within {
+    background: transparent;
+  }
+
+  .plans-hero-select-eyebrow {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.56rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--accent);
+    opacity: 0.82;
+  }
+
+  .plans-hero-select-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+    min-width: 0;
+  }
+
+  .plans-hero-select-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+
+  .plans-hero-select-label {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--foreground);
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .plans-hero-select-meta {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.66rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .plans-hero-select-caret {
+    flex-shrink: 0;
+    font-size: 1.1rem;
+    color: var(--muted-foreground);
+    opacity: 0.7;
+  }
+
+  .plans-hero-select-native {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: inherit;
+    font: inherit;
+    border: none;
+    background: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  .plans-hero-select-disabled .plans-hero-select-native {
+    cursor: not-allowed;
+  }
+
+  /* ── Live dot ── */
+
   .plans-live-dot {
     display: inline-block;
-    width: 0.375rem;
-    height: 0.375rem;
+    width: 0.4rem;
+    height: 0.4rem;
     border-radius: 999px;
     background: var(--signal);
-    box-shadow: 0 0 6px rgba(0, 229, 255, 0.4);
-    animation: plans-pulse 2s ease-in-out infinite;
+    box-shadow: 0 0 10px rgba(0, 229, 255, 0.55);
+    animation: plans-pulse 2.2s ease-in-out infinite;
     vertical-align: middle;
   }
 
   @keyframes plans-pulse {
-    0%, 100% { opacity: 0.5; }
-    50% { opacity: 1; }
+    0%, 100% { opacity: 0.45; transform: scale(0.88); }
+    50% { opacity: 1; transform: scale(1); }
   }
 
-  .plans-tab-bar {
-    display: flex;
-    flex-wrap: wrap;
+  /* ── KPI strip ── */
+
+  .plans-kpi-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0;
-    padding: 0;
-    border-bottom: 1px solid var(--border);
+    padding: 0.1rem clamp(0.75rem, 1vw, 1.1rem);
   }
 
-  .dark .plans-tab-bar {
-    border-color: rgba(255, 255, 255, 0.07);
+  .plans-kpi-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.35rem 1.15rem 0.35rem;
+    border-left: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+    min-width: 0;
   }
+  .plans-kpi-metric:first-child {
+    border-left: none;
+    padding-left: 0.2rem;
+  }
+
+  .plans-kpi-label {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.56rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--muted-foreground);
+  }
+
+  .plans-kpi-value {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: clamp(1.5rem, 2.2vw, 1.95rem);
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: -0.03em;
+    color: var(--foreground);
+  }
+
+  .plans-kpi-pulse {
+    display: inline-block;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 999px;
+    background: var(--signal);
+    box-shadow: 0 0 12px rgba(0, 229, 255, 0.5);
+    animation: plans-pulse 2.2s ease-in-out infinite;
+    transform: translateY(-0.18rem);
+  }
+
+  .plans-kpi-meta {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.62rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* ── Tab bar ── */
+
+  .plans-tabs {
+    position: relative;
+    padding: 0.35rem;
+    border-radius: 999px;
+    margin-inline: clamp(0.5rem, 1vw, 1rem);
+  }
+
+  .plans-tabs-inner {
+    display: flex;
+    gap: 0.15rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .plans-tabs-inner::-webkit-scrollbar { display: none; }
 
   .plans-tab {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    min-height: 2.2rem;
-    padding: 0.4rem 0.65rem 0.65rem;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: max-content;
+    padding: 0.65rem 1rem;
     border: none;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
+    border-radius: 999px;
     background: transparent;
     color: var(--muted-foreground);
     font-size: 0.82rem;
     font-weight: 600;
     cursor: pointer;
-    transition: border-color 180ms ease, color 180ms ease;
+    white-space: nowrap;
+    transition:
+      background-color 220ms cubic-bezier(0.16, 1, 0.3, 1),
+      color 220ms ease,
+      box-shadow 220ms ease,
+      transform 220ms ease;
+    justify-content: center;
   }
 
-  .plans-tab:hover,
-  .plans-tab:focus-visible {
+  .plans-tab:hover {
     color: var(--foreground);
-    outline: none;
+  }
+
+  .plans-tab:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--accent) 45%, transparent);
+    outline-offset: 2px;
   }
 
   .plans-tab-active {
     color: var(--accent);
-    border-bottom-color: var(--accent);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow:
+      0 4px 14px -4px rgba(10, 21, 37, 0.12),
+      inset 0 0 0 1px rgba(255, 255, 255, 1);
   }
 
   .dark .plans-tab-active {
+    background: rgba(10, 21, 37, 0.65);
+    box-shadow:
+      0 4px 14px -4px rgba(0, 0, 0, 0.45),
+      inset 0 0 0 1px rgba(51, 197, 244, 0.18);
+  }
+
+  .plans-tab-number {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.3rem;
+    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    color: var(--muted-foreground);
+    transition: color 180ms ease, border-color 180ms ease, background-color 180ms ease;
+  }
+
+  .plans-tab-active .plans-tab-number {
     color: var(--accent);
-    border-bottom-color: var(--accent);
+    background: color-mix(in oklab, var(--signal-soft) 65%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 25%, transparent);
   }
 
   .plans-tab-icon {
-    font-size: 1rem;
-    opacity: 0.7;
+    font-size: 1.05rem;
+    opacity: 0.65;
+    transition: opacity 180ms ease;
   }
 
   .plans-tab-active .plans-tab-icon {
     opacity: 1;
-    color: var(--accent);
   }
 
-  .plans-content-grid {
+  .plans-tab-label {
+    font-weight: 600;
+  }
+
+  /* ── Body layout ── */
+
+  .plans-body {
     display: grid;
     grid-template-columns: minmax(0, 1.7fr) minmax(20rem, 0.95fr);
-    gap: 1rem;
+    gap: clamp(0.85rem, 1.2vw, 1.35rem);
     align-items: start;
+    padding: 0 clamp(0.5rem, 1vw, 1rem);
   }
 
   .plans-main {
-    display: grid;
-    gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.85rem, 1.2vw, 1.25rem);
     min-width: 0;
   }
 
   .plans-rail {
-    display: grid;
-    gap: 1rem;
-    min-width: 0;
-  }
-
-  .plans-card {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    padding: 1.25rem;
-    border-radius: 1.25rem;
-    background: rgba(255, 255, 255, 0.7);
-    backdrop-filter: blur(25px);
-    -webkit-backdrop-filter: blur(25px);
-    border: 1px solid rgba(255, 255, 255, 0.8);
-    box-shadow:
-      0 30px 60px -15px rgba(25, 28, 29, 0.08),
-      inset 0 0 0 1px rgba(255, 255, 255, 1);
+    gap: clamp(0.85rem, 1.2vw, 1.25rem);
+    min-width: 0;
+    position: sticky;
+    top: 0.5rem;
   }
 
-  .dark .plans-card {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    box-shadow:
-      0 30px 60px -15px rgba(0, 0, 0, 0.2),
-      inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  .plans-stack {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.85rem, 1.2vw, 1.25rem);
+  }
+
+  /* ── Cards (shared) ── */
+
+  .plans-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: clamp(1.1rem, 1.6vw, 1.5rem);
+    border-radius: 1.5rem;
+    overflow: hidden;
   }
 
   .plans-card-head {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 0.6rem;
+    gap: 0.65rem;
   }
 
   .plans-card-eyebrow {
-    margin: 0 0 0.12rem;
+    margin: 0 0 0.35rem;
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.55rem;
     text-transform: uppercase;
-    letter-spacing: 0.25em;
+    letter-spacing: 0.24em;
     color: var(--muted-foreground);
   }
 
   .plans-card-title {
     margin: 0;
-    font-size: 1.05rem;
-    line-height: 1.2;
+    font-size: 1.08rem;
+    line-height: 1.25;
     font-weight: 700;
     color: var(--foreground);
+    letter-spacing: -0.01em;
+  }
+
+  .plans-card-title-display {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: clamp(1.7rem, 2.5vw, 2.35rem);
+    font-weight: 500;
+    line-height: 1.05;
+    letter-spacing: -0.035em;
+  }
+
+  .plans-card-title-display em {
+    color: var(--cyan-ink);
+    font-style: italic;
+    font-weight: 500;
   }
 
   .plans-card-meta {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    min-height: 1.5rem;
-    padding: 0.12rem 0.45rem;
-    border-radius: 0.55rem;
-    background: color-mix(in oklab, var(--signal-soft) 86%, white 14%);
+    gap: 0.35rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--signal-soft) 72%, transparent);
     color: var(--accent);
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.56rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.15em;
+    letter-spacing: 0.16em;
     flex-shrink: 0;
+    border: 1px solid color-mix(in oklab, var(--accent) 18%, transparent);
+  }
+
+  .plans-card-meta-warn {
+    color: var(--warning);
+    background: color-mix(in oklab, var(--warning) 10%, transparent);
+    border-color: color-mix(in oklab, var(--warning) 22%, transparent);
   }
 
   .plans-card-body {
     margin: 0;
     color: var(--muted-foreground);
-    font-size: 0.82rem;
-    line-height: 1.45;
+    font-size: 0.86rem;
+    line-height: 1.55;
+    max-width: 52ch;
   }
 
-  .plans-card-stats {
-    display: flex;
+  /* ── Inline action button ── */
+
+  .plans-inline-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 0.65rem 0.55rem 1rem;
+    border: 1px solid color-mix(in oklab, var(--accent) 25%, transparent);
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--signal-soft) 55%, transparent);
+    color: var(--accent);
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    cursor: pointer;
+    align-self: flex-start;
+    transition: background-color 180ms ease, border-color 180ms ease, transform 180ms ease;
+  }
+
+  .plans-inline-action:hover {
+    background: color-mix(in oklab, var(--signal-soft) 95%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 38%, transparent);
+    transform: translateX(1px);
+  }
+
+  .plans-inline-action:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--accent) 50%, transparent);
+    outline-offset: 2px;
+  }
+
+  .plans-inline-action .material-symbols-outlined {
+    font-size: 1rem;
+    padding: 0.25rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--accent) 22%, transparent);
+  }
+
+  /* ── Overview tab: asymmetric bento ── */
+
+  .plans-overview-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    grid-template-rows: auto auto auto;
+    gap: clamp(0.85rem, 1.2vw, 1.25rem);
+  }
+
+  .plans-vitality {
+    grid-column: 1 / 2;
+    grid-row: 1 / 3;
+  }
+
+  .plans-pressure {
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
+  }
+
+  .plans-velocity {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+  }
+
+  .plans-lanes {
+    grid-column: 1 / -1;
+    grid-row: 3 / 4;
+  }
+
+  /* Vitality card — hero + chart */
+  .plans-vitality::before,
+  .plans-vitality::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.12) 0%, transparent 70%);
+    pointer-events: none;
+    z-index: 0;
+  }
+  .plans-vitality::before {
+    width: 16rem;
+    height: 16rem;
+    top: -6rem;
+    right: -6rem;
+  }
+  .plans-vitality::after {
+    width: 10rem;
+    height: 10rem;
+    bottom: -4rem;
+    left: -3rem;
+    opacity: 0.6;
+  }
+  .plans-vitality > * { position: relative; z-index: 1; }
+
+  .plans-vitality-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
-    flex-wrap: wrap;
+    padding-top: 0.25rem;
+    border-top: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
+    padding: 0.85rem 0 0.15rem;
+    margin-top: 0.25rem;
   }
 
-  .plans-stat {
+  .plans-vitality-stat {
     display: flex;
     flex-direction: column;
-    gap: 0.08rem;
+    gap: 0.2rem;
   }
 
-  .plans-stat-value {
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.95rem;
-    font-weight: 600;
+  .plans-vitality-stat-value {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: clamp(1.5rem, 2.4vw, 2.1rem);
+    font-weight: 500;
+    line-height: 1;
+    letter-spacing: -0.03em;
     color: var(--foreground);
   }
 
-  .plans-stat-value-accent {
-    color: var(--accent);
+  .plans-vitality-stat-value-accent {
+    color: var(--cyan-ink);
   }
 
-  .plans-stat-key {
+  .plans-vitality-stat-label {
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.55rem;
     text-transform: uppercase;
-    letter-spacing: 0.25em;
+    letter-spacing: 0.22em;
     color: var(--muted-foreground);
   }
+
+  .plans-vitality-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin-top: 0.35rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
+  }
+
+  .plans-vitality-chart-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .plans-chart-label {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--muted-foreground);
+  }
+
+  .plans-chart-legend {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.55rem;
+    color: var(--accent);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    opacity: 0.78;
+  }
+
+  .plans-vitality-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+
+  .plans-vitality-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .plans-vitality-bar-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .plans-vitality-bar-name {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--foreground);
+    letter-spacing: 0.02em;
+  }
+
+  .plans-vitality-bar-val {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: 0.92rem;
+    font-weight: 500;
+    color: var(--cyan-ink);
+    letter-spacing: -0.01em;
+  }
+
+  .plans-vitality-bar-track {
+    height: 6px;
+    border-radius: 3px;
+    background: color-mix(in oklab, var(--border) 35%, transparent);
+    overflow: hidden;
+  }
+
+  .plans-vitality-bar-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--signal), var(--cyan-ink));
+    box-shadow: 0 0 14px rgba(0, 229, 255, 0.35);
+    transition: width 600ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .plans-vitality-bar-claims {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.58rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+  }
+
+  /* Reserve pressure card */
+  .plans-pressure-unit {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: 0.55em;
+    color: var(--muted-foreground);
+    margin-left: 0.15em;
+  }
+
+  .plans-pressure-bar {
+    height: 8px;
+    border-radius: 4px;
+    background: color-mix(in oklab, var(--border) 35%, transparent);
+    overflow: hidden;
+    margin-top: auto;
+  }
+
+  .plans-pressure-bar-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--signal), var(--cyan-ink));
+    box-shadow: 0 0 16px rgba(0, 229, 255, 0.45);
+    transition: width 600ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .plans-pressure-meta {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.62rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+    margin-top: 0.2rem;
+  }
+
+  /* Claims velocity card */
+  .plans-velocity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  /* Lanes card */
+  .plans-lane-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .plans-lane {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.85rem;
+    border: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
+    background: color-mix(in oklab, var(--surface-elevated) 38%, transparent);
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      transform 180ms ease;
+  }
+
+  .plans-lane:hover {
+    background: color-mix(in oklab, var(--signal-soft) 55%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 28%, transparent);
+    transform: translateX(2px);
+  }
+
+  .plans-lane:focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--accent) 45%, transparent);
+    outline-offset: 2px;
+  }
+
+  .plans-lane-active {
+    background: color-mix(in oklab, var(--signal-soft) 80%, transparent);
+    border-color: color-mix(in oklab, var(--accent) 35%, transparent);
+    box-shadow: inset 2px 0 0 var(--accent);
+  }
+
+  .plans-lane-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+
+  .plans-lane-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--foreground);
+  }
+
+  .plans-lane-key {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.62rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+  }
+
+  .plans-lane-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .plans-lane-mode {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.62rem;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+
+  /* ── Badges ── */
 
   .plans-badge {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-    padding: 0.15rem 0.55rem;
+    padding: 0.2rem 0.6rem;
     border-radius: 999px;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    line-height: 1.6;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    line-height: 1.5;
     white-space: nowrap;
   }
 
   .plans-badge-success {
     background: color-mix(in oklab, var(--success) 14%, transparent);
     color: var(--success);
-    border: 1px solid color-mix(in oklab, var(--success) 22%, transparent);
+    border: 1px solid color-mix(in oklab, var(--success) 24%, transparent);
   }
-
   .plans-badge-warning {
     background: color-mix(in oklab, var(--warning) 14%, transparent);
     color: var(--warning);
-    border: 1px solid color-mix(in oklab, var(--warning) 22%, transparent);
+    border: 1px solid color-mix(in oklab, var(--warning) 24%, transparent);
   }
-
   .plans-badge-danger {
     background: color-mix(in oklab, var(--danger) 14%, transparent);
     color: var(--danger);
-    border: 1px solid color-mix(in oklab, var(--danger) 22%, transparent);
+    border: 1px solid color-mix(in oklab, var(--danger) 24%, transparent);
   }
-
   .plans-badge-info {
     background: color-mix(in oklab, var(--cyan-ink) 12%, transparent);
     color: var(--cyan-ink);
-    border: 1px solid color-mix(in oklab, var(--cyan-ink) 20%, transparent);
+    border: 1px solid color-mix(in oklab, var(--cyan-ink) 22%, transparent);
   }
-
   .plans-badge-muted {
     background: color-mix(in oklab, var(--muted-foreground) 10%, transparent);
     color: var(--muted-foreground);
-    border: 1px solid color-mix(in oklab, var(--muted-foreground) 16%, transparent);
+    border: 1px solid color-mix(in oklab, var(--muted-foreground) 18%, transparent);
   }
+
+  /* ── Tables ── */
 
   .plans-table-wrap {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    margin-top: 0.25rem;
   }
 
   .plans-table {
@@ -4783,10 +5390,10 @@
   }
 
   .plans-table th {
-    padding: 0.45rem 0.65rem 0.45rem 0;
-    border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    padding: 0.5rem 0.75rem 0.5rem 0;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.55rem;
     text-transform: uppercase;
     letter-spacing: 0.2em;
     color: var(--muted-foreground);
@@ -4800,11 +5407,11 @@
   }
 
   .plans-table td {
-    padding: 0.55rem 0.65rem 0.55rem 0;
-    border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+    padding: 0.72rem 0.75rem 0.72rem 0;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 35%, transparent);
     vertical-align: middle;
     color: var(--foreground);
-    font-size: 0.84rem;
+    font-size: 0.85rem;
   }
 
   .plans-table td:last-child {
@@ -4817,17 +5424,34 @@
   }
 
   .plans-table tbody tr {
-    transition: background-color 150ms ease;
+    transition: background-color 180ms ease;
   }
 
   .plans-table tbody tr:hover {
-    background: color-mix(in oklab, var(--status-surface) 40%, transparent);
+    background: color-mix(in oklab, var(--signal-soft) 36%, transparent);
+  }
+
+  .plans-table-row-active {
+    background: color-mix(in oklab, var(--signal-soft) 62%, transparent);
+  }
+
+  .plans-table-row-active td:first-child {
+    box-shadow: inset 2px 0 0 var(--accent);
   }
 
   .plans-table-mono {
     font-family: var(--font-mono), "Fira Code", monospace;
     font-size: 0.78rem;
     letter-spacing: 0.01em;
+  }
+
+  .plans-table-amount {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: 0.96rem;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--foreground);
   }
 
   .plans-table-link {
@@ -4839,6 +5463,7 @@
     padding: 0;
     font-size: inherit;
     font-family: inherit;
+    text-align: left;
   }
 
   .plans-table-link:hover,
@@ -4847,188 +5472,189 @@
     outline: none;
   }
 
-  /* ── Rail unified panel ── */
-  .plans-rail-panel {
+  /* ── Rail cards ── */
+
+  .plans-rail-card {
     display: flex;
     flex-direction: column;
-    border-radius: 1.25rem;
-    background: rgba(255, 255, 255, 0.7);
-    backdrop-filter: blur(25px);
-    -webkit-backdrop-filter: blur(25px);
-    border: 1px solid rgba(255, 255, 255, 0.8);
-    box-shadow:
-      0 25px 50px -12px rgba(10, 21, 37, 0.1),
-      inset 0 1px 1px rgba(255, 255, 255, 0.9);
-    overflow: hidden;
-  }
-  .dark .plans-rail-panel {
-    background: rgba(255, 255, 255, 0.04);
-    backdrop-filter: blur(30px) saturate(140%);
-    -webkit-backdrop-filter: blur(30px) saturate(140%);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    box-shadow:
-      0 25px 50px -12px rgba(0, 0, 0, 0.3),
-      inset 0 1px 1px rgba(255, 255, 255, 0.04),
-      inset 0 -1px 20px rgba(0, 229, 255, 0.02);
+    gap: 0.75rem;
+    padding: 1.1rem 1.2rem;
+    border-radius: 1.35rem;
   }
 
-  .plans-rp-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-    padding: 1rem 1.25rem;
-  }
-  .plans-rp-section + .plans-rp-section {
-    border-top: 1px solid rgba(186, 201, 204, 0.15);
-  }
-  .dark .plans-rp-section + .plans-rp-section {
-    border-top-color: rgba(255, 255, 255, 0.06);
-  }
-
-  .plans-rp-head {
+  .plans-rail-head {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
   }
-  .plans-rp-title {
-    margin: 0;
-    font-size: 0.7rem;
-    font-weight: 700;
+
+  .plans-rail-tag {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.55rem;
     text-transform: uppercase;
-    letter-spacing: 0.15em;
+    letter-spacing: 0.24em;
     color: var(--muted-foreground);
   }
-  .plans-rp-tag {
-    display: flex;
+
+  .plans-rail-subtag {
+    display: inline-flex;
     align-items: center;
     gap: 0.3rem;
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.55rem;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.18em;
     color: var(--accent);
-    opacity: 0.7;
   }
 
-  /* Sponsor hero number */
-  .plans-rp-hero {
+  .plans-rail-hero {
     display: flex;
     flex-direction: column;
-    gap: 0.1rem;
+    gap: 0.2rem;
   }
-  .plans-rp-hero-val {
+
+  .plans-rail-hero-val {
     font-family: var(--font-display), "Newsreader", Georgia, serif;
     font-style: italic;
-    font-size: 1.6rem;
-    font-weight: 700;
-    color: var(--foreground);
+    font-size: clamp(1.7rem, 2.6vw, 2.1rem);
+    font-weight: 500;
+    color: var(--cyan-ink);
     line-height: 1;
-    letter-spacing: -0.03em;
+    letter-spacing: -0.035em;
   }
-  .plans-rp-hero-sub {
-    font-size: 0.7rem;
+
+  .plans-rail-hero-sub {
+    font-size: 0.72rem;
     color: var(--muted-foreground);
   }
 
-  /* Budget / funding progress bars */
-  .plans-rp-bar {
-    height: 5px;
+  .plans-rail-bar {
+    height: 6px;
     border-radius: 3px;
-    background: rgba(148, 163, 184, 0.1);
+    background: color-mix(in oklab, var(--border) 35%, transparent);
     overflow: hidden;
   }
-  .plans-rp-bar-sm { height: 3px; border-radius: 2px; }
-  .plans-rp-bar-fill {
+
+  .plans-rail-bar-sm { height: 4px; border-radius: 2px; }
+
+  .plans-rail-bar-fill {
     height: 100%;
     border-radius: inherit;
-    background: linear-gradient(90deg, #00E5FF, #33C5F4);
+    background: linear-gradient(90deg, var(--signal), var(--cyan-ink));
+    box-shadow: 0 0 12px rgba(0, 229, 255, 0.35);
     transition: width 600ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 
-  /* Key-value rows */
-  .plans-rp-row {
+  .plans-rail-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
   }
-  .plans-rp-row > span {
-    font-size: 0.78rem;
+
+  .plans-rail-row > span {
+    font-size: 0.76rem;
     color: var(--muted-foreground);
   }
-  .plans-rp-row > strong {
+
+  .plans-rail-row > strong {
     font-family: var(--font-mono), "Fira Code", monospace;
     font-size: 0.8rem;
     font-weight: 600;
     color: var(--foreground);
   }
 
-  /* Funding line items */
-  .plans-rp-fund {
+  .plans-rail-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .plans-rail-line {
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
   }
-  .plans-rp-fund-meta {
+
+  .plans-rail-line-meta {
     display: flex;
     justify-content: space-between;
-    font-size: 0.6rem;
-    color: var(--muted-foreground);
     font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.58rem;
+    color: var(--muted-foreground);
     letter-spacing: 0.02em;
   }
 
-  /* Audit trail — compact dot list */
-  .plans-rp-trail {
+  /* Audit trail */
+  .plans-rail-trail {
     display: flex;
     flex-direction: column;
-    gap: 0;
   }
-  .plans-rp-event {
+
+  .plans-rail-event {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.65rem;
+    padding: 0.7rem 0;
+    border-top: 1px solid color-mix(in oklab, var(--border) 35%, transparent);
+  }
+  .plans-rail-event:first-child { border-top: none; padding-top: 0.2rem; }
+  .plans-rail-event:last-child { padding-bottom: 0.2rem; }
+
+  .plans-rail-event-dot {
+    width: 0.48rem;
+    height: 0.48rem;
+    margin-top: 0.38rem;
+    border-radius: 999px;
+    flex-shrink: 0;
+    background: color-mix(in oklab, var(--signal) 22%, transparent);
+    box-shadow: 0 0 10px rgba(0, 229, 255, 0.18);
+  }
+
+  .plans-rail-event-signal .plans-rail-event-dot {
+    background: var(--signal);
+    box-shadow: 0 0 12px rgba(0, 229, 255, 0.55);
+  }
+
+  .plans-rail-event-copy {
+    min-width: 0;
+  }
+
+  .plans-rail-event-row {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0;
-    border-bottom: 1px solid rgba(186, 201, 204, 0.08);
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.6rem;
   }
-  .dark .plans-rp-event {
-    border-bottom-color: rgba(255, 255, 255, 0.04);
-  }
-  .plans-rp-event:last-child { border-bottom: none; }
 
-  .plans-rp-event-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background: var(--muted-foreground);
-    opacity: 0.4;
-  }
-  .plans-rp-event-verified .plans-rp-event-dot { background: var(--success); opacity: 0.8; }
-  .plans-rp-event-pending .plans-rp-event-dot { background: var(--warning); opacity: 0.8; }
-  .plans-rp-event-signal .plans-rp-event-dot { background: var(--accent); opacity: 0.8; }
-
-  .plans-rp-event-label {
-    flex: 1;
+  .plans-rail-event-label {
     font-size: 0.78rem;
-    font-weight: 500;
+    font-weight: 600;
     color: var(--foreground);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
-  .plans-rp-event-time {
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.6rem;
-    color: var(--muted-foreground);
+
+  .plans-rail-event-time {
     flex-shrink: 0;
-    letter-spacing: 0.02em;
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.54rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--muted-foreground);
   }
+
+  .plans-rail-event-detail {
+    margin: 0.3rem 0 0;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: var(--muted-foreground);
+  }
+
+  /* ── Data grid (schemas) ── */
 
   .plans-data-grid {
     display: grid;
-    border-top: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+    gap: 0;
   }
 
   .plans-data-row {
@@ -5036,8 +5662,8 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.8rem;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid color-mix(in oklab, var(--border) 40%, transparent);
+    padding: 0.7rem 0;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 35%, transparent);
   }
 
   .plans-data-row:last-child {
@@ -5046,126 +5672,102 @@
 
   .plans-data-label {
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.5rem;
+    font-size: 0.55rem;
     text-transform: uppercase;
-    letter-spacing: 0.2em;
+    letter-spacing: 0.22em;
     color: var(--muted-foreground);
   }
 
   .plans-data-value {
     font-weight: 600;
-    font-size: 0.84rem;
+    font-size: 0.85rem;
     color: var(--foreground);
     text-align: right;
   }
 
-  .plans-split {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 1rem;
-  }
+  /* ── Empty state ── */
 
   .plans-empty {
-    display: grid;
-    gap: 0.25rem;
-    padding: 1.5rem 1.2rem;
-    border-radius: 1rem;
-    background: color-mix(in oklab, var(--surface-elevated) 50%, transparent 50%);
-    border: 1px dashed color-mix(in oklab, var(--border-strong) 40%, transparent);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 2.5rem 1.5rem;
+    border-radius: 1.5rem;
     text-align: center;
+    max-width: 42rem;
+    margin-inline: auto;
   }
 
   .plans-empty strong {
+    font-family: var(--font-display), "Newsreader", Georgia, serif;
+    font-style: italic;
+    font-size: 1.3rem;
+    font-weight: 500;
     color: var(--foreground);
-    font-size: 0.85rem;
+    letter-spacing: -0.02em;
   }
 
   .plans-empty p {
     margin: 0;
     color: var(--muted-foreground);
-    font-size: 0.8rem;
+    font-size: 0.85rem;
+    line-height: 1.55;
+    max-width: 36ch;
   }
 
-  .plans-series-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.6rem;
-    padding: 0.5rem 0.7rem;
-    border-radius: 0.65rem;
-    border: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
-    background: color-mix(in oklab, var(--surface-elevated) 40%, transparent 60%);
-    transition:
-      background-color 150ms ease,
-      border-color 150ms ease;
-  }
-
-  .plans-series-row:hover {
-    background: color-mix(in oklab, var(--status-surface) 50%, transparent);
-    border-color: color-mix(in oklab, var(--accent) 20%, var(--border));
-  }
-
-  .plans-series-row-info {
-    display: grid;
-    gap: 0.1rem;
-    min-width: 0;
-  }
-
-  .plans-series-row-name {
-    font-weight: 600;
-    font-size: 0.84rem;
-    color: var(--foreground);
-  }
-
-  .plans-series-row-key {
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.6875rem;
-    color: var(--muted-foreground);
-    letter-spacing: 0.02em;
-  }
-
-  .plans-series-row-meta {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-shrink: 0;
-  }
-
-  .plans-series-row-mode {
-    font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.6875rem;
-    color: var(--muted-foreground);
-  }
-
-  .plans-timeline { display: grid; gap: 0.3rem; }
+  /* ── Settings grid ── */
 
   .plans-settings-grid {
     display: grid;
-    gap: 0.35rem;
+    gap: 0.5rem;
   }
 
   .plans-settings-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.8rem;
-    padding: 0.5rem 0.7rem;
-    border-radius: 0.65rem;
-    background: color-mix(in oklab, var(--surface-elevated) 50%, transparent 50%);
-    border: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
+    gap: 0.9rem;
+    padding: 0.85rem 1rem;
+    border-radius: 0.95rem;
+    background: color-mix(in oklab, var(--surface-elevated) 42%, transparent);
+    border: 1px solid color-mix(in oklab, var(--border) 40%, transparent);
+    transition: border-color 180ms ease, background-color 180ms ease;
+  }
+
+  .plans-settings-row:hover {
+    border-color: color-mix(in oklab, var(--accent) 22%, transparent);
+    background: color-mix(in oklab, var(--signal-soft) 42%, transparent);
+  }
+
+  .plans-settings-row > div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+
+  .plans-settings-label {
+    font-family: var(--font-mono), "Fira Code", monospace;
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--accent);
+    opacity: 0.8;
   }
 
   .plans-settings-lane {
-    font-size: 0.8rem;
+    font-size: 0.84rem;
     font-weight: 600;
     color: var(--foreground);
   }
 
   .plans-settings-address {
     font-family: var(--font-mono), "Fira Code", monospace;
-    font-size: 0.72rem;
+    font-size: 0.74rem;
     color: var(--muted-foreground);
     letter-spacing: 0.02em;
+    flex-shrink: 0;
   }
 
   @media (max-width: 1320px) {
@@ -5217,26 +5819,79 @@
       border-top: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
     }
 
-    .plans-content-grid {
+    .plans-hero {
+      grid-template-columns: 1fr;
+      gap: 1.25rem;
+    }
+
+    .plans-body {
       grid-template-columns: 1fr;
     }
 
     .plans-rail {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      position: static;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start;
     }
 
-    .plans-split {
+    .plans-overview-grid {
       grid-template-columns: 1fr;
+      grid-template-rows: auto;
+    }
+    .plans-vitality,
+    .plans-pressure,
+    .plans-velocity,
+    .plans-lanes {
+      grid-column: 1 / -1;
+      grid-row: auto;
+    }
+
+    .plans-kpi-strip {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      row-gap: 1rem;
+    }
+    .plans-kpi-metric:nth-child(3) {
+      border-left: none;
+      padding-left: 0.2rem;
     }
   }
 
   @media (max-width: 899px) {
-    .plans-selector-row {
+    .plans-hero-selectors {
       grid-template-columns: 1fr;
+      gap: 0.25rem;
+    }
+
+    .plans-hero-selectors-divider {
+      width: 100%;
+      height: 1px;
+      margin: 0.15rem 0;
+      background: linear-gradient(
+        90deg,
+        transparent 0%,
+        color-mix(in oklab, var(--border-strong) 55%, transparent) 50%,
+        transparent 100%
+      );
     }
 
     .plans-rail {
       grid-template-columns: 1fr;
+    }
+
+    .plans-kpi-strip {
+      grid-template-columns: 1fr;
+      row-gap: 0.75rem;
+    }
+    .plans-kpi-metric {
+      border-left: none !important;
+      padding-left: 0.2rem;
+      border-top: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
+      padding-top: 0.75rem;
+    }
+    .plans-kpi-metric:first-child {
+      border-top: none;
+      padding-top: 0;
     }
 
     .protocol-workbench-shell {
@@ -5244,9 +5899,9 @@
       min-height: 100vh;
     }
 
-    .protocol-workbench-shell-overview {
-      --protocol-overview-top-overlap: 0px;
-      --protocol-overview-bottom-overlap: calc(env(safe-area-inset-bottom, 0px) + 1.2rem);
+    .protocol-workbench-shell-fullscreen {
+      --protocol-workbench-top-overlap: 0px;
+      --protocol-workbench-bottom-overlap: calc(env(safe-area-inset-bottom, 0px) + 1.2rem);
     }
 
     .protocol-topbar-nav {
@@ -5375,10 +6030,10 @@
       margin-top: 0;
       margin-bottom: 0;
       padding-top: 0.25rem;
-      padding-bottom: calc(var(--protocol-overview-bottom-overlap) + 0.35rem);
+      padding-bottom: calc(var(--protocol-workbench-bottom-overlap) + 0.35rem);
       overflow: visible;
       scroll-padding-top: 0.25rem;
-      scroll-padding-bottom: calc(var(--protocol-overview-bottom-overlap) + 0.35rem);
+      scroll-padding-bottom: calc(var(--protocol-workbench-bottom-overlap) + 0.35rem);
     }
 
     .workbench-rail {
@@ -5405,35 +6060,50 @@
 
   @media (max-width: 767px) {
     .plans-hero {
-      padding: 1.25rem 1.1rem 1.15rem;
-      border-radius: 1.5rem;
+      padding: 0.4rem 0.65rem 0;
     }
 
     .plans-hero-title {
-      font-size: 1.35rem;
+      font-size: clamp(2.2rem, 10vw, 3.1rem);
     }
 
-    .plans-hero-metrics {
-      flex-wrap: wrap;
-      gap: 1rem;
+    .plans-hero-subtitle {
+      font-size: 0.82rem;
     }
 
-    .plans-hero-metric-divider {
-      display: none;
+    .plans-hero-selectors {
+      padding: 0.65rem 0.75rem;
+      border-radius: 1rem;
+    }
+
+    .plans-tabs {
+      border-radius: 1.2rem;
+      padding: 0.3rem;
     }
 
     .plans-tab {
-      padding: 0.35rem 0.65rem;
-      font-size: 0.72rem;
+      flex: 0 0 auto;
+      padding: 0.55rem 0.85rem;
+      font-size: 0.74rem;
     }
 
-    .plans-tab-icon {
+    .plans-tab-icon,
+    .plans-tab-number {
       display: none;
     }
 
     .plans-card {
       padding: 1rem;
       border-radius: 1.25rem;
+    }
+
+    .plans-card-title-display {
+      font-size: clamp(1.4rem, 5vw, 1.7rem);
+    }
+
+    .plans-vitality-stats {
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
     }
 
     .plans-table {

--- a/frontend/components/overview-workbench.tsx
+++ b/frontend/components/overview-workbench.tsx
@@ -476,14 +476,14 @@ export function OverviewWorkbench() {
               <span className="ov-eyebrow">OVERVIEW_SYNC // {sectionLabelForPersona(effectivePersona)}</span>
               <h1 className="ov-hero-title">Health Capital Markets</h1>
 
-              <div className="ov-total-stack">
-                <span className="ov-total-value">${formatAmount(stats.tvl)}</span>
-                <span className="ov-total-label">Aggregate network value locked</span>
-              </div>
-
               <div className="ov-wave-panel">
                 <div className="ov-wave-scan" aria-hidden="true" />
                 <SignalWave />
+              </div>
+
+              <div className="ov-total-stack">
+                <span className="ov-total-value">${formatAmount(stats.tvl)}</span>
+                <span className="ov-total-label">Aggregate network value locked</span>
               </div>
 
               <div className="ov-signal-grid" role="list" aria-label="Overview system metrics">

--- a/frontend/components/plans-workbench.tsx
+++ b/frontend/components/plans-workbench.tsx
@@ -2,10 +2,9 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { SearchableSelect } from "@/components/searchable-select";
 import { useWorkspacePersona } from "@/components/workspace-persona";
 import { buildCanonicalConsoleState } from "@/lib/console-model";
 import { formatAmount, seriesOutcomeCount } from "@/lib/canonical-ui";
@@ -28,7 +27,7 @@ import {
 } from "@/lib/protocol";
 import { cn } from "@/lib/cn";
 
-/* ── Constants ── */
+/* ── Constants ──────────────────────────────────────── */
 
 const SERIES_OPTIONAL_TABS = new Set<PlanTabId>(["claims", "members", "schemas"]);
 
@@ -39,10 +38,20 @@ const TAB_ICONS: Record<PlanTabId, string> = {
   claims: "gavel",
   schemas: "schema",
   funding: "account_balance",
-  settings: "settings",
+  settings: "tune",
 };
 
-/* ── Helpers ── */
+const TAB_NUMBERS: Record<PlanTabId, string> = {
+  overview: "01",
+  series: "02",
+  members: "03",
+  claims: "04",
+  schemas: "05",
+  funding: "06",
+  settings: "07",
+};
+
+/* ── Helpers ────────────────────────────────────────── */
 
 function formatControlLaneAddress(address?: string | null, size = 6) {
   return isUnsetDevnetWalletAddress(address) ? "Not configured" : shortenAddress(address ?? "", size);
@@ -75,14 +84,84 @@ function obligationsEmptyCopy(selectedSeries: boolean, planHasObligations: boole
 
 function PlansEmptyState({ title, copy }: { title: string; copy: string }) {
   return (
-    <div className="plans-empty">
+    <div className="plans-empty liquid-glass">
       <strong>{title}</strong>
       <p>{copy}</p>
     </div>
   );
 }
 
-/* ── Component ── */
+function personaHeroCopy(persona: string): { eyebrow: string; subtitle: string } {
+  switch (persona) {
+    case "sponsor":
+      return {
+        eyebrow: "PROTOCOL_CONSOLE // SPONSOR_WORKSPACE",
+        subtitle: "Operate the full lifecycle of your clinical plans — budgets, series, members, and claims across a single control plane.",
+      };
+    case "capital":
+      return {
+        eyebrow: "PROTOCOL_CONSOLE // CAPITAL_WORKSPACE",
+        subtitle: "Inspect how pool allocations flow into each plan and trace reserve coverage across the sponsor rail.",
+      };
+    case "governance":
+      return {
+        eyebrow: "PROTOCOL_CONSOLE // GOVERNANCE_WORKSPACE",
+        subtitle: "Review plan operations, administration lanes, and settlement history before approving new controls.",
+      };
+    default:
+      return {
+        eyebrow: "PROTOCOL_CONSOLE // OBSERVER_WORKSPACE",
+        subtitle: "Coverage series, member exposure, and sponsor operations across the public OmegaX protocol surface.",
+      };
+  }
+}
+
+type HeroSelectorProps<T extends { address: string }> = {
+  eyebrow: string;
+  label: string;
+  value: T | null;
+  options: T[];
+  renderLabel: (item: T) => string;
+  renderMeta: (item: T) => string;
+  placeholder: string;
+  disabled?: boolean;
+  onChange: (address: string) => void;
+};
+
+function HeroSelector<T extends { address: string }>(props: HeroSelectorProps<T>) {
+  return (
+    <label className={cn("plans-hero-select", props.disabled && "plans-hero-select-disabled")}>
+      <span className="plans-hero-select-eyebrow">{props.eyebrow}</span>
+      <div className="plans-hero-select-body">
+        <div className="plans-hero-select-copy">
+          <span className="plans-hero-select-label">
+            {props.value ? props.renderLabel(props.value) : props.placeholder}
+          </span>
+          <span className="plans-hero-select-meta">
+            {props.value ? props.renderMeta(props.value) : "—"}
+          </span>
+        </div>
+        <span className="material-symbols-outlined plans-hero-select-caret" aria-hidden="true">unfold_more</span>
+      </div>
+      <select
+        className="plans-hero-select-native"
+        value={props.value?.address ?? ""}
+        disabled={props.disabled}
+        onChange={(event) => props.onChange(event.target.value)}
+        aria-label={props.label}
+      >
+        {props.value ? null : <option value="">{props.placeholder}</option>}
+        {props.options.map((option) => (
+          <option key={option.address} value={option.address}>
+            {props.renderLabel(option)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/* ── Component ──────────────────────────────────────── */
 
 export function PlansWorkbench() {
   const router = useRouter();
@@ -90,8 +169,6 @@ export function PlansWorkbench() {
   const searchParams = useSearchParams();
   const { effectivePersona } = useWorkspacePersona();
   const consoleState = useMemo(() => buildCanonicalConsoleState(), []);
-  const [planSearch, setPlanSearch] = useState("");
-  const [seriesSearch, setSeriesSearch] = useState("");
 
   /* ── Selection state ── */
 
@@ -100,47 +177,32 @@ export function PlansWorkbench() {
     ?? defaultTabForPersona("plans", effectivePersona)) as PlanTabId;
 
   const allPlans = DEVNET_PROTOCOL_FIXTURE_STATE.healthPlans;
-  const filteredPlans = useMemo(() => {
-    const query = planSearch.trim().toLowerCase();
-    if (!query) return allPlans;
-    return allPlans.filter((plan) =>
-      [plan.displayName, plan.planId, plan.sponsorLabel, plan.address].some((value) =>
-        value.toLowerCase().includes(query),
-      ),
-    );
-  }, [allPlans, planSearch]);
-
   const queryPlan = searchParams.get("plan")?.trim() ?? "";
   const matchedPlan = useMemo(() => allPlans.find((plan) => plan.address === queryPlan) ?? null, [allPlans, queryPlan]);
   const hasInvalidPlan = Boolean(queryPlan) && !matchedPlan;
   const selectedPlan = useMemo(() => {
     if (hasInvalidPlan) return null;
-    return matchedPlan ?? filteredPlans[0] ?? allPlans[0] ?? null;
-  }, [allPlans, filteredPlans, hasInvalidPlan, matchedPlan]);
+    return matchedPlan ?? allPlans[0] ?? null;
+  }, [allPlans, hasInvalidPlan, matchedPlan]);
 
   const planSeries = useMemo(() => {
     if (!selectedPlan) return [];
     return DEVNET_PROTOCOL_FIXTURE_STATE.policySeries.filter((series) => series.healthPlan === selectedPlan.address);
   }, [selectedPlan]);
-  const filteredSeries = useMemo(() => {
-    const query = seriesSearch.trim().toLowerCase();
-    if (!query) return planSeries;
-    return planSeries.filter((series) =>
-      [series.displayName, series.seriesId, series.comparabilityKey, series.address].some((value) =>
-        value.toLowerCase().includes(query),
-      ),
-    );
-  }, [planSeries, seriesSearch]);
+
   const querySeries = searchParams.get("series")?.trim() ?? "";
   const seriesSelectionOptional = SERIES_OPTIONAL_TABS.has(activeTab);
-  const matchedSeries = useMemo(() => planSeries.find((series) => series.address === querySeries) ?? null, [planSeries, querySeries]);
+  const matchedSeries = useMemo(
+    () => planSeries.find((series) => series.address === querySeries) ?? null,
+    [planSeries, querySeries],
+  );
   const hasInvalidSeries = Boolean(querySeries) && !matchedSeries;
   const selectedSeries = useMemo(() => {
     if (hasInvalidSeries) return null;
     if (matchedSeries) return matchedSeries;
     if (seriesSelectionOptional) return null;
-    return filteredSeries[0] ?? planSeries[0] ?? null;
-  }, [filteredSeries, hasInvalidSeries, matchedSeries, planSeries, seriesSelectionOptional]);
+    return planSeries[0] ?? null;
+  }, [hasInvalidSeries, matchedSeries, planSeries, seriesSelectionOptional]);
 
   /* ── Derived data ── */
 
@@ -209,15 +271,43 @@ export function PlansWorkbench() {
     if (Object.keys(nextUpdates).length > 0) updateParams(nextUpdates);
   }, [activeTab, hasInvalidPlan, hasInvalidSeries, queryPlan, querySeries, requestedTab, selectedPlan, selectedSeries, updateParams]);
 
-  /* ── Persona copy ── */
+  /* ── Scroll tab into view ── */
+
+  const tabBarRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const bar = tabBarRef.current;
+    if (!bar) return;
+    const activeButton = bar.querySelector<HTMLButtonElement>(`[data-tab-id="${activeTab}"]`);
+    if (activeButton) activeButton.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+  }, [activeTab]);
+
+  /* ── Derived stats ── */
 
   const planClaimCount = sponsorView?.activeClaimCount ?? 0;
-  const primaryActionLabel =
-    effectivePersona === "capital"
-      ? "Inspect how pool allocations support this plan."
-      : effectivePersona === "governance"
-        ? "Review operational history before approving new controls."
-        : "Manage the full plan lifecycle here.";
+  const remaining = Number(sponsorView?.remainingSponsorBudget ?? 0);
+  const funded = Number(sponsorView?.fundedSponsorBudget ?? 0);
+  const deployed = Math.max(0, funded - remaining);
+  const deployedPct = funded > 0 ? Math.round((deployed / funded) * 100) : 0;
+  const reserveCoverage = Number(sponsorView?.reserveCoverageBps ?? 0);
+  const totalFunded = planFundingLines.reduce((sum, line) => sum + Number(line.fundedAmount), 0);
+  const totalReserved = planFundingLines.reduce((sum, line) => sum + Number(line.reservedAmount), 0);
+  const poolUtilization = totalFunded > 0 ? Math.round((totalReserved / totalFunded) * 100) : 0;
+
+  // Protocol Vitality bar chart data (per-series approvals × claim count)
+  const vitalityBars = useMemo(() => {
+    const rows = sponsorView?.perSeriesPerformance ?? [];
+    if (rows.length === 0) return [] as Array<{ id: string; name: string; value: number; claims: number; ratio: number }>;
+    const maxValue = rows.reduce((max, row) => Math.max(max, Number(row.reserved)), 0) || 1;
+    return rows.map((row) => ({
+      id: row.policySeries,
+      name: row.seriesId,
+      value: Number(row.reserved),
+      claims: row.claimCount,
+      ratio: Number(row.reserved) / maxValue,
+    }));
+  }, [sponsorView]);
+
+  const { eyebrow: heroEyebrow, subtitle: heroSubtitle } = personaHeroCopy(effectivePersona);
 
   /* ── Invalid selection guard ── */
 
@@ -227,588 +317,677 @@ export function PlansWorkbench() {
       ? { title: "Series not found", copy: "The requested policy series is not linked to the selected plan. Choose another series or clear the series filter." }
       : null;
 
-  if (invalidSelection) {
-    return (
-      <div className="plans-dashboard">
-        <section className="plans-header">
-          <div className="plans-selector-row">
-            <SearchableSelect
-              label="Health plan"
-              value={selectedPlan?.address ?? ""}
-              options={filteredPlans.map((plan) => ({
-                value: plan.address,
-                label: `${plan.displayName} (${plan.planId})`,
-                hint: `${plan.sponsorLabel} // ${plan.membershipModel}`,
-              }))}
-              onChange={(value) => updateParams({ plan: value, series: null })}
-              searchValue={planSearch}
-              onSearchChange={setPlanSearch}
-              placeholder="Choose plan"
-              error={hasInvalidPlan ? "Requested health plan was not found in the current fixture set." : null}
-              showOptionCount={false}
-              showSelectedHint={false}
-            />
-            <SearchableSelect
-              label="Policy series"
-              value={selectedSeries?.address ?? ""}
-              options={filteredSeries.map((series) => ({
-                value: series.address,
-                label: `${series.displayName} (${series.seriesId})`,
-                hint: `${series.termsVersion} // ${describeSeriesMode(series.mode)}`,
-              }))}
-              onChange={(value) => updateParams({ series: value })}
-              searchValue={seriesSearch}
-              onSearchChange={setSeriesSearch}
-              placeholder="Choose series"
-              disabled={!selectedPlan}
-              disabledHint="Choose a valid health plan before selecting a policy series."
-              error={hasInvalidSeries ? "Requested policy series is not linked to the selected plan." : null}
-              emptyMessage="No policy series match this plan filter."
-              showOptionCount={false}
-              showSelectedHint={false}
-            />
-          </div>
-        </section>
-
-        <PlansEmptyState title={invalidSelection.title} copy={invalidSelection.copy} />
-      </div>
-    );
-  }
-
   /* ── Main render ── */
 
   return (
-    <div className="plans-dashboard">
-      {/* ── Header ── */}
-      <section className="plans-header">
-        <div className="plans-selector-row">
-          <SearchableSelect
-            label="Health plan"
-            value={selectedPlan?.address ?? ""}
-            options={filteredPlans.map((plan) => ({
-              value: plan.address,
-              label: `${plan.displayName} (${plan.planId})`,
-              hint: `${plan.sponsorLabel} // ${plan.membershipModel}`,
-            }))}
-            onChange={(value) => updateParams({ plan: value, series: null })}
-            searchValue={planSearch}
-            onSearchChange={setPlanSearch}
-            placeholder="Choose plan"
-            showOptionCount={false}
-            showSelectedHint={false}
-          />
-          <SearchableSelect
-            label="Policy series"
-            value={selectedSeries?.address ?? ""}
-            options={filteredSeries.map((series) => ({
-              value: series.address,
-              label: `${series.displayName} (${series.seriesId})`,
-              hint: `${series.termsVersion} // ${describeSeriesMode(series.mode)}`,
-            }))}
-            onChange={(value) => updateParams({ series: value })}
-            searchValue={seriesSearch}
-            onSearchChange={setSeriesSearch}
-            placeholder="Choose series"
-            disabled={!selectedPlan}
-            disabledHint="Choose a valid health plan before selecting a policy series."
-            emptyMessage="No policy series match this plan filter."
-            showOptionCount={false}
-            showSelectedHint={false}
-          />
-        </div>
+    <div className="plans-shell">
+      <div className="plans-scroll">
 
-        <div className="plans-metrics-strip">
-          <div className="plans-strip-metric plans-strip-metric-primary">
-            <span className="plans-strip-metric-val">{formatAmount(sponsorView?.remainingSponsorBudget ?? 0)}</span>
-            <span className="plans-strip-metric-label">Budget</span>
+        {/* ── Hero ──────────────────────────── */}
+        <header className="plans-hero">
+          <div className="plans-hero-glow" aria-hidden="true" />
+          <div className="plans-hero-copy">
+            <span className="plans-hero-eyebrow">{heroEyebrow}</span>
+            <h1 className="plans-hero-title">
+              Active <em>Workspace</em>
+            </h1>
+            <p className="plans-hero-subtitle">{heroSubtitle}</p>
           </div>
-          <div className="plans-strip-metric">
-            <span className="plans-strip-metric-val">{planSeries.length}</span>
-            <span className="plans-strip-metric-label">Series</span>
+
+          <div className="plans-hero-selectors liquid-glass">
+            <HeroSelector
+              eyebrow="HEALTH_PLAN"
+              label="Health plan"
+              value={selectedPlan}
+              options={allPlans}
+              renderLabel={(plan) => plan.displayName}
+              renderMeta={(plan) => `${plan.planId} · ${plan.sponsorLabel}`}
+              placeholder="Choose plan"
+              onChange={(value) => updateParams({ plan: value, series: null })}
+            />
+            <span className="plans-hero-selectors-divider" aria-hidden="true" />
+            <HeroSelector
+              eyebrow="POLICY_SERIES"
+              label="Policy series"
+              value={selectedSeries}
+              options={planSeries}
+              renderLabel={(series) => series.displayName}
+              renderMeta={(series) => `${series.seriesId} · ${describeSeriesMode(series.mode)}`}
+              placeholder={planSeries.length > 0 ? "All series" : "No series"}
+              disabled={!selectedPlan || planSeries.length === 0}
+              onChange={(value) => updateParams({ series: value || null })}
+            />
           </div>
-          <div className="plans-strip-metric">
-            <span className="plans-strip-metric-val">{planClaimCount}</span>
-            <span className="plans-strip-metric-label">Claims</span>
+        </header>
+
+        {/* ── KPI strip ─────────────────────── */}
+        <section className="plans-kpi-strip" aria-label="Plan workspace telemetry">
+          <div className="plans-kpi-metric">
+            <span className="plans-kpi-label">BUDGET_REMAINING</span>
+            <span className="plans-kpi-value">${formatAmount(remaining)}</span>
+            <span className="plans-kpi-meta">of ${formatAmount(funded)} funded</span>
           </div>
-          <div className="plans-strip-metric">
-            <span className="plans-strip-metric-val">{planFundingLines.length}</span>
-            <span className="plans-strip-metric-label">Funding</span>
+          <div className="plans-kpi-metric">
+            <span className="plans-kpi-label">ACTIVE_SERIES</span>
+            <span className="plans-kpi-value">{planSeries.length}</span>
+            <span className="plans-kpi-meta">{planMembers.length} member positions</span>
           </div>
-        </div>
-      </section>
-
-      {/* ── Tab bar ── */}
-      <nav className="plans-tab-bar">
-        {PLAN_TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            className={cn("plans-tab", activeTab === tab.id && "plans-tab-active")}
-            onClick={() => updateParams({ tab: tab.id })}
-          >
-            <span className="material-symbols-outlined plans-tab-icon">{TAB_ICONS[tab.id as PlanTabId]}</span>
-            {tab.label}
-          </button>
-        ))}
-      </nav>
-
-      {/* ── Content grid ── */}
-      <div className="plans-content-grid">
-        <section className="plans-main">
-          {/* ── Overview tab ── */}
-          {activeTab === "overview" ? (
-            <div className="plans-split">
-              <div className="plans-card">
-                <div className="plans-card-head">
-                  <div>
-                    <p className="plans-card-eyebrow">Plan overview</p>
-                    <h2 className="plans-card-title">{selectedPlan?.displayName ?? "Awaiting selection"}</h2>
-                  </div>
-                  {selectedPlan ? <span className="plans-card-meta">{selectedPlan.planId}</span> : null}
-                </div>
-                <div className="plans-card-stats">
-                  <div className="plans-stat">
-                    <span className="plans-stat-value">{planSeries.length}</span>
-                    <span className="plans-stat-key">Series</span>
-                  </div>
-                  <div className="plans-stat">
-                    <span className="plans-stat-value">{planMembers.length}</span>
-                    <span className="plans-stat-key">Members</span>
-                  </div>
-                  <div className="plans-stat">
-                    <span className="plans-stat-value plans-stat-value-accent">{planClaimCount}</span>
-                    <span className="plans-stat-key">Claims</span>
-                  </div>
-                  <div className="plans-stat">
-                    <span className="plans-stat-value">{planFundingLines.length}</span>
-                    <span className="plans-stat-key">Funding</span>
-                  </div>
-                </div>
-                <div className="plans-rail-stack">
-                  {planSeries.map((series) => (
-                    <article key={series.address} className="plans-series-row">
-                      <div className="plans-series-row-info">
-                        <span className="plans-series-row-name">{series.displayName}</span>
-                        <span className="plans-series-row-key">{series.comparabilityKey}</span>
-                      </div>
-                      <div className="plans-series-row-meta">
-                        <span className="plans-series-row-mode">{describeSeriesMode(series.mode)}</span>
-                        <StatusBadge label={describeSeriesStatus(series.status)} />
-                      </div>
-                    </article>
-                  ))}
-                </div>
-              </div>
-
-              <div className="plans-card">
-                <div className="plans-card-head">
-                  <div>
-                    <p className="plans-card-eyebrow">Performance</p>
-                    <h2 className="plans-card-title">Outcomes by lane</h2>
-                  </div>
-                </div>
-                <div className="plans-table-wrap">
-                  <table className="plans-table">
-                    <thead>
-                      <tr>
-                        <th>Series</th>
-                        <th>Mode</th>
-                        <th>Claims</th>
-                        <th>Reserved</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {(sponsorView?.perSeriesPerformance ?? []).map((series) => (
-                        <tr key={series.policySeries}>
-                          <td data-label="Series"><span className="plans-table-mono">{series.seriesId}</span></td>
-                          <td data-label="Mode">{series.mode}</td>
-                          <td data-label="Claims"><span className="plans-table-mono">{series.claimCount}</span></td>
-                          <td data-label="Reserved"><span className="plans-table-mono">{formatAmount(series.reserved)}</span></td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-          ) : null}
-
-          {/* ── Series tab ── */}
-          {activeTab === "series" ? (
-            <div className="plans-card">
-              <div className="plans-card-head">
-                <div>
-                  <p className="plans-card-eyebrow">Series</p>
-                  <h2 className="plans-card-title">Series lanes</h2>
-                </div>
-                <span className="plans-card-meta">
-                  <span className="plans-live-dot" />
-                  {planSeries.length} active
-                </span>
-              </div>
-              <div className="plans-table-wrap">
-                <table className="plans-table">
-                  <thead>
-                    <tr>
-                      <th>Series</th>
-                      <th>Version</th>
-                      <th>Comparability</th>
-                      <th>Outcomes</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {planSeries.map((series) => (
-                      <tr key={series.address}>
-                        <td data-label="Series">
-                          <button type="button" className="plans-table-link" onClick={() => updateParams({ series: series.address })}>
-                            {series.displayName}
-                          </button>
-                        </td>
-                        <td data-label="Version"><span className="plans-table-mono">{series.termsVersion}</span></td>
-                        <td data-label="Comparability"><span className="plans-table-mono">{series.comparabilityKey}</span></td>
-                        <td data-label="Outcomes"><span className="plans-table-mono">{formatAmount(seriesOutcomeCount(series.address))}</span></td>
-                        <td data-label="Status"><StatusBadge label={describeSeriesStatus(series.status)} /></td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          ) : null}
-
-          {/* ── Members tab ── */}
-          {activeTab === "members" ? (
-            filteredMembers.length > 0 ? (
-              <div className="plans-card">
-                <div className="plans-card-head">
-                  <div>
-                    <p className="plans-card-eyebrow">Members</p>
-                    <h2 className="plans-card-title">Eligibility register</h2>
-                  </div>
-                  <span className="plans-card-meta">{filteredMembers.length} positions</span>
-                </div>
-                <div className="plans-table-wrap">
-                  <table className="plans-table">
-                    <thead>
-                      <tr>
-                        <th>Wallet</th>
-                        <th>Eligibility</th>
-                        <th>Delegated rights</th>
-                        <th>Position</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {filteredMembers.map((member) => (
-                        <tr key={member.address}>
-                          <td data-label="Wallet"><span className="plans-table-mono">{shortenAddress(member.wallet, 6)}</span></td>
-                          <td data-label="Eligibility"><StatusBadge label={describeEligibilityStatus(member.eligibilityStatus)} /></td>
-                          <td data-label="Delegated rights">{member.delegatedRights.join(", ") || "None"}</td>
-                          <td data-label="Position"><span className="plans-table-mono">{shortenAddress(member.address, 6)}</span></td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            ) : (
-              <PlansEmptyState
-                title="No member positions in this filter"
-                copy={effectivePersona === "sponsor" ? "Choose another series or plan to inspect member rights." : "This plan filter does not currently expose member positions."}
-              />
-            )
-          ) : null}
-
-          {/* ── Claims tab ── */}
-          {activeTab === "claims" ? (
-            <div className="plans-split">
-              <div className="plans-card">
-                <div className="plans-card-head">
-                  <div>
-                    <p className="plans-card-eyebrow">Claims</p>
-                    <h2 className="plans-card-title">Adjudication register</h2>
-                  </div>
-                </div>
-                {filteredClaims.length > 0 ? (
-                  <div className="plans-table-wrap">
-                    <table className="plans-table">
-                      <thead>
-                        <tr>
-                          <th>Claim</th>
-                          <th>Status</th>
-                          <th>Approved</th>
-                          <th>Reserved</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {filteredClaims.map((claim) => (
-                          <tr key={claim.address}>
-                            <td data-label="Claim"><span className="plans-table-mono">{claim.claimId}</span></td>
-                            <td data-label="Status"><StatusBadge label={describeClaimStatus(claim.intakeStatus)} /></td>
-                            <td data-label="Approved"><span className="plans-table-mono">{formatAmount(claim.approvedAmount)}</span></td>
-                            <td data-label="Reserved"><span className="plans-table-mono">{formatAmount(claim.reservedAmount)}</span></td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                ) : (
-                  <PlansEmptyState
-                    title="No claim cases in this filter"
-                    copy={claimsEmptyCopy(Boolean(selectedSeries), planClaims.length > 0)}
-                  />
-                )}
-              </div>
-
-              <div className="plans-card">
-                <div className="plans-card-head">
-                  <div>
-                    <p className="plans-card-eyebrow">Obligations</p>
-                    <h2 className="plans-card-title">Outstanding liabilities</h2>
-                  </div>
-                </div>
-                {filteredObligations.length > 0 ? (
-                  <div className="plans-table-wrap">
-                    <table className="plans-table">
-                      <thead>
-                        <tr>
-                          <th>Obligation</th>
-                          <th>Status</th>
-                          <th>Principal</th>
-                          <th>Outstanding</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {filteredObligations.map((obligation) => (
-                          <tr key={obligation.address}>
-                            <td data-label="Obligation"><span className="plans-table-mono">{obligation.obligationId}</span></td>
-                            <td data-label="Status"><StatusBadge label={describeObligationStatus(obligation.status)} /></td>
-                            <td data-label="Principal"><span className="plans-table-mono">{formatAmount(obligation.principalAmount)}</span></td>
-                            <td data-label="Outstanding"><span className="plans-table-mono">{formatAmount(obligation.outstandingAmount)}</span></td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                ) : (
-                  <PlansEmptyState
-                    title="No obligations in this filter"
-                    copy={obligationsEmptyCopy(Boolean(selectedSeries), planObligations.length > 0)}
-                  />
-                )}
-              </div>
-            </div>
-          ) : null}
-
-          {/* ── Schemas tab ── */}
-          {activeTab === "schemas" ? (
-            selectedSeries ? (
-              <div className="plans-split">
-                <div className="plans-card">
-                  <div className="plans-card-head">
-                    <div>
-                      <p className="plans-card-eyebrow">Schema</p>
-                      <h2 className="plans-card-title">{selectedSeries.displayName}</h2>
-                    </div>
-                    <span className="plans-card-meta">{selectedSeries.termsVersion}</span>
-                  </div>
-                  <div className="plans-data-grid">
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Comparability_Key</span>
-                      <strong className="plans-data-value">{selectedSeries.comparabilityKey}</strong>
-                    </div>
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Outcome_Count</span>
-                      <strong className="plans-data-value">{formatAmount(seriesOutcomeCount(selectedSeries.address))}</strong>
-                    </div>
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Status</span>
-                      <StatusBadge label={describeSeriesStatus(selectedSeries.status)} />
-                    </div>
-                  </div>
-                </div>
-
-                <div className="plans-card">
-                  <div className="plans-card-head">
-                    <div>
-                      <p className="plans-card-eyebrow">Detail</p>
-                      <h2 className="plans-card-title">On-chain state</h2>
-                    </div>
-                  </div>
-                  <div className="plans-data-grid">
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Series_ID</span>
-                      <span className="plans-data-value plans-table-mono">{selectedSeries.seriesId}</span>
-                    </div>
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Mode</span>
-                      <span className="plans-data-value">{describeSeriesMode(selectedSeries.mode)}</span>
-                    </div>
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Terms_Version</span>
-                      <span className="plans-data-value plans-table-mono">{selectedSeries.termsVersion}</span>
-                    </div>
-                    <div className="plans-data-row">
-                      <span className="plans-data-label">Address</span>
-                      <span className="plans-data-value plans-table-mono">{shortenAddress(selectedSeries.address, 8)}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <PlansEmptyState title="No schema context" copy="Choose a plan and series to inspect comparability posture." />
-            )
-          ) : null}
-
-          {/* ── Funding tab ── */}
-          {activeTab === "funding" ? (
-            <div className="plans-card">
-              <div className="plans-card-head">
-                <div>
-                  <p className="plans-card-eyebrow">Funding</p>
-                  <h2 className="plans-card-title">Balances and reserves</h2>
-                </div>
-                <span className="plans-card-meta">
-                  <span className="plans-live-dot" />
-                  {planFundingLines.length} lines
-                </span>
-              </div>
-              <div className="plans-table-wrap">
-                <table className="plans-table">
-                  <thead>
-                    <tr>
-                      <th>Funding line</th>
-                      <th>Type</th>
-                      <th>Funded</th>
-                      <th>Reserved</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {planFundingLines.map((line) => (
-                      <tr key={line.address}>
-                        <td data-label="Funding line">{line.displayName}</td>
-                        <td data-label="Type">{describeFundingLineType(line.lineType)}</td>
-                        <td data-label="Funded"><span className="plans-table-mono">{formatAmount(line.fundedAmount)}</span></td>
-                        <td data-label="Reserved"><span className="plans-table-mono">{formatAmount(line.reservedAmount)}</span></td>
-                        <td data-label="Status"><StatusBadge label={line.status === 0 ? "Open" : "Managed"} /></td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          ) : null}
-
-          {/* ── Settings tab ── */}
-          {activeTab === "settings" ? (
-            <div className="plans-card">
-              <div className="plans-card-head">
-                <div>
-                  <p className="plans-card-eyebrow">Settings</p>
-                  <h2 className="plans-card-title">Administration addresses</h2>
-                </div>
-                <span className="plans-card-meta">Settings</span>
-              </div>
-              <div className="plans-settings-grid">
-                <div className="plans-settings-row">
-                  <span className="plans-settings-lane">Reserve domain</span>
-                  <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.reserveDomain, 6)}</span>
-                </div>
-                <div className="plans-settings-row">
-                  <span className="plans-settings-lane">Plan admin</span>
-                  <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.planAdmin, 6)}</span>
-                </div>
-                <div className="plans-settings-row">
-                  <span className="plans-settings-lane">Sponsor operator</span>
-                  <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.sponsorOperator, 6)}</span>
-                </div>
-                <div className="plans-settings-row">
-                  <span className="plans-settings-lane">Claims operator</span>
-                  <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.claimsOperator, 6)}</span>
-                </div>
-              </div>
-            </div>
-          ) : null}
+          <div className="plans-kpi-metric">
+            <span className="plans-kpi-label">CLAIMS_LIVE</span>
+            <span className="plans-kpi-value">{planClaimCount}</span>
+            <span className="plans-kpi-meta">{planObligations.length} obligations tracked</span>
+          </div>
+          <div className="plans-kpi-metric">
+            <span className="plans-kpi-label">FUNDING_UTILIZATION</span>
+            <span className="plans-kpi-value">
+              <span className="plans-kpi-pulse" aria-hidden="true" />
+              {poolUtilization}%
+            </span>
+            <span className="plans-kpi-meta">{planFundingLines.length} {planFundingLines.length === 1 ? "line" : "lines"} · {formatAmount(reserveCoverage)} bps</span>
+          </div>
         </section>
 
-        {/* ── Rail ── */}
-        <aside className="plans-rail">
-          <div className="plans-rail-panel">
-            {/* Sponsor */}
-            <section className="plans-rp-section">
-              <div className="plans-rp-head">
-                <h3 className="plans-rp-title">Sponsor</h3>
-                <span className="plans-rp-tag"><span className="plans-live-dot" /> Live</span>
-              </div>
-              {(() => {
-                const committed = Number(sponsorView?.committedSponsorBudget ?? 0);
-                const remaining = Number(sponsorView?.remainingSponsorBudget ?? 0);
-                const usedPct = committed > 0 ? Math.round(((committed - remaining) / committed) * 100) : 0;
-                return (
-                  <>
-                    <div className="plans-rp-hero">
-                      <span className="plans-rp-hero-val">{formatAmount(remaining)}</span>
-                      <span className="plans-rp-hero-sub">remaining of {formatAmount(committed)}</span>
-                    </div>
-                    <div className="plans-rp-bar">
-                      <div className="plans-rp-bar-fill" style={{ width: `${usedPct}%` }} />
-                    </div>
-                    <div className="plans-rp-row">
-                      <span>Reserve coverage</span>
-                      <strong>{formatAmount(sponsorView?.reserveCoverageBps ?? 0)} bps</strong>
-                    </div>
-                  </>
-                );
-              })()}
-            </section>
-
-            {/* Funding */}
-            <section className="plans-rp-section">
-              <div className="plans-rp-head">
-                <h3 className="plans-rp-title">Funding</h3>
-                <span className="plans-rp-tag">{planFundingLines.length} active</span>
-              </div>
-              {planFundingLines.map((line) => {
-                const funded = Number(line.fundedAmount);
-                const reserved = Number(line.reservedAmount);
-                const available = availableFundingLineBalance(line);
-                const usedPct = funded > 0 ? Math.round((reserved / funded) * 100) : 0;
-                return (
-                  <div key={line.address} className="plans-rp-fund">
-                    <div className="plans-rp-row">
-                      <span>{line.displayName}</span>
-                      <strong>{formatAmount(available)}</strong>
-                    </div>
-                    <div className="plans-rp-bar plans-rp-bar-sm">
-                      <div className="plans-rp-bar-fill" style={{ width: `${usedPct}%` }} />
-                    </div>
-                    <div className="plans-rp-fund-meta">
-                      <span>{formatAmount(reserved)} reserved</span>
-                      <span>{formatAmount(funded)} funded</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </section>
-
-            {/* Audit trail */}
-            <section className="plans-rp-section">
-              <div className="plans-rp-head">
-                <h3 className="plans-rp-title">Audit trail</h3>
-              </div>
-              <div className="plans-rp-trail">
-                {auditTrail.map((item) => (
-                  <div key={item.id} className={`plans-rp-event plans-rp-event-${item.tone}`}>
-                    <span className="plans-rp-event-dot" />
-                    <strong className="plans-rp-event-label">{item.label}</strong>
-                    <time className="plans-rp-event-time">{item.timestamp}</time>
-                  </div>
-                ))}
-              </div>
-            </section>
+        {/* ── Tab bar ───────────────────────── */}
+        <nav className="plans-tabs liquid-glass" aria-label="Plan workspace sections">
+          <div ref={tabBarRef} className="plans-tabs-inner">
+            {PLAN_TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  data-tab-id={tab.id}
+                  className={cn("plans-tab", isActive && "plans-tab-active")}
+                  onClick={() => updateParams({ tab: tab.id })}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <span className="plans-tab-number">{TAB_NUMBERS[tab.id as PlanTabId]}</span>
+                  <span className="material-symbols-outlined plans-tab-icon">{TAB_ICONS[tab.id as PlanTabId]}</span>
+                  <span className="plans-tab-label">{tab.label}</span>
+                </button>
+              );
+            })}
           </div>
-        </aside>
+        </nav>
+
+        {/* ── Body ──────────────────────────── */}
+        {invalidSelection ? (
+          <PlansEmptyState title={invalidSelection.title} copy={invalidSelection.copy} />
+        ) : (
+          <div className="plans-body">
+            <section className="plans-main">
+
+              {/* ── Overview tab ── */}
+              {activeTab === "overview" ? (
+                <div className="plans-overview-grid">
+                  <article className="plans-card plans-vitality heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">PROTOCOL_VITALITY_INDEX</p>
+                        <h2 className="plans-card-title plans-card-title-display">
+                          {selectedPlan?.displayName ?? "Awaiting plan"}
+                        </h2>
+                      </div>
+                      <span className="plans-card-meta">
+                        <span className="plans-live-dot" aria-hidden="true" />
+                        {selectedPlan?.planId ?? "—"}
+                      </span>
+                    </div>
+                    <p className="plans-card-body">
+                      Capital velocity, claim activity, and reserve depth across every lane of this plan — a single
+                      operational heartbeat for the sponsor rail.
+                    </p>
+
+                    <div className="plans-vitality-stats">
+                      <div className="plans-vitality-stat">
+                        <span className="plans-vitality-stat-value">{deployedPct}%</span>
+                        <span className="plans-vitality-stat-label">Budget deployed</span>
+                      </div>
+                      <div className="plans-vitality-stat">
+                        <span className="plans-vitality-stat-value">{planSeries.length}</span>
+                        <span className="plans-vitality-stat-label">Active lanes</span>
+                      </div>
+                      <div className="plans-vitality-stat">
+                        <span className="plans-vitality-stat-value plans-vitality-stat-value-accent">
+                          {planClaimCount}
+                        </span>
+                        <span className="plans-vitality-stat-label">Claims live</span>
+                      </div>
+                    </div>
+
+                    {vitalityBars.length > 0 ? (
+                      <div className="plans-vitality-chart" aria-label="Per-series reserved capital">
+                        <div className="plans-vitality-chart-head">
+                          <span className="plans-chart-label">RESERVED_BY_SERIES</span>
+                          <span className="plans-chart-legend">Reserved · Claims</span>
+                        </div>
+                        <div className="plans-vitality-bars">
+                          {vitalityBars.map((bar) => (
+                            <div key={bar.id} className="plans-vitality-bar">
+                              <div className="plans-vitality-bar-head">
+                                <span className="plans-vitality-bar-name">{bar.name}</span>
+                                <span className="plans-vitality-bar-val">{formatAmount(bar.value)}</span>
+                              </div>
+                              <div className="plans-vitality-bar-track">
+                                <div
+                                  className="plans-vitality-bar-fill"
+                                  style={{ width: `${Math.max(4, bar.ratio * 100)}%` }}
+                                />
+                              </div>
+                              <span className="plans-vitality-bar-claims">{bar.claims} claim cases</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </article>
+
+                  <article className="plans-card plans-pressure heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">RESERVE_PRESSURE</p>
+                        <h2 className="plans-card-title plans-card-title-display">
+                          {deployedPct}<span className="plans-pressure-unit">%</span>
+                        </h2>
+                      </div>
+                      <span className={cn("plans-card-meta", deployedPct > 80 && "plans-card-meta-warn")}>
+                        {deployedPct > 80 ? "ELEVATED" : "NOMINAL"}
+                      </span>
+                    </div>
+                    <div className="plans-pressure-bar">
+                      <div
+                        className="plans-pressure-bar-fill"
+                        style={{ width: `${Math.min(100, deployedPct)}%` }}
+                      />
+                    </div>
+                    <div className="plans-pressure-meta">
+                      <span>${formatAmount(deployed)} deployed</span>
+                      <span>${formatAmount(remaining)} remaining</span>
+                    </div>
+                  </article>
+
+                  <article className="plans-card plans-velocity heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">CLAIMS_VELOCITY</p>
+                        <h2 className="plans-card-title plans-card-title-display">{planClaimCount}</h2>
+                      </div>
+                      <span className="plans-card-meta">
+                        <span className="plans-live-dot" aria-hidden="true" />
+                        LIVE
+                      </span>
+                    </div>
+                    <p className="plans-card-body">
+                      Active adjudications across {planSeries.length} series lanes, with {planObligations.length} obligations
+                      in protocol custody.
+                    </p>
+                    <button
+                      type="button"
+                      className="plans-inline-action"
+                      onClick={() => updateParams({ tab: "claims" })}
+                    >
+                      INSPECT_CLAIMS
+                      <span className="material-symbols-outlined">arrow_forward</span>
+                    </button>
+                  </article>
+
+                  <article className="plans-card plans-lanes heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">SERIES_LANES</p>
+                        <h2 className="plans-card-title">Coverage across the plan</h2>
+                      </div>
+                      <span className="plans-card-meta">{planSeries.length} active</span>
+                    </div>
+                    <div className="plans-lane-stack">
+                      {planSeries.map((series) => {
+                        const isSelected = selectedSeries?.address === series.address;
+                        return (
+                          <button
+                            type="button"
+                            key={series.address}
+                            className={cn("plans-lane", isSelected && "plans-lane-active")}
+                            onClick={() => updateParams({ series: series.address })}
+                          >
+                            <div className="plans-lane-info">
+                              <span className="plans-lane-name">{series.displayName}</span>
+                              <span className="plans-lane-key">{series.comparabilityKey}</span>
+                            </div>
+                            <div className="plans-lane-meta">
+                              <span className="plans-lane-mode">{describeSeriesMode(series.mode)}</span>
+                              <StatusBadge label={describeSeriesStatus(series.status)} />
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </article>
+                </div>
+              ) : null}
+
+              {/* ── Series tab ── */}
+              {activeTab === "series" ? (
+                <article className="plans-card heavy-glass">
+                  <div className="plans-card-head">
+                    <div>
+                      <p className="plans-card-eyebrow">POLICY_SERIES_REGISTER</p>
+                      <h2 className="plans-card-title plans-card-title-display">
+                        {planSeries.length} active <em>{planSeries.length === 1 ? "lane" : "lanes"}</em>
+                      </h2>
+                    </div>
+                    <span className="plans-card-meta">
+                      <span className="plans-live-dot" aria-hidden="true" />
+                      {selectedPlan?.planId}
+                    </span>
+                  </div>
+                  <div className="plans-table-wrap">
+                    <table className="plans-table">
+                      <thead>
+                        <tr>
+                          <th>Series</th>
+                          <th>Version</th>
+                          <th>Comparability</th>
+                          <th>Outcomes</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {planSeries.map((series) => {
+                          const isSelected = selectedSeries?.address === series.address;
+                          return (
+                            <tr key={series.address} className={cn(isSelected && "plans-table-row-active")}>
+                              <td data-label="Series">
+                                <button
+                                  type="button"
+                                  className="plans-table-link"
+                                  onClick={() => updateParams({ series: series.address })}
+                                >
+                                  {series.displayName}
+                                </button>
+                              </td>
+                              <td data-label="Version"><span className="plans-table-mono">{series.termsVersion}</span></td>
+                              <td data-label="Comparability"><span className="plans-table-mono">{series.comparabilityKey}</span></td>
+                              <td data-label="Outcomes"><span className="plans-table-mono">{formatAmount(seriesOutcomeCount(series.address))}</span></td>
+                              <td data-label="Status"><StatusBadge label={describeSeriesStatus(series.status)} /></td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
+              ) : null}
+
+              {/* ── Members tab ── */}
+              {activeTab === "members" ? (
+                filteredMembers.length > 0 ? (
+                  <article className="plans-card heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">ELIGIBILITY_REGISTER</p>
+                        <h2 className="plans-card-title plans-card-title-display">
+                          Member <em>positions</em>
+                        </h2>
+                      </div>
+                      <span className="plans-card-meta">{filteredMembers.length} tracked</span>
+                    </div>
+                    <div className="plans-table-wrap">
+                      <table className="plans-table">
+                        <thead>
+                          <tr>
+                            <th>Wallet</th>
+                            <th>Eligibility</th>
+                            <th>Delegated rights</th>
+                            <th>Position</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {filteredMembers.map((member) => (
+                            <tr key={member.address}>
+                              <td data-label="Wallet"><span className="plans-table-mono">{shortenAddress(member.wallet, 6)}</span></td>
+                              <td data-label="Eligibility"><StatusBadge label={describeEligibilityStatus(member.eligibilityStatus)} /></td>
+                              <td data-label="Delegated rights">{member.delegatedRights.join(", ") || "None"}</td>
+                              <td data-label="Position"><span className="plans-table-mono">{shortenAddress(member.address, 6)}</span></td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </article>
+                ) : (
+                  <PlansEmptyState
+                    title="No member positions in this filter"
+                    copy={effectivePersona === "sponsor"
+                      ? "Choose another series or plan to inspect member rights."
+                      : "This plan filter does not currently expose member positions."}
+                  />
+                )
+              ) : null}
+
+              {/* ── Claims tab ── */}
+              {activeTab === "claims" ? (
+                <div className="plans-stack">
+                  <article className="plans-card heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">ADJUDICATION_REGISTER</p>
+                        <h2 className="plans-card-title plans-card-title-display">
+                          Claim <em>cases</em>
+                        </h2>
+                      </div>
+                      <span className="plans-card-meta">{filteredClaims.length} tracked</span>
+                    </div>
+                    {filteredClaims.length > 0 ? (
+                      <div className="plans-table-wrap">
+                        <table className="plans-table">
+                          <thead>
+                            <tr>
+                              <th>Claim</th>
+                              <th>Status</th>
+                              <th>Approved</th>
+                              <th>Reserved</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {filteredClaims.map((claim) => (
+                              <tr key={claim.address}>
+                                <td data-label="Claim"><span className="plans-table-mono">{claim.claimId}</span></td>
+                                <td data-label="Status"><StatusBadge label={describeClaimStatus(claim.intakeStatus)} /></td>
+                                <td data-label="Approved"><span className="plans-table-amount">{formatAmount(claim.approvedAmount)}</span></td>
+                                <td data-label="Reserved"><span className="plans-table-amount">{formatAmount(claim.reservedAmount)}</span></td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <PlansEmptyState
+                        title="No claim cases in this filter"
+                        copy={claimsEmptyCopy(Boolean(selectedSeries), planClaims.length > 0)}
+                      />
+                    )}
+                  </article>
+
+                  <article className="plans-card heavy-glass">
+                    <div className="plans-card-head">
+                      <div>
+                        <p className="plans-card-eyebrow">OUTSTANDING_OBLIGATIONS</p>
+                        <h2 className="plans-card-title plans-card-title-display">
+                          Protocol <em>liabilities</em>
+                        </h2>
+                      </div>
+                      <span className="plans-card-meta">{filteredObligations.length} tracked</span>
+                    </div>
+                    {filteredObligations.length > 0 ? (
+                      <div className="plans-table-wrap">
+                        <table className="plans-table">
+                          <thead>
+                            <tr>
+                              <th>Obligation</th>
+                              <th>Status</th>
+                              <th>Principal</th>
+                              <th>Outstanding</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {filteredObligations.map((obligation) => (
+                              <tr key={obligation.address}>
+                                <td data-label="Obligation"><span className="plans-table-mono">{obligation.obligationId}</span></td>
+                                <td data-label="Status"><StatusBadge label={describeObligationStatus(obligation.status)} /></td>
+                                <td data-label="Principal"><span className="plans-table-amount">{formatAmount(obligation.principalAmount)}</span></td>
+                                <td data-label="Outstanding"><span className="plans-table-amount">{formatAmount(obligation.outstandingAmount)}</span></td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    ) : (
+                      <PlansEmptyState
+                        title="No obligations in this filter"
+                        copy={obligationsEmptyCopy(Boolean(selectedSeries), planObligations.length > 0)}
+                      />
+                    )}
+                  </article>
+                </div>
+              ) : null}
+
+              {/* ── Schemas tab ── */}
+              {activeTab === "schemas" ? (
+                selectedSeries ? (
+                  <div className="plans-stack">
+                    <article className="plans-card heavy-glass">
+                      <div className="plans-card-head">
+                        <div>
+                          <p className="plans-card-eyebrow">COMPARABILITY_SCHEMA</p>
+                          <h2 className="plans-card-title plans-card-title-display">
+                            {selectedSeries.displayName}
+                          </h2>
+                        </div>
+                        <span className="plans-card-meta">{selectedSeries.termsVersion}</span>
+                      </div>
+                      <div className="plans-data-grid">
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Comparability_Key</span>
+                          <strong className="plans-data-value">{selectedSeries.comparabilityKey}</strong>
+                        </div>
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Outcome_Count</span>
+                          <strong className="plans-data-value">{formatAmount(seriesOutcomeCount(selectedSeries.address))}</strong>
+                        </div>
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Status</span>
+                          <StatusBadge label={describeSeriesStatus(selectedSeries.status)} />
+                        </div>
+                      </div>
+                    </article>
+
+                    <article className="plans-card heavy-glass">
+                      <div className="plans-card-head">
+                        <div>
+                          <p className="plans-card-eyebrow">ON_CHAIN_STATE</p>
+                          <h2 className="plans-card-title">Series metadata</h2>
+                        </div>
+                      </div>
+                      <div className="plans-data-grid">
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Series_ID</span>
+                          <span className="plans-data-value plans-table-mono">{selectedSeries.seriesId}</span>
+                        </div>
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Mode</span>
+                          <span className="plans-data-value">{describeSeriesMode(selectedSeries.mode)}</span>
+                        </div>
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Terms_Version</span>
+                          <span className="plans-data-value plans-table-mono">{selectedSeries.termsVersion}</span>
+                        </div>
+                        <div className="plans-data-row">
+                          <span className="plans-data-label">Address</span>
+                          <span className="plans-data-value plans-table-mono">{shortenAddress(selectedSeries.address, 8)}</span>
+                        </div>
+                      </div>
+                    </article>
+                  </div>
+                ) : (
+                  <PlansEmptyState
+                    title="No schema context"
+                    copy="Choose a policy series to inspect its comparability posture and on-chain metadata."
+                  />
+                )
+              ) : null}
+
+              {/* ── Funding tab ── */}
+              {activeTab === "funding" ? (
+                <article className="plans-card heavy-glass">
+                  <div className="plans-card-head">
+                    <div>
+                      <p className="plans-card-eyebrow">FUNDING_LINES</p>
+                      <h2 className="plans-card-title plans-card-title-display">
+                        Balances &amp; <em>reserves</em>
+                      </h2>
+                    </div>
+                    <span className="plans-card-meta">
+                      <span className="plans-live-dot" aria-hidden="true" />
+                      {planFundingLines.length} {planFundingLines.length === 1 ? "line" : "lines"}
+                    </span>
+                  </div>
+                  <div className="plans-table-wrap">
+                    <table className="plans-table">
+                      <thead>
+                        <tr>
+                          <th>Funding line</th>
+                          <th>Type</th>
+                          <th>Funded</th>
+                          <th>Reserved</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {planFundingLines.map((line) => (
+                          <tr key={line.address}>
+                            <td data-label="Funding line">{line.displayName}</td>
+                            <td data-label="Type">{describeFundingLineType(line.lineType)}</td>
+                            <td data-label="Funded"><span className="plans-table-amount">{formatAmount(line.fundedAmount)}</span></td>
+                            <td data-label="Reserved"><span className="plans-table-amount">{formatAmount(line.reservedAmount)}</span></td>
+                            <td data-label="Status"><StatusBadge label={line.status === 0 ? "Open" : "Managed"} /></td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </article>
+              ) : null}
+
+              {/* ── Settings tab ── */}
+              {activeTab === "settings" ? (
+                <article className="plans-card heavy-glass">
+                  <div className="plans-card-head">
+                    <div>
+                      <p className="plans-card-eyebrow">ADMINISTRATION_LANES</p>
+                      <h2 className="plans-card-title plans-card-title-display">
+                        Control <em>addresses</em>
+                      </h2>
+                    </div>
+                    <span className="plans-card-meta">{selectedPlan?.planId}</span>
+                  </div>
+                  <div className="plans-settings-grid">
+                    <div className="plans-settings-row">
+                      <div>
+                        <span className="plans-settings-label">RESERVE_DOMAIN</span>
+                        <span className="plans-settings-lane">Reserve domain</span>
+                      </div>
+                      <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.reserveDomain, 6)}</span>
+                    </div>
+                    <div className="plans-settings-row">
+                      <div>
+                        <span className="plans-settings-label">PLAN_ADMIN</span>
+                        <span className="plans-settings-lane">Plan admin</span>
+                      </div>
+                      <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.planAdmin, 6)}</span>
+                    </div>
+                    <div className="plans-settings-row">
+                      <div>
+                        <span className="plans-settings-label">SPONSOR_OPERATOR</span>
+                        <span className="plans-settings-lane">Sponsor operator</span>
+                      </div>
+                      <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.sponsorOperator, 6)}</span>
+                    </div>
+                    <div className="plans-settings-row">
+                      <div>
+                        <span className="plans-settings-label">CLAIMS_OPERATOR</span>
+                        <span className="plans-settings-lane">Claims operator</span>
+                      </div>
+                      <span className="plans-settings-address">{formatControlLaneAddress(selectedPlan?.claimsOperator, 6)}</span>
+                    </div>
+                  </div>
+                </article>
+              ) : null}
+            </section>
+
+            {/* ── Rail ───────────────────────── */}
+            <aside className="plans-rail">
+              <section className="plans-rail-card heavy-glass">
+                <div className="plans-rail-head">
+                  <span className="plans-rail-tag">SPONSOR_VELOCITY</span>
+                  <span className="plans-rail-subtag">
+                    <span className="plans-live-dot" aria-hidden="true" />
+                    LIVE
+                  </span>
+                </div>
+                <div className="plans-rail-hero">
+                  <span className="plans-rail-hero-val">${formatAmount(remaining)}</span>
+                  <span className="plans-rail-hero-sub">remaining of ${formatAmount(funded)} funded</span>
+                </div>
+                <div className="plans-rail-bar">
+                  <div className="plans-rail-bar-fill" style={{ width: `${Math.min(100, deployedPct)}%` }} />
+                </div>
+                <div className="plans-rail-row">
+                  <span>Deployed</span>
+                  <strong>{deployedPct}%</strong>
+                </div>
+                <div className="plans-rail-row">
+                  <span>Reserve coverage</span>
+                  <strong>{formatAmount(reserveCoverage)} bps</strong>
+                </div>
+                <div className="plans-rail-row">
+                  <span>Accrued rewards</span>
+                  <strong>${formatAmount(sponsorView?.accruedRewards ?? 0)}</strong>
+                </div>
+              </section>
+
+              <section className="plans-rail-card heavy-glass">
+                <div className="plans-rail-head">
+                  <span className="plans-rail-tag">FUNDING_LINES</span>
+                  <span className="plans-rail-subtag">{planFundingLines.length} active</span>
+                </div>
+                <div className="plans-rail-lines">
+                  {planFundingLines.map((line) => {
+                    const fundedVal = Number(line.fundedAmount);
+                    const reservedVal = Number(line.reservedAmount);
+                    const available = availableFundingLineBalance(line);
+                    const usedPct = fundedVal > 0 ? Math.round((reservedVal / fundedVal) * 100) : 0;
+                    return (
+                      <div key={line.address} className="plans-rail-line">
+                        <div className="plans-rail-row">
+                          <span>{line.displayName}</span>
+                          <strong>${formatAmount(available)}</strong>
+                        </div>
+                        <div className="plans-rail-bar plans-rail-bar-sm">
+                          <div className="plans-rail-bar-fill" style={{ width: `${Math.min(100, usedPct)}%` }} />
+                        </div>
+                        <div className="plans-rail-line-meta">
+                          <span>${formatAmount(reservedVal)} reserved</span>
+                          <span>${formatAmount(fundedVal)} funded</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+
+              <section className="plans-rail-card heavy-glass">
+                <div className="plans-rail-head">
+                  <span className="plans-rail-tag">FIELD_LOG</span>
+                  <span className="plans-rail-subtag">LIVE_AUDIT</span>
+                </div>
+                <div className="plans-rail-trail">
+                  {auditTrail.map((item) => (
+                    <div key={item.id} className={`plans-rail-event plans-rail-event-${item.tone}`}>
+                      <span className="plans-rail-event-dot" aria-hidden="true" />
+                      <div className="plans-rail-event-copy">
+                        <div className="plans-rail-event-row">
+                          <strong className="plans-rail-event-label">{item.label}</strong>
+                          <time className="plans-rail-event-time">{item.timestamp}</time>
+                        </div>
+                        <p className="plans-rail-event-detail">{item.detail}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            </aside>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/protocol-workbench-shell.tsx
+++ b/frontend/components/protocol-workbench-shell.tsx
@@ -62,6 +62,13 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
   const { selectedNetwork, setSelectedNetwork, canSelectNetwork } = useNetworkContext();
   const { effectivePersona, previewPersona, setPreviewPersona, canPreviewPersona } = useWorkspacePersona();
   const isOverviewRoute = pathname === "/overview" || pathname.startsWith("/overview/");
+  const useFullscreenWorkbenchChrome = [
+    "/overview",
+    "/plans",
+    "/capital",
+    "/governance",
+    "/oracles",
+  ].some((route) => pathname === route || pathname.startsWith(`${route}/`));
 
   const networkMenuRef = useRef<HTMLDivElement | null>(null);
   const personaMenuRef = useRef<HTMLDivElement | null>(null);
@@ -171,7 +178,13 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
   }, [connection, selectedNetwork]);
 
   return (
-    <div className={cn("protocol-workbench-shell relative", isOverviewRoute && "protocol-workbench-shell-overview")}>
+    <div
+      className={cn(
+        "protocol-workbench-shell relative",
+        useFullscreenWorkbenchChrome && "protocol-workbench-shell-fullscreen",
+        isOverviewRoute && "protocol-workbench-shell-overview",
+      )}
+    >
       {isOverviewRoute ? null : <div className="absolute inset-0 misty-cyan-glow pointer-events-none z-0" />}
 
       <header className="protocol-topbar">
@@ -395,13 +408,20 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
       <main
         className={cn(
           "protocol-workbench-content micro-etch",
+          useFullscreenWorkbenchChrome && "protocol-workbench-content-fullscreen",
           isOverviewRoute && "protocol-workbench-content-overview",
         )}
       >
         {children}
       </main>
 
-      <footer className={cn("protocol-footer", isOverviewRoute && "protocol-footer-overview")}>
+      <footer
+        className={cn(
+          "protocol-footer",
+          useFullscreenWorkbenchChrome && "protocol-footer-fullscreen",
+          isOverviewRoute && "protocol-footer-overview",
+        )}
+      >
         <span className="protocol-footer-copy">
           &copy; 2026 OmegaX Health Capital Markets. All rights reserved. // {footerMetadataLabel}
         </span>

--- a/frontend/components/protocol-workbench-shell.tsx
+++ b/frontend/components/protocol-workbench-shell.tsx
@@ -5,9 +5,9 @@
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useConnection } from "@solana/wallet-adapter-react";
-import { BookOpenText, ChevronDown, GitBranch, Menu, MoonStar, Package, ShieldCheck, Signal, SunMedium, Users, X } from "lucide-react";
+import { ChevronDown, Menu, MoonStar, SunMedium, Users, X } from "lucide-react";
 
 import { useNetworkContext } from "@/components/network-context";
 import { useTheme } from "@/components/theme-provider";
@@ -24,11 +24,11 @@ const SDK_PACKAGE_URL = "https://www.npmjs.com/package/@omegax/protocol-sdk";
 const DOCS_URL = "https://docs.omegax.health";
 const SECURITY_AUDITS_URL = "https://omegax.health/protocol/audit";
 
-function buildFooterMetadataLabel(): string {
+function buildFooterMetadata(): { version: string; networkLabel: string } {
   const configuredCluster = normalizeExplorerCluster(process.env.NEXT_PUBLIC_SOLANA_EXPLORER_CLUSTER);
   const networkLabel = NETWORK_OPTIONS.find((option) => option.id === configuredCluster)?.label ?? "Devnet";
   const protocolVersion = (process.env.NEXT_PUBLIC_PROTOCOL_BUILD_VERSION || "").trim() || frontendPackage.version;
-  return `Protocol v${protocolVersion} • ${networkLabel} build`;
+  return { version: `v${protocolVersion}`, networkLabel };
 }
 
 function personaBadgeForNav(sectionId: (typeof WORKBENCH_NAV)[number]["id"], persona: string) {
@@ -56,7 +56,6 @@ function sectionLabelForPersona(persona: string) {
 
 export default function ProtocolWorkbenchShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const { connection } = useConnection();
   const { mounted, theme, toggleTheme } = useTheme();
   const { selectedNetwork, setSelectedNetwork, canSelectNetwork } = useNetworkContext();
@@ -83,34 +82,7 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
   const isDarkTheme = mounted && theme === "dark";
   const ThemeIcon = isDarkTheme ? SunMedium : MoonStar;
   const nextThemeLabel = isDarkTheme ? "light" : "dark";
-  const footerMetadataLabel = buildFooterMetadataLabel();
-  const activePlansTab = searchParams.get("tab");
-  const shortcutActions = [
-    {
-      href: "/plans",
-      label: "Plans",
-      icon: "description",
-      active: pathname === "/plans" && (!activePlansTab || activePlansTab === "overview"),
-    },
-    {
-      href: "/members",
-      label: "Members",
-      icon: "groups",
-      active: pathname === "/members" || (pathname === "/plans" && activePlansTab === "members"),
-    },
-    {
-      href: "/claims",
-      label: "Claims",
-      icon: "assignment_turned_in",
-      active: pathname === "/claims" || (pathname === "/plans" && activePlansTab === "claims"),
-    },
-    {
-      href: "/schemas",
-      label: "Schemas",
-      icon: "schema",
-      active: pathname === "/schemas" || (pathname === "/plans" && activePlansTab === "schemas"),
-    },
-  ] as const;
+  const footerMetadata = buildFooterMetadata();
 
   useEffect(() => {
     setIsMobileNavOpen(false);
@@ -235,22 +207,6 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
           </div>
 
           <div className="protocol-topbar-controls">
-            <div className="protocol-topbar-icon-group" aria-label="Workspace shortcuts" role="navigation">
-              {shortcutActions.map((action) => (
-                <Link
-                  key={action.href}
-                  href={action.href}
-                  className={cn("protocol-topbar-icon-link", action.active && "protocol-topbar-icon-link-active")}
-                  aria-label={action.label}
-                  aria-current={action.active ? "page" : undefined}
-                  data-tooltip={action.label}
-                  title={action.label}
-                >
-                  <span className="material-symbols-outlined" aria-hidden="true">{action.icon}</span>
-                </Link>
-              ))}
-            </div>
-
             <div ref={networkMenuRef} className="protocol-toolbar-dropdown">
               <button
                 type="button"
@@ -422,30 +378,35 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
           isOverviewRoute && "protocol-footer-overview",
         )}
       >
-        <span className="protocol-footer-copy">
-          &copy; 2026 OmegaX Health Capital Markets. All rights reserved. // {footerMetadataLabel}
-        </span>
-        <div className="protocol-footer-links">
+        <div className="protocol-footer-identity">
+          <span className="protocol-footer-mark">OmegaX Protocol</span>
+          <span className="protocol-footer-legal">
+            &copy; 2026 OmegaX Health Capital Markets · All rights reserved
+          </span>
+        </div>
+
+        <nav className="protocol-footer-links" aria-label="Resources">
           <Link href={SOURCE_REPO_URL} target="_blank" rel="noopener noreferrer" className="protocol-footer-link">
-            <GitBranch className="protocol-footer-link-icon" aria-hidden="true" />
-            <span>SOURCE</span>
+            Source
           </Link>
           <Link href={SDK_PACKAGE_URL} target="_blank" rel="noopener noreferrer" className="protocol-footer-link">
-            <Package className="protocol-footer-link-icon" aria-hidden="true" />
-            <span>SDK</span>
+            SDK
           </Link>
           <Link href={DOCS_URL} target="_blank" rel="noopener noreferrer" className="protocol-footer-link">
-            <BookOpenText className="protocol-footer-link-icon" aria-hidden="true" />
-            <span>DOCS</span>
+            Docs
           </Link>
           <Link href="/network-health" className="protocol-footer-link">
-            <Signal className="protocol-footer-link-icon" aria-hidden="true" />
-            <span>STATUS</span>
+            Status
           </Link>
           <Link href={SECURITY_AUDITS_URL} target="_blank" rel="noopener noreferrer" className="protocol-footer-link">
-            <ShieldCheck className="protocol-footer-link-icon" aria-hidden="true" />
-            <span>AUDITS</span>
+            Audits
           </Link>
+        </nav>
+
+        <div className="protocol-footer-build" aria-label="Build">
+          <span className="protocol-footer-build-version">{footerMetadata.version}</span>
+          <span className="protocol-footer-build-sep" aria-hidden="true" />
+          <span className="protocol-footer-build-network">{footerMetadata.networkLabel}</span>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- Drops the four workspace shortcut icon-buttons (Plans / Members / Claims / Schemas) from the topbar so the header stays anchored to the primary nav and gains breathing room.
- Rebuilds the footer as a 3-column composition: brand identity + legal on the left, centered resource links, and a compact mono build pill on the right.
- Tightens type scale, weights, spacing, and active-state treatments across the topbar — slimmer wordmark, lighter nav with sharper underline, refined status pill, lighter toolbar buttons. Newsreader is now used sparingly (only the footer brand mark); body / nav / labels stay in Space Grotesk and Fira Code for meta.
- Tunes responsive breakpoints so the footer stacks gracefully at tablet and the topbar stays uncramped at 375 px (system-synced label collapses to dot + icon, devnet pill / persona / theme controls compress).

## Test plan
- [ ] Visit `/overview` and `/plans` on desktop in light + dark mode and confirm header / footer hierarchy reads cleanly.
- [ ] Resize through tablet (`768`) and mobile (`375`) — footer should stack into 3 centered tiers, header chrome should not overflow.
- [ ] Verify nav active state (underline + heavier weight) on each route.
- [ ] Verify footer link hover (cyan + subtle underline) and the build pill's mono typography in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)