### PR TITLE
fix: manage LP credentialing and sync workbench updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository now treats the earlier pool-first surface as retired devnet hist
 - sponsor budgets are not LP capital
 - reward and protection reconcile through one reserve kernel
 - reserve truth is ledger-based, not implied by scattered treasuries
-- restricted or wrapper-mediated participation is layered through reserve domains and capital classes, not fake parallel protocols
+- restricted or wrapper-mediated participation is layered through reserve domains, capital classes, and managed LP credentialing, not fake parallel protocols
 
 ## Release Status
 

--- a/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
+++ b/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 10cf548fd9221511a40aafb2952640e41d16ce2c7e28b89a3f4acaf11613947b
+// contract_sha256: a9034c2cfe96235af9882c7a63ca150dc8df175df478a89c0354e9516a1df603
 
 package com.omegax.protocol
 
@@ -38,6 +38,7 @@ object ProtocolContract {
         "update_allocation_caps" to byteArrayOf(224u.toByte(), 101u.toByte(), 103u.toByte(), 146u.toByte(), 78u.toByte(), 5u.toByte(), 48u.toByte(), 132u.toByte()),
         "update_capital_class_controls" to byteArrayOf(34u.toByte(), 4u.toByte(), 113u.toByte(), 70u.toByte(), 79u.toByte(), 197u.toByte(), 244u.toByte(), 109u.toByte()),
         "update_health_plan_controls" to byteArrayOf(108u.toByte(), 11u.toByte(), 28u.toByte(), 140u.toByte(), 226u.toByte(), 164u.toByte(), 239u.toByte(), 113u.toByte()),
+        "update_lp_position_credentialing" to byteArrayOf(54u.toByte(), 194u.toByte(), 211u.toByte(), 94u.toByte(), 197u.toByte(), 61u.toByte(), 228u.toByte(), 202u.toByte()),
         "update_member_eligibility" to byteArrayOf(254u.toByte(), 66u.toByte(), 68u.toByte(), 244u.toByte(), 98u.toByte(), 157u.toByte(), 111u.toByte(), 191u.toByte()),
         "update_reserve_domain_controls" to byteArrayOf(3u.toByte(), 60u.toByte(), 38u.toByte(), 233u.toByte(), 198u.toByte(), 167u.toByte(), 116u.toByte(), 197u.toByte()),
         "version_policy_series" to byteArrayOf(64u.toByte(), 76u.toByte(), 132u.toByte(), 253u.toByte(), 41u.toByte(), 220u.toByte(), 169u.toByte(), 146u.toByte()),

--- a/docs/architecture/solana-instruction-map.md
+++ b/docs/architecture/solana-instruction-map.md
@@ -50,7 +50,8 @@ All current public instructions are defined in [`programs/omegax_protocol/src/li
 | --- | --- |
 | `create_liquidity_pool` | create an LP-facing capital sleeve inside a reserve domain |
 | `create_capital_class` | create a class-specific investor instrument inside a pool |
-| `deposit_into_capital_class` | mint or expand LP exposure into a class |
+| `update_lp_position_credentialing` | grant or revoke managed LP access for restricted classes |
+| `deposit_into_capital_class` | mint or expand LP exposure into a class using on-chain LP credential state |
 | `request_redemption` | queue a class redemption request |
 | `process_redemption_queue` | settle queued redemptions when capacity allows |
 | `create_allocation_position` | bridge a capital class into a plan funding line |

--- a/e2e/support/surface_manifest.ts
+++ b/e2e/support/surface_manifest.ts
@@ -75,10 +75,11 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioName, ScenarioDefinition> = {
   },
   liquidity_pool_and_capital_class_lifecycle: {
     title: "Liquidity Pool and Capital Class Lifecycle",
-    focus: "LP capital enters through explicit pools, classes, and LP positions rather than plan-side sponsor budgets.",
+    focus: "LP capital enters through explicit pools, classes, managed credentialing, and LP positions rather than plan-side sponsor budgets.",
     instructions: [
       "create_liquidity_pool",
       "create_capital_class",
+      "update_lp_position_credentialing",
       "deposit_into_capital_class",
       "request_redemption",
       "process_redemption_queue",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8867,6 +8867,19 @@
       gap: 0.5rem;
     }
 
+    .plans-overview-grid {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto;
+    }
+
+    .plans-vitality,
+    .plans-pressure,
+    .plans-velocity,
+    .plans-lanes {
+      grid-column: auto;
+      grid-row: auto;
+    }
+
     .plans-table {
       min-width: 0;
       display: block;

--- a/frontend/components/governance-workbench.tsx
+++ b/frontend/components/governance-workbench.tsx
@@ -15,10 +15,13 @@ import { firstSearchParamValue, type RouteSearchParams, toURLSearchParams } from
 import {
   buildAuditTrail,
   buildGovernanceQueue,
+  canonicalizeGovernanceWorkbenchParams,
   defaultTabForPersona,
   describeGovernanceQueueStatus,
   GOVERNANCE_TABS,
   GOVERNANCE_TEMPLATE_ROWS,
+  governanceStatusVariant,
+  resolveGovernanceProposalSelection,
   type GovernanceQueueItem,
   type GovernanceTabId,
 } from "@/lib/workbench";
@@ -34,8 +37,6 @@ import { shortenAddress } from "@/lib/protocol";
 import { cn } from "@/lib/cn";
 
 /* ── Constants ──────────────────────────────────────── */
-
-const PROPOSAL_CONTEXT_TABS = new Set<GovernanceTabId>(["overview", "queue"]);
 
 const TAB_ICONS: Record<GovernanceTabId, string> = {
   overview: "dashboard",
@@ -78,17 +79,8 @@ function personaHeroCopy(persona: string): { eyebrow: string; subtitle: string }
   }
 }
 
-function statusVariant(label: string): "success" | "warning" | "danger" | "info" | "muted" {
-  const l = label.toLowerCase();
-  if (l.includes("succeed") || l.includes("approved") || l.includes("completed")) return "success";
-  if (l.includes("execut") || l.includes("vot") || l.includes("active")) return "info";
-  if (l.includes("draft") || l.includes("review") || l.includes("signing")) return "warning";
-  if (l.includes("defeat") || l.includes("cancel") || l.includes("fail")) return "danger";
-  return "muted";
-}
-
 function StatusBadge({ label }: { label: string }) {
-  return <span className={`plans-badge plans-badge-${statusVariant(label)}`}>{label}</span>;
+  return <span className={`plans-badge plans-badge-${governanceStatusVariant(label)}`}>{label}</span>;
 }
 
 function buildQueueStateCounts(queue: GovernanceQueueItem[]) {
@@ -128,7 +120,10 @@ export function GovernanceWorkbench({ searchParams = {} }: GovernanceWorkbenchPr
   const activeTab = (GOVERNANCE_TABS.find((tab) => tab.id === requestedTab)?.id
     ?? defaultTabForPersona("governance", effectivePersona)) as GovernanceTabId;
   const queryProposal = firstSearchParamValue(searchParams.proposal)?.trim() ?? "";
-  const selectedProposal = queue.find((proposal) => proposal.proposal === queryProposal) ?? queue[0] ?? null;
+  const selectedProposal = useMemo(
+    () => resolveGovernanceProposalSelection(queue, queryProposal),
+    [queue, queryProposal],
+  );
 
   /* ── Derived data ── */
 
@@ -173,10 +168,10 @@ export function GovernanceWorkbench({ searchParams = {} }: GovernanceWorkbenchPr
 
   const handleTabChange = useCallback((tab: string) => {
     const nextTab = tab as GovernanceTabId;
-    const nextProposal = selectedProposal?.proposal || queryProposal || undefined;
+    const nextProposal = selectedProposal?.proposal || queryProposal || null;
     updateParams({
       tab: nextTab,
-      proposal: PROPOSAL_CONTEXT_TABS.has(nextTab) ? nextProposal : null,
+      proposal: nextProposal,
     });
   }, [queryProposal, selectedProposal, updateParams]);
 
@@ -210,15 +205,15 @@ export function GovernanceWorkbench({ searchParams = {} }: GovernanceWorkbenchPr
   }, [connection]);
 
   useEffect(() => {
-    const nextUpdates: Record<string, string | null | undefined> = {};
-    if (requestedTab !== activeTab) nextUpdates.tab = activeTab;
-    if (PROPOSAL_CONTEXT_TABS.has(activeTab)) {
-      if (selectedProposal && queryProposal !== selectedProposal.proposal) nextUpdates.proposal = selectedProposal.proposal;
-    } else if (queryProposal) {
-      nextUpdates.proposal = null;
-    }
+    const nextUpdates = canonicalizeGovernanceWorkbenchParams({
+      activeTab,
+      loaded: proposalQueueLoaded,
+      queryProposal,
+      requestedTab,
+      selectedProposal,
+    });
     if (Object.keys(nextUpdates).length > 0) updateParams(nextUpdates);
-  }, [activeTab, queryProposal, requestedTab, selectedProposal, updateParams]);
+  }, [activeTab, proposalQueueLoaded, queryProposal, requestedTab, selectedProposal, updateParams]);
 
   /* ── Scroll tab into view ── */
 

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 10cf548fd9221511a40aafb2952640e41d16ce2c7e28b89a3f4acaf11613947b
+// contract_sha256: a9034c2cfe96235af9882c7a63ca150dc8df175df478a89c0354e9516a1df603
 
 export type ProtocolInstructionName =
   | "adjudicate_claim_case"
@@ -33,6 +33,7 @@ export type ProtocolInstructionName =
   | "update_allocation_caps"
   | "update_capital_class_controls"
   | "update_health_plan_controls"
+  | "update_lp_position_credentialing"
   | "update_member_eligibility"
   | "update_reserve_domain_controls"
   | "version_policy_series";
@@ -84,6 +85,7 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS: Record<ProtocolInstructionName
   "update_allocation_caps": Uint8Array.from([224, 101, 103, 146, 78, 5, 48, 132]),
   "update_capital_class_controls": Uint8Array.from([34, 4, 113, 70, 79, 197, 244, 109]),
   "update_health_plan_controls": Uint8Array.from([108, 11, 28, 140, 226, 164, 239, 113]),
+  "update_lp_position_credentialing": Uint8Array.from([54, 194, 211, 94, 197, 61, 228, 202]),
   "update_member_eligibility": Uint8Array.from([254, 66, 68, 244, 98, 157, 111, 191]),
   "update_reserve_domain_controls": Uint8Array.from([3, 60, 38, 233, 198, 167, 116, 197]),
   "version_policy_series": Uint8Array.from([64, 76, 132, 253, 41, 220, 169, 146]),
@@ -179,6 +181,9 @@ export const PROTOCOL_INSTRUCTION_ARGS: Record<ProtocolInstructionName, Protocol
   ],
   "update_health_plan_controls": [
       { name: "args", type: {"defined":{"name":"UpdateHealthPlanControlsArgs"}} },
+  ],
+  "update_lp_position_credentialing": [
+      { name: "args", type: {"defined":{"name":"UpdateLpPositionCredentialingArgs"}} },
   ],
   "update_member_eligibility": [
       { name: "args", type: {"defined":{"name":"UpdateMemberEligibilityArgs"}} },
@@ -472,6 +477,14 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
       { name: "health_plan", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [104, 101, 97, 108, 116, 104, 95, 112, 108, 97, 110] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "health_plan.health_plan_id" }] },
+  ],
+  "update_lp_position_credentialing": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "capital_class", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
+      { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "arg", path: "args.owner" }] },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
   ],
   "update_member_eligibility": [
       { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },

--- a/frontend/lib/workbench.js
+++ b/frontend/lib/workbench.js
@@ -152,6 +152,48 @@ export function describeGovernanceQueueStatus(input) {
         metricValue: input.count.toString(),
     };
 }
+export function governanceStatusVariant(label) {
+    const normalizedLabel = label.toLowerCase();
+    if (normalizedLabel.includes("error")
+        || normalizedLabel.includes("fail")
+        || normalizedLabel.includes("defeat")
+        || normalizedLabel.includes("cancel")
+        || normalizedLabel.includes("veto")) {
+        return "danger";
+    }
+    if (normalizedLabel.includes("succeed")
+        || normalizedLabel.includes("approved")
+        || normalizedLabel.includes("completed")) {
+        return "success";
+    }
+    if (normalizedLabel.includes("execut") || normalizedLabel.includes("vot") || normalizedLabel.includes("active"))
+        return "info";
+    if (normalizedLabel.includes("draft")
+        || normalizedLabel.includes("review")
+        || normalizedLabel.includes("signing")) {
+        return "warning";
+    }
+    return "muted";
+}
+export function resolveGovernanceProposalSelection(queue, queryProposal) {
+    const normalizedProposal = queryProposal?.trim() ?? "";
+    return queue.find((proposal) => proposal.proposal === normalizedProposal) ?? queue[0] ?? null;
+}
+export function canonicalizeGovernanceWorkbenchParams(input) {
+    const nextUpdates = {};
+    if (input.requestedTab !== input.activeTab)
+        nextUpdates.tab = input.activeTab;
+    const normalizedProposal = input.queryProposal?.trim() ?? "";
+    if (input.selectedProposal) {
+        if (normalizedProposal !== input.selectedProposal.proposal) {
+            nextUpdates.proposal = input.selectedProposal.proposal;
+        }
+    }
+    else if (input.loaded && normalizedProposal) {
+        nextUpdates.proposal = null;
+    }
+    return nextUpdates;
+}
 function authorityLabelForProposal(proposal) {
     if (proposal.ownerWalletAddress)
         return shortenGovernanceAddress(proposal.ownerWalletAddress);

--- a/frontend/lib/workbench.ts
+++ b/frontend/lib/workbench.ts
@@ -124,6 +124,8 @@ export type GovernanceQueueStatusCopy = {
   metricValue: string;
 };
 
+export type GovernanceStatusVariant = "success" | "warning" | "danger" | "info" | "muted";
+
 export type WorkbenchAuditItem = {
   id: string;
   tone: "verified" | "pending" | "signal";
@@ -260,6 +262,63 @@ export function describeGovernanceQueueStatus(input: {
     metricAriaLabel: `${input.count} live governance ${proposalLabel}.`,
     metricValue: input.count.toString(),
   };
+}
+
+export function governanceStatusVariant(label: string): GovernanceStatusVariant {
+  const normalizedLabel = label.toLowerCase();
+  if (
+    normalizedLabel.includes("error")
+    || normalizedLabel.includes("fail")
+    || normalizedLabel.includes("defeat")
+    || normalizedLabel.includes("cancel")
+    || normalizedLabel.includes("veto")
+  ) {
+    return "danger";
+  }
+  if (
+    normalizedLabel.includes("succeed")
+    || normalizedLabel.includes("approved")
+    || normalizedLabel.includes("completed")
+  ) {
+    return "success";
+  }
+  if (normalizedLabel.includes("execut") || normalizedLabel.includes("vot") || normalizedLabel.includes("active")) {
+    return "info";
+  }
+  if (normalizedLabel.includes("draft") || normalizedLabel.includes("review") || normalizedLabel.includes("signing")) {
+    return "warning";
+  }
+  return "muted";
+}
+
+export function resolveGovernanceProposalSelection(
+  queue: GovernanceQueueItem[],
+  queryProposal?: string | null,
+): GovernanceQueueItem | null {
+  const normalizedProposal = queryProposal?.trim() ?? "";
+  return queue.find((proposal) => proposal.proposal === normalizedProposal) ?? queue[0] ?? null;
+}
+
+export function canonicalizeGovernanceWorkbenchParams(input: {
+  activeTab: GovernanceTabId;
+  loaded: boolean;
+  queryProposal?: string | null;
+  requestedTab?: string | null;
+  selectedProposal: GovernanceQueueItem | null;
+}): Record<string, string | null | undefined> {
+  const nextUpdates: Record<string, string | null | undefined> = {};
+  if (input.requestedTab !== input.activeTab) nextUpdates.tab = input.activeTab;
+
+  const normalizedProposal = input.queryProposal?.trim() ?? "";
+  if (input.selectedProposal) {
+    if (normalizedProposal !== input.selectedProposal.proposal) {
+      nextUpdates.proposal = input.selectedProposal.proposal;
+    }
+  } else if (input.loaded && normalizedProposal) {
+    nextUpdates.proposal = null;
+  }
+
+  return nextUpdates;
 }
 
 function authorityLabelForProposal(proposal: GovernanceProposalSummary): string {

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -6390,6 +6390,173 @@
       ]
     },
     {
+      "name": "update_lp_position_credentialing",
+      "discriminator": [
+        54,
+        194,
+        211,
+        94,
+        197,
+        61,
+        228,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "capital_class",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  112,
+                  105,
+                  116,
+                  97,
+                  108,
+                  95,
+                  99,
+                  108,
+                  97,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "capital_class.class_id",
+                "account": "CapitalClass"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lp_position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  112,
+                  95,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "capital_class"
+              },
+              {
+                "kind": "arg",
+                "path": "args.owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "UpdateLpPositionCredentialingArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "update_member_eligibility",
       "discriminator": [
         254,
@@ -7169,6 +7336,19 @@
       ]
     },
     {
+      "name": "LPPositionCredentialingUpdatedEvent",
+      "discriminator": [
+        215,
+        90,
+        105,
+        53,
+        22,
+        8,
+        19,
+        82
+      ]
+    },
+    {
       "name": "LedgerInitializedEvent",
       "discriminator": [
         155,
@@ -7394,21 +7574,26 @@
     },
     {
       "code": 6021,
+      "name": "LPPositionHasActiveCapital",
+      "msg": "LP position with active capital cannot be decredentialed"
+    },
+    {
+      "code": 6022,
       "name": "LockupActive",
       "msg": "Capital class lockup is still active"
     },
     {
-      "code": 6022,
+      "code": 6023,
       "name": "AllocationCapExceeded",
       "msg": "Allocation cap exceeded"
     },
     {
-      "code": 6023,
+      "code": 6024,
       "name": "InsufficientFreeAllocationCapacity",
       "msg": "Insufficient free allocation capacity"
     },
     {
-      "code": 6024,
+      "code": 6025,
       "name": "ArithmeticError",
       "msg": "Arithmetic overflow or underflow"
     }
@@ -8395,10 +8580,6 @@
           {
             "name": "shares",
             "type": "u64"
-          },
-          {
-            "name": "credentialed",
-            "type": "bool"
           }
         ]
       }
@@ -8836,6 +9017,39 @@
           {
             "name": "bump",
             "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LPPositionCredentialingUpdatedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "capital_class",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "credentialed",
+            "type": "bool"
+          },
+          {
+            "name": "reason_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           }
         ]
       }
@@ -10086,6 +10300,31 @@
           },
           {
             "name": "active",
+            "type": "bool"
+          },
+          {
+            "name": "reason_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLpPositionCredentialingArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "credentialed",
             "type": "bool"
           },
           {

--- a/programs/omegax_protocol/README.md
+++ b/programs/omegax_protocol/README.md
@@ -36,6 +36,8 @@ The active public object model is:
 - `AllocationPosition`
 - `AllocationLedger`
 
+Restricted and wrapper-only capital classes now rely on managed `LPPosition` credentialing. Direct deposits do not carry a caller-supplied credential flag; access is granted on-chain through the canonical LP position for that class and owner.
+
 ## Important reviewer rule
 
 Older module files still exist in the tree for historical context, but the canonical public program surface is the one declared in `src/lib.rs`. Review the current architecture and instruction map docs before treating older pool-first modules as active design truth.

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1212,6 +1212,37 @@ pub mod omegax_protocol {
         Ok(())
     }
 
+    pub fn update_lp_position_credentialing(
+        ctx: Context<UpdateLpPositionCredentialing>,
+        args: UpdateLpPositionCredentialingArgs,
+    ) -> Result<()> {
+        require_curator_control(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+            &ctx.accounts.liquidity_pool,
+        )?;
+
+        let capital_class_key = ctx.accounts.capital_class.key();
+        let lp_position = &mut ctx.accounts.lp_position;
+        ensure_lp_position_binding(
+            lp_position,
+            capital_class_key,
+            args.owner,
+            ctx.bumps.lp_position,
+        )?;
+        update_lp_position_credentialing_state(lp_position, args.credentialed)?;
+
+        emit!(LPPositionCredentialingUpdatedEvent {
+            capital_class: capital_class_key,
+            owner: args.owner,
+            authority: ctx.accounts.authority.key(),
+            credentialed: args.credentialed,
+            reason_hash: args.reason_hash,
+        });
+
+        Ok(())
+    }
+
     pub fn deposit_into_capital_class(
         ctx: Context<DepositIntoCapitalClass>,
         args: DepositIntoCapitalClassArgs,
@@ -1224,7 +1255,6 @@ pub mod omegax_protocol {
             ctx.accounts.capital_class.pause_flags & PAUSE_FLAG_CAPITAL_SUBSCRIPTIONS == 0,
             OmegaXProtocolError::CapitalSubscriptionsPaused
         );
-        require_class_access(&ctx.accounts.capital_class, args.credentialed)?;
 
         let amount = args.amount;
         let shares = if args.shares == 0 {
@@ -1232,24 +1262,16 @@ pub mod omegax_protocol {
         } else {
             args.shares
         };
+        let owner = ctx.accounts.owner.key();
+        let capital_class_key = ctx.accounts.capital_class.key();
+        let restriction_mode = ctx.accounts.capital_class.restriction_mode;
+        let min_lockup_seconds = ctx.accounts.capital_class.min_lockup_seconds;
+        let now_ts = Clock::get()?.unix_timestamp;
 
         let lp_position = &mut ctx.accounts.lp_position;
-        lp_position.capital_class = ctx.accounts.capital_class.key();
-        lp_position.owner = ctx.accounts.owner.key();
-        lp_position.shares = checked_add(lp_position.shares, shares)?;
-        lp_position.subscription_basis = checked_add(lp_position.subscription_basis, amount)?;
-        lp_position.pending_redemption_shares = 0;
-        lp_position.realized_distributions = 0;
-        lp_position.impaired_principal = 0;
-        lp_position.lockup_ends_at =
-            Clock::get()?.unix_timestamp + ctx.accounts.capital_class.min_lockup_seconds;
-        lp_position.credentialed = args.credentialed;
-        lp_position.queue_status = LP_QUEUE_STATUS_NONE;
-        lp_position.bump = if lp_position.bump == 0 {
-            ctx.bumps.lp_position
-        } else {
-            lp_position.bump
-        };
+        ensure_lp_position_binding(lp_position, capital_class_key, owner, ctx.bumps.lp_position)?;
+        require_class_access_mode(restriction_mode, lp_position.credentialed)?;
+        apply_lp_position_deposit(lp_position, amount, shares, min_lockup_seconds, now_ts)?;
 
         let capital_class = &mut ctx.accounts.capital_class;
         capital_class.total_shares = checked_add(capital_class.total_shares, shares)?;
@@ -2128,6 +2150,28 @@ pub struct UpdateCapitalClassControls<'info> {
 }
 
 #[derive(Accounts)]
+#[instruction(args: UpdateLpPositionCredentialingArgs)]
+pub struct UpdateLpPositionCredentialing<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Account<'info, ProtocolGovernance>,
+    #[account(seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()], bump = liquidity_pool.bump)]
+    pub liquidity_pool: Account<'info, LiquidityPool>,
+    #[account(seeds = [SEED_CAPITAL_CLASS, liquidity_pool.key().as_ref(), capital_class.class_id.as_bytes()], bump = capital_class.bump)]
+    pub capital_class: Account<'info, CapitalClass>,
+    #[account(
+        init_if_needed,
+        payer = authority,
+        space = 8 + LPPosition::INIT_SPACE,
+        seeds = [SEED_LP_POSITION, capital_class.key().as_ref(), args.owner.as_ref()],
+        bump
+    )]
+    pub lp_position: Account<'info, LPPosition>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 pub struct DepositIntoCapitalClass<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
@@ -2934,10 +2978,16 @@ pub struct UpdateCapitalClassControlsArgs {
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct UpdateLpPositionCredentialingArgs {
+    pub owner: Pubkey,
+    pub credentialed: bool,
+    pub reason_hash: [u8; 32],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct DepositIntoCapitalClassArgs {
     pub amount: u64,
     pub shares: u64,
-    pub credentialed: bool,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
@@ -3051,6 +3101,15 @@ pub struct CapitalClassDepositEvent {
     pub owner: Pubkey,
     pub asset_amount: u64,
     pub shares: u64,
+}
+
+#[event]
+pub struct LPPositionCredentialingUpdatedEvent {
+    pub capital_class: Pubkey,
+    pub owner: Pubkey,
+    pub authority: Pubkey,
+    pub credentialed: bool,
+    pub reason_hash: [u8; 32],
 }
 
 #[event]
@@ -3173,6 +3232,8 @@ pub enum OmegaXProtocolError {
     AmountExceedsPendingRedemption,
     #[msg("Restricted capital class access failed")]
     RestrictedCapitalClass,
+    #[msg("LP position with active capital cannot be decredentialed")]
+    LPPositionHasActiveCapital,
     #[msg("Capital class lockup is still active")]
     LockupActive,
     #[msg("Allocation cap exceeded")]
@@ -3258,6 +3319,18 @@ fn require_pool_control(
     }
 }
 
+fn require_curator_control(
+    authority: &Pubkey,
+    governance: &ProtocolGovernance,
+    pool: &LiquidityPool,
+) -> Result<()> {
+    if *authority == pool.curator || *authority == governance.governance_authority {
+        Ok(())
+    } else {
+        err!(OmegaXProtocolError::Unauthorized)
+    }
+}
+
 fn require_allocator(
     authority: &Pubkey,
     governance: &ProtocolGovernance,
@@ -3274,7 +3347,11 @@ fn require_allocator(
 }
 
 fn require_class_access(capital_class: &CapitalClass, credentialed: bool) -> Result<()> {
-    match capital_class.restriction_mode {
+    require_class_access_mode(capital_class.restriction_mode, credentialed)
+}
+
+fn require_class_access_mode(restriction_mode: u8, credentialed: bool) -> Result<()> {
+    match restriction_mode {
         CAPITAL_CLASS_RESTRICTION_OPEN => Ok(()),
         CAPITAL_CLASS_RESTRICTION_RESTRICTED | CAPITAL_CLASS_RESTRICTION_WRAPPER_ONLY => {
             require!(credentialed, OmegaXProtocolError::RestrictedCapitalClass);
@@ -3282,6 +3359,71 @@ fn require_class_access(capital_class: &CapitalClass, credentialed: bool) -> Res
         }
         _ => err!(OmegaXProtocolError::RestrictedCapitalClass),
     }
+}
+
+fn ensure_lp_position_binding(
+    lp_position: &mut LPPosition,
+    capital_class: Pubkey,
+    owner: Pubkey,
+    bump: u8,
+) -> Result<()> {
+    if lp_position.owner == ZERO_PUBKEY && lp_position.capital_class == ZERO_PUBKEY {
+        lp_position.capital_class = capital_class;
+        lp_position.owner = owner;
+        lp_position.shares = 0;
+        lp_position.subscription_basis = 0;
+        lp_position.pending_redemption_shares = 0;
+        lp_position.realized_distributions = 0;
+        lp_position.impaired_principal = 0;
+        lp_position.lockup_ends_at = 0;
+        lp_position.credentialed = false;
+        lp_position.queue_status = LP_QUEUE_STATUS_NONE;
+        lp_position.bump = bump;
+        return Ok(());
+    }
+
+    require_keys_eq!(
+        lp_position.capital_class,
+        capital_class,
+        OmegaXProtocolError::Unauthorized
+    );
+    require_keys_eq!(lp_position.owner, owner, OmegaXProtocolError::Unauthorized);
+
+    if lp_position.bump == 0 {
+        lp_position.bump = bump;
+    }
+
+    Ok(())
+}
+
+fn update_lp_position_credentialing_state(
+    lp_position: &mut LPPosition,
+    credentialed: bool,
+) -> Result<()> {
+    if !credentialed {
+        require!(
+            lp_position.shares == 0 && lp_position.pending_redemption_shares == 0,
+            OmegaXProtocolError::LPPositionHasActiveCapital
+        );
+    }
+
+    lp_position.credentialed = credentialed;
+    Ok(())
+}
+
+fn apply_lp_position_deposit(
+    lp_position: &mut LPPosition,
+    amount: u64,
+    shares: u64,
+    min_lockup_seconds: i64,
+    now_ts: i64,
+) -> Result<()> {
+    lp_position.shares = checked_add(lp_position.shares, shares)?;
+    lp_position.subscription_basis = checked_add(lp_position.subscription_basis, amount)?;
+    lp_position.lockup_ends_at = now_ts
+        .checked_add(min_lockup_seconds)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?;
+    Ok(())
 }
 
 fn checked_add(lhs: u64, rhs: u64) -> Result<u64> {
@@ -3644,6 +3786,90 @@ fn book_settlement_from_delivery(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn class_access_requires_credential_for_restricted_modes() {
+        assert!(require_class_access_mode(CAPITAL_CLASS_RESTRICTION_OPEN, false).is_ok());
+        assert!(require_class_access_mode(CAPITAL_CLASS_RESTRICTION_RESTRICTED, false).is_err());
+        assert!(require_class_access_mode(CAPITAL_CLASS_RESTRICTION_RESTRICTED, true).is_ok());
+        assert!(require_class_access_mode(CAPITAL_CLASS_RESTRICTION_WRAPPER_ONLY, false).is_err());
+        assert!(require_class_access_mode(CAPITAL_CLASS_RESTRICTION_WRAPPER_ONLY, true).is_ok());
+    }
+
+    #[test]
+    fn lp_credentialing_cannot_revoke_active_position() {
+        let mut lp_position = LPPosition {
+            capital_class: Pubkey::new_unique(),
+            owner: Pubkey::new_unique(),
+            shares: 10,
+            subscription_basis: 10,
+            pending_redemption_shares: 1,
+            realized_distributions: 0,
+            impaired_principal: 0,
+            lockup_ends_at: 0,
+            credentialed: true,
+            queue_status: LP_QUEUE_STATUS_PENDING,
+            bump: 7,
+        };
+
+        assert!(update_lp_position_credentialing_state(&mut lp_position, false).is_err());
+        assert!(lp_position.credentialed);
+    }
+
+    #[test]
+    fn lp_position_binding_initializes_fresh_position() {
+        let mut lp_position = LPPosition {
+            capital_class: ZERO_PUBKEY,
+            owner: ZERO_PUBKEY,
+            shares: 0,
+            subscription_basis: 0,
+            pending_redemption_shares: 0,
+            realized_distributions: 0,
+            impaired_principal: 0,
+            lockup_ends_at: 0,
+            credentialed: false,
+            queue_status: 0,
+            bump: 0,
+        };
+        let capital_class = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        ensure_lp_position_binding(&mut lp_position, capital_class, owner, 9).unwrap();
+
+        assert_eq!(lp_position.capital_class, capital_class);
+        assert_eq!(lp_position.owner, owner);
+        assert_eq!(lp_position.queue_status, LP_QUEUE_STATUS_NONE);
+        assert_eq!(lp_position.bump, 9);
+        assert!(!lp_position.credentialed);
+    }
+
+    #[test]
+    fn lp_deposit_top_up_preserves_existing_state() {
+        let mut lp_position = LPPosition {
+            capital_class: Pubkey::new_unique(),
+            owner: Pubkey::new_unique(),
+            shares: 100,
+            subscription_basis: 90,
+            pending_redemption_shares: 12,
+            realized_distributions: 7,
+            impaired_principal: 3,
+            lockup_ends_at: 50,
+            credentialed: true,
+            queue_status: LP_QUEUE_STATUS_PENDING,
+            bump: 4,
+        };
+
+        apply_lp_position_deposit(&mut lp_position, 25, 30, 120, 1_000).unwrap();
+
+        assert_eq!(lp_position.shares, 130);
+        assert_eq!(lp_position.subscription_basis, 115);
+        assert_eq!(lp_position.pending_redemption_shares, 12);
+        assert_eq!(lp_position.realized_distributions, 7);
+        assert_eq!(lp_position.impaired_principal, 3);
+        assert_eq!(lp_position.queue_status, LP_QUEUE_STATUS_PENDING);
+        assert!(lp_position.credentialed);
+        assert_eq!(lp_position.lockup_ends_at, 1_120);
+    }
 
     #[test]
     fn balance_sheet_recompute_preserves_free_and_redeemable() {

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -6853,6 +6853,188 @@
       ]
     },
     {
+      "name": "update_lp_position_credentialing",
+      "discriminator": [
+        54,
+        194,
+        211,
+        94,
+        197,
+        61,
+        228,
+        202
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "UpdateLpPositionCredentialingArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "capital_class",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  112,
+                  105,
+                  116,
+                  97,
+                  108,
+                  95,
+                  99,
+                  108,
+                  97,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "capital_class.class_id",
+                "account": "CapitalClass"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lp_position",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  112,
+                  95,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "capital_class"
+              },
+              {
+                "kind": "arg",
+                "path": "args.owner"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
       "name": "update_member_eligibility",
       "discriminator": [
         254,

--- a/tests/governance_workbench_helpers.test.ts
+++ b/tests/governance_workbench_helpers.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import workbenchModule from "../frontend/lib/workbench.ts";
+
+const {
+  canonicalizeGovernanceWorkbenchParams,
+  governanceStatusVariant,
+  resolveGovernanceProposalSelection,
+} = workbenchModule as typeof import("../frontend/lib/workbench.ts");
+
+const queue = [
+  {
+    proposal: "proposal-1",
+    title: "Proposal One",
+    template: "Template A",
+    authority: "Authority A",
+    status: "Voting",
+    stage: "Review",
+  },
+  {
+    proposal: "proposal-2",
+    title: "Proposal Two",
+    template: "Template B",
+    authority: "Authority B",
+    status: "Executing with errors",
+    stage: "Execution",
+  },
+];
+
+test("governance proposal selection stays canonical across non-queue tabs", () => {
+  const selectedProposal = resolveGovernanceProposalSelection(queue, "proposal-2");
+  assert.equal(selectedProposal?.proposal, "proposal-2");
+
+  for (const activeTab of ["authorities", "templates"] as const) {
+    const nextUpdates = canonicalizeGovernanceWorkbenchParams({
+      activeTab,
+      loaded: true,
+      queryProposal: "proposal-2",
+      requestedTab: "overview",
+      selectedProposal,
+    });
+
+    assert.deepEqual(nextUpdates, { tab: activeTab });
+  }
+});
+
+test("invalid governance proposal query canonicalizes to the resolved live proposal", () => {
+  const selectedProposal = resolveGovernanceProposalSelection(queue, "bogus-proposal");
+  assert.equal(selectedProposal?.proposal, "proposal-1");
+
+  const nextUpdates = canonicalizeGovernanceWorkbenchParams({
+    activeTab: "authorities",
+    loaded: true,
+    queryProposal: "bogus-proposal",
+    requestedTab: "authorities",
+    selectedProposal,
+  });
+
+  assert.deepEqual(nextUpdates, { proposal: "proposal-1" });
+});
+
+test("empty loaded governance queues clear stale proposal params", () => {
+  const selectedProposal = resolveGovernanceProposalSelection([], "bogus-proposal");
+  assert.equal(selectedProposal, null);
+
+  const nextUpdates = canonicalizeGovernanceWorkbenchParams({
+    activeTab: "queue",
+    loaded: true,
+    queryProposal: "bogus-proposal",
+    requestedTab: "queue",
+    selectedProposal,
+  });
+
+  assert.deepEqual(nextUpdates, { proposal: null });
+});
+
+test("loading governance queues keep the proposal param until the queue resolves", () => {
+  const nextUpdates = canonicalizeGovernanceWorkbenchParams({
+    activeTab: "queue",
+    loaded: false,
+    queryProposal: "proposal-2",
+    requestedTab: "queue",
+    selectedProposal: null,
+  });
+
+  assert.deepEqual(nextUpdates, {});
+});
+
+test("governance status variants classify execution errors as danger", () => {
+  assert.equal(governanceStatusVariant("Executing with errors"), "danger");
+  assert.equal(governanceStatusVariant("Executing"), "info");
+});

--- a/tests/protocol_contract.test.ts
+++ b/tests/protocol_contract.test.ts
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import contractModule from "../frontend/lib/generated/protocol-contract.ts";
 
 const {
+  PROTOCOL_INSTRUCTION_ARGS,
   PROTOCOL_ACCOUNT_DISCRIMINATORS,
   PROTOCOL_INSTRUCTION_ACCOUNTS,
   PROTOCOL_INSTRUCTION_DISCRIMINATORS,
@@ -13,6 +15,11 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   const instructionNames = Object.keys(PROTOCOL_INSTRUCTION_DISCRIMINATORS);
   const accountNames = Object.keys(PROTOCOL_ACCOUNT_DISCRIMINATORS);
   const serializedAccounts = JSON.stringify(PROTOCOL_INSTRUCTION_ACCOUNTS);
+  const idl = JSON.parse(readFileSync(new URL("../idl/omegax_protocol.json", import.meta.url), "utf8")) as {
+    instructions: Array<{ name: string }>;
+    types: Array<{ name: string; type: { kind: string; fields?: Array<{ name: string }> } }>;
+  };
+  const depositArgs = idl.types.find((entry) => entry.name === "DepositIntoCapitalClassArgs");
 
   assert(instructionNames.includes("create_reserve_domain"));
   assert(instructionNames.includes("create_health_plan"));
@@ -20,6 +27,7 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert(instructionNames.includes("open_funding_line"));
   assert(instructionNames.includes("create_liquidity_pool"));
   assert(instructionNames.includes("create_capital_class"));
+  assert(instructionNames.includes("update_lp_position_credentialing"));
   assert(instructionNames.includes("create_allocation_position"));
   assert(instructionNames.includes("mark_impairment"));
 
@@ -35,4 +43,11 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert(!instructionNames.includes("create_pool"));
   assert(!instructionNames.includes("set_pool_status"));
   assert(!serializedAccounts.includes("pool_type"));
+  assert(PROTOCOL_INSTRUCTION_ARGS.deposit_into_capital_class.length === 1);
+  assert(idl.instructions.some((instruction) => instruction.name === "update_lp_position_credentialing"));
+  assert.equal(depositArgs?.type.kind, "struct");
+  assert.deepEqual(
+    depositArgs?.type.fields?.map((field) => field.name),
+    ["amount", "shares"],
+  );
 });


### PR DESCRIPTION
### Motivation
- Close the authorization bypass where `deposit_into_capital_class` trusted a caller-supplied credential flag for restricted or wrapper-only capital classes.
- Preserve legitimate restricted-class behavior by moving credentialing to managed on-chain LP state instead of forcing all direct deposits to become uncredentialed.
- Publish the queued local governance workbench improvements that were explicitly bundled into this branch update.

### Description
- Add `update_lp_position_credentialing` so pool curators or protocol governance can grant or revoke LP access for restricted classes.
- Remove the caller-supplied `credentialed` field from `DepositIntoCapitalClassArgs` and make deposits read the canonical `LPPosition` credential state instead.
- Treat capital deposits as top-ups that preserve existing LP position state while refreshing the lockup timestamp.
- Reject credential revocation for LP positions that still hold active or pending capital so existing holders are not stranded behind redemption checks.
- Regenerate the checked-in IDL and protocol contract artifacts and update the public instruction map, protocol README, and release audit manifest.
- Include the pending governance workbench URL-canonicalization helpers, regression tests, and mobile layout tweak from the local checkout.

### Testing
- `cargo test -q`
- `npm run anchor:idl`
- `npm run protocol:contract`
- `npm run test:node`
- `npm run verify:public`
- `npm run test:e2e:localnet`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d13ae47d04832f8222a0ddaa3b0f82)