### PR TITLE
fix(protocol): require pool-approved oracle permissions for claim attestations

### DIFF
--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -3577,6 +3577,9 @@ export function buildAttachClaimEvidenceRefTx(params: {
 export function buildAttestClaimCaseTx(params: {
   oracle: PublicKeyish;
   claimCaseAddress: PublicKeyish;
+  healthPlanAddress: PublicKeyish;
+  obligationAddress: PublicKeyish;
+  liquidityPoolAddress: PublicKeyish;
   recentBlockhash: string;
   decision: number;
   attestationHashHex: string;
@@ -3593,6 +3596,14 @@ export function buildAttestClaimCaseTx(params: {
   });
   const outcomeSchema = deriveOutcomeSchemaPda({
     schemaKeyHashHex: normalizedSchemaKeyHashHex,
+  });
+  const poolOracleApproval = derivePoolOracleApprovalPda({
+    liquidityPool: params.liquidityPoolAddress,
+    oracle,
+  });
+  const poolOraclePermissionSet = derivePoolOraclePermissionSetPda({
+    liquidityPool: params.liquidityPoolAddress,
+    oracle,
   });
   return buildProtocolTransactionFromInstruction({
     feePayer: oracle,
@@ -3612,6 +3623,11 @@ export function buildAttestClaimCaseTx(params: {
       { pubkey: oracle, isSigner: true, isWritable: true },
       { pubkey: oracleProfile },
       { pubkey: params.claimCaseAddress },
+      { pubkey: params.healthPlanAddress },
+      { pubkey: params.obligationAddress },
+      { pubkey: params.liquidityPoolAddress },
+      { pubkey: poolOracleApproval },
+      { pubkey: poolOraclePermissionSet },
       { pubkey: outcomeSchema },
       { pubkey: claimAttestation, isWritable: true },
       { pubkey: SystemProgram.programId },

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -95,6 +95,7 @@ pub const CLAIM_ATTESTATION_DECISION_SUPPORT_APPROVE: u8 = 0;
 pub const CLAIM_ATTESTATION_DECISION_SUPPORT_DENY: u8 = 1;
 pub const CLAIM_ATTESTATION_DECISION_REQUEST_REVIEW: u8 = 2;
 pub const CLAIM_ATTESTATION_DECISION_ABSTAIN: u8 = 3;
+pub const POOL_ORACLE_PERMISSION_ATTEST_CLAIM_CASE: u32 = 1 << 0;
 
 pub const OBLIGATION_STATUS_PROPOSED: u8 = 0;
 pub const OBLIGATION_STATUS_RESERVED: u8 = 1;
@@ -2535,6 +2536,38 @@ pub struct AttestClaimCase<'info> {
         bump = claim_case.bump,
     )]
     pub claim_case: Box<Account<'info, ClaimCase>>,
+    #[account(
+        seeds = [SEED_HEALTH_PLAN, health_plan.reserve_domain.as_ref(), health_plan.health_plan_id.as_bytes()],
+        bump = health_plan.bump,
+        constraint = health_plan.key() == claim_case.health_plan @ OmegaXProtocolError::HealthPlanMismatch,
+    )]
+    pub health_plan: Box<Account<'info, HealthPlan>>,
+    #[account(
+        seeds = [SEED_OBLIGATION, obligation.health_plan.as_ref(), obligation.obligation_id.as_bytes()],
+        bump = obligation.bump,
+        constraint = claim_case.linked_obligation != ZERO_PUBKEY @ OmegaXProtocolError::Unauthorized,
+        constraint = obligation.key() == claim_case.linked_obligation @ OmegaXProtocolError::Unauthorized,
+        constraint = obligation.health_plan == claim_case.health_plan @ OmegaXProtocolError::HealthPlanMismatch,
+    )]
+    pub obligation: Box<Account<'info, Obligation>>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+        constraint = obligation.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::Unauthorized,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        seeds = [SEED_POOL_ORACLE_APPROVAL, liquidity_pool.key().as_ref(), oracle_profile.oracle.as_ref()],
+        bump = pool_oracle_approval.bump,
+        constraint = pool_oracle_approval.active @ OmegaXProtocolError::PoolOracleApprovalRequired,
+    )]
+    pub pool_oracle_approval: Box<Account<'info, PoolOracleApproval>>,
+    #[account(
+        seeds = [SEED_POOL_ORACLE_PERMISSION_SET, liquidity_pool.key().as_ref(), oracle_profile.oracle.as_ref()],
+        bump = pool_oracle_permission_set.bump,
+        constraint = pool_oracle_permission_set.permissions & POOL_ORACLE_PERMISSION_ATTEST_CLAIM_CASE != 0 @ OmegaXProtocolError::Unauthorized,
+    )]
+    pub pool_oracle_permission_set: Box<Account<'info, PoolOraclePermissionSet>>,
     #[account(
         seeds = [SEED_OUTCOME_SCHEMA, args.schema_key_hash.as_ref()],
         bump = outcome_schema.bump,

--- a/tests/protocol_pdas.test.ts
+++ b/tests/protocol_pdas.test.ts
@@ -104,6 +104,9 @@ test("claim attestation builders reject unsupported decisions before chain submi
       buildAttestClaimCaseTx({
         oracle: DEFAULT_HEALTH_PLAN_ADDRESS,
         claimCaseAddress: DEVNET_PROTOCOL_FIXTURE_STATE.claimCases[0]!.address,
+        healthPlanAddress: DEFAULT_HEALTH_PLAN_ADDRESS,
+        obligationAddress: DEVNET_PROTOCOL_FIXTURE_STATE.obligations[0]!.address,
+        liquidityPoolAddress: DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!.address,
         recentBlockhash: "11111111111111111111111111111111",
         decision: 99,
         attestationHashHex: "11".repeat(32),


### PR DESCRIPTION
### Motivation
- The `attest_claim_case` instruction allowed any claimed oracle profile to write attestations without verifying pool/plan approval or pool-oracle permissions, enabling unapproved oracles to pollute attestation records.
- The intent of this change is to enforce existing pool-level oracle approval and permissioning so only authorized oracles can attest claim cases linked to a funded obligation and its pool.

### Description
- Added a scoped permission bit constant `POOL_ORACLE_PERMISSION_ATTEST_CLAIM_CASE` to make attestation permissions auditable and extensible in `programs/omegax_protocol/src/lib.rs`.
- Hardened `AttestClaimCase` account context to require the `HealthPlan`, a `linked Obligation`, the `LiquidityPool` backing that obligation, an active `PoolOracleApproval`, and a `PoolOraclePermissionSet` entry that includes the attestation permission bit.
- Kept the runtime behavior of `attest_claim_case` (decision and schema checks) but added account-level constraints so unauthorized oracles will fail before writing attestations.
- Updated the public TypeScript builder `buildAttestClaimCaseTx` to accept and pass the new accounts (`healthPlanAddress`, `obligationAddress`, `liquidityPoolAddress`, pool oracle approval PDA, and pool oracle permission PDA), and updated a PDAs test callsite to provide the new parameters.

### Testing
- Ran `npm run test:node` and all existing Node tests passed (`52` tests, `0` failures). ✅
- Built the Rust program with `cargo build -p omegax_protocol` and the build completed successfully (warnings only). ✅
- Re-generated frontend/contract artifacts with `npm run protocol:contract` and it wrote updated files under `shared/` and `frontend/lib/generated/`. ✅
- Attempted `npm run anchor:idl` but it failed in this environment because the `anchor` binary is not installed (`spawn anchor ENOENT`), so IDL regeneration could not be validated here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9bc88e0c832f87fe611f76594999)