### PR TITLE
Add per-route error boundaries and brand-aligned toast infra

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "frontend",
       "runtimeExecutable": "npx",
-      "runtimeArgs": ["next", "dev"],
+      "runtimeArgs": ["next", "dev", "--webpack"],
       "port": 3847,
       "autoPort": true,
       "cwd": "frontend"

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { useEffect } from "react";
+
+type ErrorBoundaryProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function RouteError({ error, reset }: ErrorBoundaryProps) {
+  useEffect(() => {
+    if (typeof console !== "undefined") {
+      console.error("[omegax-protocol] route error", {
+        message: error.message,
+        digest: error.digest,
+      });
+    }
+  }, [error]);
+
+  return (
+    <div
+      className="workbench-panel workbench-primary-surface"
+      role="alert"
+      aria-live="polite"
+      style={{ maxWidth: "36rem" }}
+    >
+      <div className="workbench-panel-head">
+        <div>
+          <h1 className="workbench-panel-title">This panel hit an unexpected error.</h1>
+        </div>
+      </div>
+      <p style={{ margin: 0, color: "var(--muted-foreground)", fontSize: "0.875rem" }}>
+        Try this section again. If the issue persists, reload the page or check the network
+        health view to confirm the configured RPC endpoint is reachable.
+      </p>
+      {error.digest ? (
+        <p
+          style={{
+            margin: 0,
+            color: "var(--muted-foreground)",
+            fontSize: "0.75rem",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          Reference: {error.digest}
+        </p>
+      ) : null}
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+        <button
+          type="button"
+          onClick={reset}
+          className="wallet-control-button wallet-control-button-connected"
+        >
+          Try this section again
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (typeof window !== "undefined") {
+              window.location.reload();
+            }
+          }}
+          className="wallet-control-button"
+        >
+          Reload page
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    if (typeof console !== "undefined") {
+      console.error("[omegax-protocol] root error", {
+        message: error.message,
+        digest: error.digest,
+      });
+    }
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0a1525",
+          color: "#f0f1f2",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          padding: "1.5rem",
+        }}
+      >
+        <div
+          role="alert"
+          aria-live="assertive"
+          style={{
+            maxWidth: "32rem",
+            background: "rgba(12, 22, 38, 0.92)",
+            border: "1px solid rgba(0, 229, 255, 0.24)",
+            borderRadius: "1rem",
+            padding: "1.75rem",
+            boxShadow: "0 28px 64px rgba(0, 0, 0, 0.38)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "1rem",
+          }}
+        >
+          <h1 style={{ margin: 0, fontSize: "1.25rem", fontWeight: 600 }}>
+            The console hit an unexpected error.
+          </h1>
+          <p style={{ margin: 0, color: "#94a3b8", fontSize: "0.875rem", lineHeight: 1.5 }}>
+            Reload to recover. If the issue persists, the configured RPC endpoint may be
+            unreachable.
+          </p>
+          {error.digest ? (
+            <p
+              style={{
+                margin: 0,
+                color: "#94a3b8",
+                fontSize: "0.75rem",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              }}
+            >
+              Reference: {error.digest}
+            </p>
+          ) : null}
+          <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "0.5rem",
+                border: "1px solid rgba(0, 229, 255, 0.4)",
+                background: "rgba(0, 229, 255, 0.14)",
+                color: "#00e5ff",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (typeof window !== "undefined") {
+                  window.location.reload();
+                }
+              }}
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "0.5rem",
+                border: "1px solid rgba(148, 163, 184, 0.24)",
+                background: "transparent",
+                color: "#f0f1f2",
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/components/app-providers.tsx
+++ b/frontend/components/app-providers.tsx
@@ -4,6 +4,7 @@
 
 import type { ReactNode } from "react";
 
+import { BrandedToaster } from "@/components/branded-toaster";
 import { WalletProviders } from "@/components/wallet-providers";
 import { NetworkProvider } from "@/components/network-context";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -14,7 +15,10 @@ export default function AppProviders({ children }: { children: ReactNode }) {
     <ThemeProvider>
       <NetworkProvider>
         <WalletProviders>
-          <WorkspacePersonaProvider>{children}</WorkspacePersonaProvider>
+          <WorkspacePersonaProvider>
+            {children}
+            <BrandedToaster />
+          </WorkspacePersonaProvider>
         </WalletProviders>
       </NetworkProvider>
     </ThemeProvider>

--- a/frontend/components/branded-toaster.tsx
+++ b/frontend/components/branded-toaster.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { Toaster } from "sonner";
+
+import { useTheme } from "@/components/theme-provider";
+
+export function BrandedToaster() {
+  const { theme, mounted } = useTheme();
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Toaster
+      theme={theme}
+      position="bottom-right"
+      closeButton
+      richColors={false}
+      toastOptions={{
+        style: {
+          background: "var(--panel-heavy)",
+          color: "var(--foreground)",
+          border: "1px solid var(--border-strong)",
+          boxShadow: "var(--panel-shadow)",
+          fontFamily: "var(--font-sans)",
+        },
+        classNames: {
+          toast: "omegax-toast",
+          title: "omegax-toast-title",
+          description: "omegax-toast-description",
+          actionButton: "omegax-toast-action",
+          cancelButton: "omegax-toast-cancel",
+          closeButton: "omegax-toast-close",
+        },
+      }}
+    />
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "ogl": "^1.0.11",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tweetnacl": "^1.0.3"
       },
@@ -7053,7 +7054,6 @@
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7802,6 +7802,16 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "ogl": "^1.0.11",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tweetnacl": "^1.0.3"
   },


### PR DESCRIPTION
## Summary
- Adds Next App Router `error.tsx` + `global-error.tsx` so a route segment crash shows a brand-aligned recovery panel (heading, recovery copy, opaque digest reference, reset + reload affordances) instead of leaving the workbench blank.
- Adds sonner as the toast library and mounts a theme-aware `BrandedToaster` in the provider chain — foundation that OX-PROTO-ROAST-006 (post-sign tx lifecycle), OX-PROTO-ROAST-007 (money/USD), and async wallet/RPC events will hang off.
- Updates `.claude/launch.json` to pass `--webpack` so the preview launch config matches the project's webpack-only `next.config.mjs`.

Refs **OX-PROTO-ROAST-009**. Foundation-only scope per the agreed PR plan; route-level coverage and toast wiring for transaction lifecycle land in follow-ups.

## Test plan
- [x] `npm --prefix frontend run build` — green, no TS or compile errors
- [x] Deliberate throw in `/network-health` routes the user to the recovery panel with `Reference: <digest>` and both `Try this section again` + `Reload page` buttons present
- [x] Reverting the throw restores normal `/network-health` render
- [x] Console logs confirm `[omegax-protocol] route error` fires from the boundary's `useEffect`
- [x] Sonner Toaster region (`section[aria-label="Notifications alt+T"]`) mounts on every route
- [x] Theme-aware: `BrandedToaster` syncs with `useTheme()` hook; `mounted` guard prevents SSR mismatch
- [ ] Reviewer: pull the branch, run `npm --prefix frontend run dev`, navigate to any workbench route, and confirm no regressions on the existing flows
- [ ] Reviewer: optionally add a temporary `throw` in any page to verify the boundary on a different route

## Out of scope (follow-up PRs)
- Per-route segment error boundaries with route-specific copy (e.g., capital workbench, governance, plans) — current foundation provides default coverage; refinements come later
- Wiring sonner into `executeProtocolTransaction()` for the post-sign lifecycle (handled in OX-PROTO-ROAST-006)
- Replacing inline `walletStatus`/`settingsStatus` strings with toasts
- Human-error map for known program error codes (`0x1771`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)