### PR TITLE
Wire post-sign transaction toast lifecycle (governance proof)

### DIFF
--- a/frontend/components/governance-operator-drawer.tsx
+++ b/frontend/components/governance-operator-drawer.tsx
@@ -7,7 +7,7 @@ import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import type { Transaction } from "@solana/web3.js";
 
 import { WizardDetailSheet } from "@/components/wizard-detail-sheet";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildCreateDomainAssetVaultTx,
   buildCreateReserveDomainTx,
@@ -144,13 +144,23 @@ export function GovernanceOperatorDrawer(props: GovernanceOperatorDrawerProps) {
     setStatus(null);
     try {
       const tx = await factory();
-      const result = await executeProtocolTransaction({ connection, sendTransaction, tx, label });
+      const result = await executeProtocolTransactionWithToast({
+        connection,
+        sendTransaction,
+        tx,
+        label,
+        onConfirmed: async () => {
+          await props.onRefresh?.();
+        },
+        onRetry: () => {
+          void run(label, factory);
+        },
+      });
       if (!result.ok) {
         setStatus({ tone: "error", message: result.error });
         return;
       }
       setStatus({ tone: "ok", message: result.message, explorerUrl: result.explorerUrl });
-      await props.onRefresh?.();
     } catch (err) {
       setStatus({
         tone: "error",

--- a/frontend/lib/protocol-action-toast.ts
+++ b/frontend/lib/protocol-action-toast.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { WalletContextState } from "@solana/wallet-adapter-react";
+import type { Connection, Signer, Transaction } from "@solana/web3.js";
+import { toast } from "sonner";
+
+import {
+  executeProtocolTransaction,
+  type ProtocolActionResult,
+  type ProtocolActionSuccess,
+  type ProtocolTransactionReviewMetadata,
+} from "@/lib/protocol-action";
+import { humanizeProtocolError } from "@/lib/protocol-error-map";
+
+/**
+ * Wrap `executeProtocolTransaction` with the post-sign transaction lifecycle:
+ *
+ *   submitting (loading)
+ *     → submitted   (loading, with truncated signature + explorer link)
+ *       → confirmed (success)  +  optional snapshot refetch via `onConfirmed`
+ *       → failed    (error, with humanized cause + optional retry action)
+ *
+ * Caller-supplied `onConfirmed` should trigger snapshot refetch — the
+ * wrapper does NOT introspect application state. The pure helper
+ * `executeProtocolTransaction` remains side-effect free and is still
+ * the right primitive for non-UI call sites (tests, server-side flows).
+ */
+
+const TOAST_LOADING_DURATION_MS = 30_000;
+const TOAST_SUCCESS_DURATION_MS = 8_000;
+const TOAST_ERROR_DURATION_MS = 12_000;
+
+export type ProtocolActionToastParams = {
+  connection: Connection;
+  sendTransaction: WalletContextState["sendTransaction"];
+  tx: Transaction;
+  label: string;
+  signers?: Signer[];
+  explorerCluster?: string | null;
+  review?: ProtocolTransactionReviewMetadata;
+  onConfirmed?: (result: ProtocolActionSuccess) => void | Promise<void>;
+  onRetry?: () => void | Promise<void>;
+};
+
+export async function executeProtocolTransactionWithToast(
+  params: ProtocolActionToastParams,
+): Promise<ProtocolActionResult> {
+  const toastId = toast.loading(`Submitting ${params.label}…`, {
+    description: "Building blockhash and simulating the transaction.",
+    duration: TOAST_LOADING_DURATION_MS,
+  });
+
+  try {
+    const result = await executeProtocolTransaction({
+      connection: params.connection,
+      sendTransaction: params.sendTransaction,
+      tx: params.tx,
+      label: params.label,
+      signers: params.signers,
+      explorerCluster: params.explorerCluster ?? null,
+      review: params.review,
+      onLifecycle: (event) => {
+        if (event.phase !== "submitted") return;
+        toast.loading(`${params.label} submitted`, {
+          id: toastId,
+          description: `Awaiting confirmation · ${shortSignature(event.signature)}`,
+          duration: TOAST_LOADING_DURATION_MS,
+        });
+      },
+    });
+
+    if (result.ok) {
+      toast.success(`${params.label} confirmed`, {
+        id: toastId,
+        description: shortSignature(result.signature),
+        action: {
+          label: "View",
+          onClick: () => openExplorer(result.explorerUrl),
+        },
+        duration: TOAST_SUCCESS_DURATION_MS,
+      });
+
+      if (params.onConfirmed) {
+        try {
+          await params.onConfirmed(result);
+        } catch {
+          // Snapshot refetch failures are surfaced through their own paths;
+          // never let them mask the confirmed-tx success state.
+        }
+      }
+
+      return result;
+    }
+
+    const humanized = humanizeProtocolError(result.error);
+    const retryAction = params.onRetry
+      ? {
+          label: "Retry",
+          onClick: () => {
+            void params.onRetry?.();
+          },
+        }
+      : undefined;
+
+    toast.error(`${params.label} failed`, {
+      id: toastId,
+      description: humanized.hint ? `${humanized.message} ${humanized.hint}` : humanized.message,
+      action: retryAction,
+      duration: TOAST_ERROR_DURATION_MS,
+    });
+
+    return result;
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : `${params.label} failed.`;
+    const humanized = humanizeProtocolError(message);
+    toast.error(`${params.label} failed`, {
+      id: toastId,
+      description: humanized.hint ? `${humanized.message} ${humanized.hint}` : humanized.message,
+      duration: TOAST_ERROR_DURATION_MS,
+    });
+    return { ok: false, error: message };
+  }
+}
+
+function shortSignature(signature: string): string {
+  if (signature.length <= 16) return signature;
+  return `${signature.slice(0, 8)}…${signature.slice(-8)}`;
+}
+
+function openExplorer(url: string | null): void {
+  if (!url) return;
+  if (typeof window === "undefined") return;
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/frontend/lib/protocol-action.ts
+++ b/frontend/lib/protocol-action.ts
@@ -48,6 +48,13 @@ export type ProtocolActionFailure = {
 
 export type ProtocolActionResult = ProtocolActionSuccess | ProtocolActionFailure;
 
+export type ProtocolTransactionLifecycleEvent = {
+  phase: "submitted";
+  signature: string;
+  explorerUrl: string;
+  label: string;
+};
+
 export async function executeProtocolTransaction(params: {
   connection: Connection;
   sendTransaction: WalletContextState["sendTransaction"];
@@ -56,6 +63,7 @@ export async function executeProtocolTransaction(params: {
   signers?: Signer[];
   explorerCluster?: string | null;
   review?: ProtocolTransactionReviewMetadata;
+  onLifecycle?: (event: ProtocolTransactionLifecycleEvent) => void;
 }): Promise<ProtocolActionResult> {
   let review: ProtocolTransactionReview | undefined;
   try {
@@ -80,6 +88,14 @@ export async function executeProtocolTransaction(params: {
       params.connection,
       params.signers?.length ? { signers: params.signers } : undefined,
     );
+    const explorerUrl = toExplorerLink(signature, params.explorerCluster ?? undefined);
+    if (params.onLifecycle) {
+      try {
+        params.onLifecycle({ phase: "submitted", signature, explorerUrl, label: params.label });
+      } catch {
+        // Lifecycle callbacks must never break the send/confirm path.
+      }
+    }
     const confirmation = await params.connection.confirmTransaction(
       {
         signature,
@@ -94,11 +110,11 @@ export async function executeProtocolTransaction(params: {
     return {
       ok: true,
       signature,
-      explorerUrl: toExplorerLink(signature, params.explorerCluster ?? undefined),
+      explorerUrl,
       message: `${params.label} confirmed.`,
       review: {
         ...review,
-        explorerUrl: toExplorerLink(signature, params.explorerCluster ?? undefined),
+        explorerUrl,
       },
     };
   } catch (cause) {

--- a/frontend/lib/protocol-error-map.ts
+++ b/frontend/lib/protocol-error-map.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Humanize raw transaction error strings into actionable messages.
+ *
+ * Inputs are typically already RPC-error-formatted by `formatRpcError`, but
+ * may still surface raw simulation errors (e.g. `Custom error: 0x1771`),
+ * insufficient-funds messages, or unbounded provider strings. This helper
+ * trims the most common patterns and falls back to the original message
+ * when no rule matches.
+ *
+ * Extend this map as protocol-specific error codes accumulate. Keep the
+ * messages short, action-oriented, and sponsor-readable; never reference
+ * internal account names or instruction handlers.
+ */
+
+export type HumanizedProtocolError = {
+  message: string;
+  hint: string | null;
+  retryable: boolean;
+};
+
+const INSUFFICIENT_FUNDS_RX = /insufficient (?:funds|lamports|balance)/i;
+const SIMULATION_FAILED_RX = /simulation failed/i;
+const RATE_LIMIT_RX = /(429|too many requests|rate limit)/i;
+const BLOCKHASH_NOT_FOUND_RX = /blockhash not found|block height exceeded/i;
+const USER_REJECTED_RX = /user rejected|wallet adapter user rejected|approval was declined/i;
+const PROGRAM_HEX_RX = /(?:custom error|program error)[:\s]*0x([0-9a-f]+)/i;
+
+export function humanizeProtocolError(raw: string | null | undefined): HumanizedProtocolError {
+  const message = (raw ?? "").trim();
+
+  if (!message) {
+    return {
+      message: "The transaction failed without a specific reason from the wallet or RPC endpoint.",
+      hint: "Retry, or open the console and check the RPC endpoint health.",
+      retryable: true,
+    };
+  }
+
+  if (USER_REJECTED_RX.test(message)) {
+    return {
+      message: "The wallet rejected the signature request.",
+      hint: "Reopen the action and approve in your wallet to try again.",
+      retryable: true,
+    };
+  }
+
+  if (INSUFFICIENT_FUNDS_RX.test(message)) {
+    return {
+      message: "Not enough SOL in the fee payer account to cover network fees.",
+      hint: "Top up the fee payer with SOL on the configured network and retry.",
+      retryable: true,
+    };
+  }
+
+  if (RATE_LIMIT_RX.test(message)) {
+    return {
+      message: "The configured RPC endpoint rate-limited this request.",
+      hint: "Wait a few seconds and retry, or switch to a dedicated RPC endpoint in wallet settings.",
+      retryable: true,
+    };
+  }
+
+  if (BLOCKHASH_NOT_FOUND_RX.test(message)) {
+    return {
+      message: "The recent blockhash expired before confirmation completed.",
+      hint: "Retry the action — the wrapper builds a fresh blockhash on each attempt.",
+      retryable: true,
+    };
+  }
+
+  const programMatch = message.match(PROGRAM_HEX_RX);
+  if (programMatch) {
+    return {
+      message: `Protocol returned program error 0x${programMatch[1]}.`,
+      hint: "Check the action's preconditions (authority, capacity, schema) and retry.",
+      retryable: true,
+    };
+  }
+
+  if (SIMULATION_FAILED_RX.test(message)) {
+    return {
+      message,
+      hint: "Simulation rejected the action before signing — adjust the inputs and retry.",
+      retryable: true,
+    };
+  }
+
+  return {
+    message,
+    hint: null,
+    retryable: true,
+  };
+}


### PR DESCRIPTION
## Summary
Stacks on #11. Wires the post-sign transaction lifecycle into the toast infrastructure so every protocol transaction gets visible `submitted → confirmed → failed` feedback with an explorer link, retry, and signature-triggered snapshot refetch — closing the silent gap where users sign and see nothing until the 20s snapshot poll.

**Surface added**
- `executeProtocolTransaction` gains an optional, non-breaking `onLifecycle` callback fired once with `phase: "submitted"` when `sendTransaction` resolves. The pure helper stays side-effect free; the callback is opt-in.
- New `lib/protocol-action-toast.ts` → `executeProtocolTransactionWithToast` wraps the helper with the loading → success/error toast lifecycle, explorer-link "View" action, retry affordance via `onRetry`, and snapshot refetch via `onConfirmed`.
- New `lib/protocol-error-map.ts` → `humanizeProtocolError` translates the common raw causes (user-rejected, insufficient funds, RPC rate-limit, blockhash expired, raw `Custom error: 0x...` codes, simulation rejections) into short, action-oriented messages. Pass-through for the long tail; designed for incremental extension.

**Migration proof**
- `governance-operator-drawer.tsx` switches to the wrapper, moves `props.onRefresh()` into `onConfirmed` (so the snapshot refresh fires on signature confirmation instead of waiting for the next 20s poll tick), and wires `onRetry: () => run(label, factory)` so the toast's Retry button resubmits the same flow.
- Inline status banner preserved; toast is global feedback, banner is in-context drawer state.

**Migration plan for remaining ~30 call sites** lands in follow-up PRs to keep diffs reviewable. Operator drawers and money-moving flows go first; oracle/schema admin later.

Refs **OX-PROTO-ROAST-006**.

## Test plan
- [x] `npm --prefix frontend run build` — green
- [x] `/governance` loads cleanly under preview; sonner Toaster region still mounted; zero console errors
- [x] Build verifies `executeProtocolTransactionWithToast` types match the existing `executeProtocolTransaction` surface (caller migration was non-breaking)
- [ ] Reviewer (devnet wallet required): on `/governance`, open the operator drawer, kick off "Initialize protocol governance" or "Create reserve domain". Expect:
  - immediate `Submitting Initialize protocol governance…` toast
  - update to `… submitted` with truncated signature once wallet returns
  - `… confirmed` toast with **View** action that opens Solscan/Solana Explorer in a new tab
  - the workbench panels reflect the new state without waiting 20s
- [ ] Reviewer: trigger a deliberate failure (e.g., disconnect wallet mid-flow, or run with insufficient SOL on the fee payer). Expect a humanized error toast with a **Retry** button that re-runs the same flow.
- [ ] Reviewer: confirm the inline status banner inside the drawer also reflects the result (toast and banner coexist).

## Out of scope (follow-up PRs)
- Migrating the remaining ~30 `executeProtocolTransaction` call sites to the wrapper (operator drawers next, oracle/schema admin after)
- Expanding `humanizeProtocolError` with protocol-specific error codes (`AnchorError` numeric mapping from the IDL)
- "Finalized" lifecycle phase (currently just submitted → confirmed) — would require a follow-up `confirmTransaction` to finality

## Stacking note
Base is `frontend/error-toast-infra` (PR #11). Once #11 merges, GitHub will auto-rebase this PR's base to `main`. If #11 changes during review, I'll rebase this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)