### PR TITLE
Add Term tooltip primitive + glossary.ts (capital class proof)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9213,4 +9213,77 @@
       grid-template-columns: minmax(0, 1fr);
     }
   }
+
+  .omegax-term {
+    position: relative;
+    display: inline;
+  }
+
+  .omegax-term-trigger {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: help;
+    text-decoration: underline dotted var(--cyan-ink);
+    text-underline-offset: 0.18em;
+    text-decoration-thickness: 1px;
+  }
+
+  .omegax-term-trigger:hover,
+  .omegax-term-trigger:focus-visible {
+    color: var(--cyan-ink);
+    outline: none;
+    text-decoration-thickness: 2px;
+  }
+
+  .omegax-term-popover {
+    position: absolute;
+    z-index: 50;
+    bottom: calc(100% + 0.4rem);
+    left: 0;
+    width: 18rem;
+    max-width: min(18rem, 90vw);
+    padding: 0.75rem 0.875rem;
+    background: var(--panel-ceramic-strong);
+    border: 1px solid var(--border-strong);
+    border-radius: 0.625rem;
+    box-shadow: var(--panel-shadow);
+    font-size: 0.8125rem;
+    line-height: 1.45;
+    color: var(--foreground);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    white-space: normal;
+    text-align: left;
+    text-decoration: none;
+  }
+
+  .omegax-term-popover-eyebrow {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    font-weight: 600;
+  }
+
+  .omegax-term-popover-body {
+    margin: 0;
+    color: var(--foreground);
+  }
+
+  .omegax-term-popover-link {
+    color: var(--cyan-ink);
+    text-decoration: underline;
+    font-size: 0.75rem;
+    align-self: flex-start;
+  }
+
+  .omegax-term-popover-link:hover,
+  .omegax-term-popover-link:focus-visible {
+    text-decoration-thickness: 2px;
+  }
 }

--- a/frontend/components/capital-operator-drawer.tsx
+++ b/frontend/components/capital-operator-drawer.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import type { Transaction } from "@solana/web3.js";
 
+import { Term } from "@/components/term";
 import { WizardDetailSheet } from "@/components/wizard-detail-sheet";
 import { executeProtocolTransaction } from "@/lib/protocol-action";
 import {
@@ -417,7 +418,7 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                 <legend className="operator-drawer-legend">Class controls</legend>
                 {!props.selectedClass ? (
                   <p className="operator-drawer-hint">
-                    Select a capital class in the context bar to edit its controls.
+                    Select a <Term name="CapitalClass">capital class</Term> in the context bar to edit its controls.
                   </p>
                 ) : (
                   <>

--- a/frontend/components/term.tsx
+++ b/frontend/components/term.tsx
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import Link from "next/link";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+
+import { getGlossaryEntry, type GlossaryKey } from "@/lib/glossary";
+
+/**
+ * Inline tooltip primitive for canonical protocol nouns. Wrap any user-visible
+ * canonical noun (capital class, funding line, obligation, …) so that hovering
+ * or focusing the term reveals a short definition + a "Learn more" link to
+ * the disclosure pages, without sending the reader away from the workbench.
+ *
+ * Behavior mirrors `components/field-hint.tsx`:
+ *   - Hover or focus opens the tooltip.
+ *   - Click pins it open until Escape, outside-click, or another click.
+ *   - Trigger has `aria-describedby` pointed at the tooltip for screen readers.
+ *
+ * Accessibility:
+ *   - Trigger is a real `<button>` so keyboard users can Tab to it and read
+ *     the definition with their screen reader of choice.
+ *   - Visual cue is a subtle dotted underline in the cyan ink token; the
+ *     trigger itself is text-styled to keep prose flow intact.
+ */
+
+export type TermProps = {
+  name: GlossaryKey;
+  /**
+   * Optional override for the visible text. Defaults to the glossary label
+   * (e.g. "capital class"). Useful when copy needs a different inflection
+   * ("capital classes" plural, "Capital Class" sentence-case start, etc.).
+   */
+  children?: ReactNode;
+};
+
+export function Term({ name, children }: TermProps) {
+  const entry = getGlossaryEntry(name);
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+  const tooltipId = useId();
+
+  useEffect(() => {
+    if (!open && !pinned) return;
+
+    function closeIfOutside(target: EventTarget | null) {
+      if (!rootRef.current) return;
+      if (target instanceof Node && rootRef.current.contains(target)) return;
+      setOpen(false);
+      setPinned(false);
+    }
+
+    function handlePointer(event: MouseEvent | TouchEvent) {
+      closeIfOutside(event.target);
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        setPinned(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open, pinned]);
+
+  function closeIfUnpinned() {
+    if (!pinned) setOpen(false);
+  }
+
+  const label = children ?? entry.label;
+
+  return (
+    <span
+      ref={rootRef}
+      className="omegax-term"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={closeIfUnpinned}
+      onFocusCapture={() => setOpen(true)}
+      onBlurCapture={(event) => {
+        if (!rootRef.current?.contains(event.relatedTarget)) {
+          closeIfUnpinned();
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="omegax-term-trigger"
+        aria-describedby={tooltipId}
+        aria-expanded={open}
+        onClick={(event) => {
+          event.preventDefault();
+          setPinned((current) => {
+            const next = !current;
+            setOpen(next);
+            return next;
+          });
+        }}
+      >
+        {label}
+      </button>
+
+      {open ? (
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className="omegax-term-popover"
+        >
+          <span className="omegax-term-popover-eyebrow">{entry.label}</span>
+          <span className="omegax-term-popover-body">{entry.shortDefinition}</span>
+          {entry.learnMoreHref ? (
+            <Link href={entry.learnMoreHref} className="omegax-term-popover-link">
+              Learn more →
+            </Link>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/lib/glossary.ts
+++ b/frontend/lib/glossary.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Single source of truth for canonical-noun definitions used across the
+ * console. The `<Term>` primitive in `components/term.tsx` reads from here.
+ *
+ * Each entry's `learnMoreHref` should point at richer disclosure content so
+ * the tooltip stays short while users still have a one-click path to depth.
+ * The current public disclosure routes are `/coverage/technical-terms` and
+ * `/coverage/risk-disclosures`; reuse them rather than introducing parallel
+ * definitions in component copy.
+ */
+
+export type GlossaryEntry = {
+  /** Stable lookup key. PascalCase mirrors the protocol noun. */
+  key: GlossaryKey;
+  /** User-visible noun phrase as it appears in body copy. */
+  label: string;
+  /** Single-sentence definition shown in the tooltip head. */
+  shortDefinition: string;
+  /** Optional richer paragraph for the tooltip body. */
+  longDefinition?: string;
+  /** Optional path/URL pointing at fuller disclosure context. */
+  learnMoreHref?: string;
+};
+
+export type GlossaryKey =
+  | "ReserveDomain"
+  | "DomainAssetVault"
+  | "HealthPlan"
+  | "PolicySeries"
+  | "FundingLine"
+  | "ClaimCase"
+  | "Obligation"
+  | "LiquidityPool"
+  | "CapitalClass"
+  | "AllocationPosition"
+  | "Oracle"
+  | "Reserve";
+
+const TECHNICAL_TERMS_HREF = "/coverage/technical-terms";
+
+const ENTRIES: Record<GlossaryKey, GlossaryEntry> = {
+  ReserveDomain: {
+    key: "ReserveDomain",
+    label: "reserve domain",
+    shortDefinition:
+      "A hard custody and legal-segregation boundary. Capital inside one domain cannot be used to settle obligations in another.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  DomainAssetVault: {
+    key: "DomainAssetVault",
+    label: "domain asset vault",
+    shortDefinition:
+      "Token custody account scoped to a single reserve domain and asset mint. The on-chain home for posted premiums, sponsor funds, and LP capital.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  HealthPlan: {
+    key: "HealthPlan",
+    label: "health plan",
+    shortDefinition:
+      "The sponsor-side root that owns members, liabilities, and claims administration for one coverage program.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  PolicySeries: {
+    key: "PolicySeries",
+    label: "policy series",
+    shortDefinition:
+      "A versioned product lane under a health plan — one set of terms, premiums, and reserve lanes that members can buy into.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  FundingLine: {
+    key: "FundingLine",
+    label: "funding line",
+    shortDefinition:
+      "A plan-side funding source. Sponsor budgets, posted premiums, LP allocations, and backstops are kept as separate funding lines, not pooled.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  ClaimCase: {
+    key: "ClaimCase",
+    label: "claim case",
+    shortDefinition:
+      "An explicit on-chain adjudication lifecycle for a material claim — intake, evidence, attestation, settlement, and any dispute or impairment.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  Obligation: {
+    key: "Obligation",
+    label: "obligation",
+    shortDefinition:
+      "The canonical liability unit. One reserved or settled commitment against the reserve, attributed to a plan, series, and funding line.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  LiquidityPool: {
+    key: "LiquidityPool",
+    label: "liquidity pool",
+    shortDefinition:
+      "An LP-facing capital sleeve. Holds investor capital that can be allocated into health-plan funding lines under controlled redemption rules.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  CapitalClass: {
+    key: "CapitalClass",
+    label: "capital class",
+    shortDefinition:
+      "An investor instrument inside a liquidity pool. Defines deposit eligibility, redemption rights, yield posture, and impairment order for one sleeve of capital.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  AllocationPosition: {
+    key: "AllocationPosition",
+    label: "allocation position",
+    shortDefinition:
+      "The explicit bridge between a capital sleeve and a plan-side funding line. Tracks how much pool capital is committed to a specific liability, with attribution preserved.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  Oracle: {
+    key: "Oracle",
+    label: "oracle",
+    shortDefinition:
+      "An external attester that produces normalized outcome events the protocol consumes. Genesis Protect's Phase 0 oracle is operator-mediated; future series may add additional attesters.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+  Reserve: {
+    key: "Reserve",
+    label: "reserve",
+    shortDefinition:
+      "Posted, claims-paying capital. Only posted premiums, posted sponsor or backstop funds, and posted LP capital count as reserve — prediction-market or off-chain numbers do not.",
+    learnMoreHref: TECHNICAL_TERMS_HREF,
+  },
+};
+
+export function getGlossaryEntry(key: GlossaryKey): GlossaryEntry {
+  return ENTRIES[key];
+}
+
+export function listGlossaryEntries(): GlossaryEntry[] {
+  return Object.values(ENTRIES);
+}


### PR DESCRIPTION
## Summary
Stacks on #13. Adds the inline tooltip foundation for canonical protocol nouns so users can read a short definition without leaving the panel they're in. This is the primitive that the full first-run sponsor explainer and shell help button (the rest of OX-PROTO-ROAST-004) build on.

**Surface added**
- **\`lib/glossary.ts\`** → single source of truth keyed by PascalCase nouns: \`HealthPlan\`, \`PolicySeries\`, \`FundingLine\`, \`ClaimCase\`, \`Obligation\`, \`LiquidityPool\`, \`CapitalClass\`, \`AllocationPosition\`, \`ReserveDomain\`, \`DomainAssetVault\`, \`Oracle\`, \`Reserve\`. Each entry has a label, a short single-sentence definition, and a \`learnMoreHref\` pointing at \`/coverage/technical-terms\` so the tooltip stays short while still having a one-click depth path.
- **\`components/term.tsx\`** → \`<Term name="CapitalClass" />\` renders inline-styled text with a subtle cyan dotted underline; hover/focus opens a popover (eyebrow + definition + Learn more link), click pins, Escape closes, outside-click closes. \`children\` prop allows inflection overrides ("capital classes" plural, sentence-case starts) without losing the lookup key.
- **globals.css** gains \`.omegax-term\`, \`.omegax-term-trigger\`, \`.omegax-term-popover\` and friends. Cursor is \`help\`; popover uses the same panel and border-strong tokens as workbench surfaces, max-width clamped to \`18rem\` / \`90vw\`.

**Migration proof**: \`capital-operator-drawer.tsx\` "Select a capital class in the context bar to edit its controls." hint now wraps "capital class" with \`<Term>\`. One change, but it covers the most common path operators hit before they understand which sleeve they're editing.

**Migration plan** (follow-up PRs): remaining capital-operator-drawer hints (3 more sites), pool-coverage "policy series" copy, plans-workbench obligation/funding-line labels, overview-workbench surface summaries (need string → ReactNode conversion first).

**Out of scope for this PR** (separate follow-ups under OX-PROTO-ROAST-004): first-run sponsor explainer on \`/overview\`, shell help button opening the glossary index.

Refs **OX-PROTO-ROAST-004**.

## Test plan
- [x] \`npm --prefix frontend run build\` — green
- [x] Temporary \`/term-demo\` route (removed before commit) rendered 23 triggers across body paragraphs + full-entry list
- [x] Cyan dotted underline applied, cursor \`help\` correct
- [x] \`aria-describedby\` wires trigger → \`role="tooltip"\` popover; \`aria-expanded\` toggles
- [x] Hover opens, focus opens (keyboard accessible), click pins, Escape closes pinned tooltip, outside-click closes
- [x] Popover renders eyebrow + definition + "Learn more →" link to \`/coverage/technical-terms\`
- [ ] Reviewer: navigate to \`/capital\`, open the operator drawer, click into "Class controls" without selecting a class. Confirm "Select a capital class…" hint shows the cyan dotted underline on "capital class" and tooltip opens on hover/focus.
- [ ] Reviewer: confirm popover doesn't overflow on narrow viewports (resize to 375px and check)

## Stacking note
Base is \`frontend/money-usd-formatter\` (PR #13). Once #13 merges, GitHub auto-rebases the base to \`main\`. If #13 changes during review, I'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)