### PR TITLE
Make the workbench mobile-usable: viewport meta, card-stack tables, hidden footer

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "frontend",
       "runtimeExecutable": "npx",
-      "runtimeArgs": ["next", "dev"],
+      "runtimeArgs": ["next", "dev", "--webpack"],
       "port": 3847,
       "autoPort": true,
       "cwd": "frontend"

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9212,5 +9212,96 @@
     .operator-drawer-rights {
       grid-template-columns: minmax(0, 1fr);
     }
+
+    /*
+     * Table card-stack pattern.
+     * Tables across the workbench (capital allocations, plan claims, oracle
+     * watch, governance proposals, schemas) all use .plans-table with
+     * data-label attributes on every <td>. At narrow viewports they used to
+     * be horizontally-scrollable wallpaper; here they collapse into a
+     * card-per-row layout that surfaces the data-label as the field name and
+     * the cell content as the value, so a sponsor can actually read every
+     * row on a phone instead of scroll-hunting columns.
+     */
+    .plans-table thead {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .plans-table tbody tr {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      padding: 0.625rem 0.75rem;
+      margin-bottom: 0.5rem;
+      border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+      border-radius: 0.5rem;
+      background: color-mix(in oklab, var(--surface-soft) 92%, transparent);
+    }
+
+    .plans-table tbody tr:hover {
+      background: color-mix(in oklab, var(--surface-strong) 92%, transparent);
+    }
+
+    .plans-table tbody tr:last-child td,
+    .plans-table tbody tr td {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.32rem 0;
+      text-align: right;
+      border-bottom: 1px solid color-mix(in oklab, var(--border) 22%, transparent);
+    }
+
+    .plans-table tbody tr td:last-child {
+      border-bottom: 0;
+      padding-right: 0;
+    }
+
+    .plans-table tbody tr td::before {
+      content: attr(data-label);
+      flex-shrink: 0;
+      align-self: center;
+      font-family: var(--font-mono), "Fira Code", monospace;
+      font-size: 0.55rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--muted-foreground);
+      text-align: left;
+    }
+
+    /* Mobile sheet panel: full-width edge-to-edge, drop the left border, and
+       respect the iOS bottom safe-area so action buttons clear the home bar. */
+    .wizard-detail-sheet-panel,
+    .wizard-detail-sheet-panel-wide {
+      width: 100vw;
+      max-width: 100vw;
+      border-left: 0;
+    }
+
+    .wizard-detail-sheet-body {
+      padding-bottom: calc(1.35rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    /*
+     * Hide the sticky resource footer on mobile.
+     * On a 375px viewport the footer was eating ~80px of screen real estate
+     * for SOURCE / SDK / DOCS / STATUS / AUDITS links no operator needs
+     * mid-task. The sidebar nav already carries everything needed for in-task
+     * navigation on mobile; the footer links are desktop reference material.
+     * Footer stays in the DOM for screen readers and crawlers but is hidden
+     * from the visual viewport.
+     */
+    .protocol-footer {
+      display: none;
+    }
   }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import { Fira_Code, Newsreader, Space_Grotesk } from "next/font/google";
 
@@ -38,6 +38,12 @@ export const metadata: Metadata = {
     ],
     apple: [{ url: "/brand/apple-touch-icon.png", sizes: "180x180", type: "image/png" }],
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
Sibling PR off \`origin/main\` (independent of all other open PRs). Closes the worst of the desktop-only-feel on a 375px viewport with three structural fixes:

1. **Viewport meta** in \`app/layout.tsx\` (Next 13+ \`Viewport\` export). Without this, mobile browsers were rendering at desktop-emulating widths and zooming users out — every tap target was tiny. iOS notch picks up \`safe-area-inset-*\` now.
2. **Card-stack tables below 720px**. Workbench tables across capital, plans, governance, oracles, and schemas all use the same \`.plans-table\` class with \`data-label\` attributes on every \`<td>\`. At narrow viewports, rows now collapse into a card-per-row layout: each \`data-label\` becomes the field name (mono caps), cell content the value. Operators on a phone can read every row instead of horizontally scroll-hunting columns.
3. **Hidden sticky footer below 720px**. The resource footer (SOURCE / SDK / DOCS / STATUS / AUDITS) was \`position: sticky\` at \`z-index: 45\`, eating ~80px of mobile real estate for desktop reference links no operator needs mid-task. Footer stays in DOM for screen readers and crawlers; hidden from visual viewport on mobile. Sidebar nav already carries everything in-task.

Plus iOS safe-area bottom padding for the wizard detail sheet so action buttons clear the home indicator.

Refs **OX-PROTO-ROAST-010**.

## Test plan
- [x] \`npm --prefix frontend run build\` — green
- [x] **375px (iPhone SE)**: viewport meta present (\`width=device-width, initial-scale=1, viewport-fit=cover\`), no horizontal scroll on \`/capital\`, footer hidden (\`display: none\`)
- [x] **1280px (desktop)**: footer back (\`display: grid\`), all original desktop layout preserved, no regressions
- [ ] Reviewer: navigate to \`/capital\` on a real iOS device or Chrome DevTools 375px and confirm tables (when populated) collapse to card-per-row with \`data-label\` field names visible
- [ ] Reviewer: open any operator drawer on mobile and confirm the bottom action area clears the home indicator (iOS safe-area)
- [ ] Reviewer: confirm the resource footer is still accessible to screen readers (it stays in DOM)

## Per-route follow-ups (separate PRs under OX-PROTO-ROAST-010)
- Topbar wallet button overlap on narrow viewports (visible in some screenshots)
- Mobile-specific operator drawer layout (currently shares desktop layout)
- Mobile-specific wallet panel as full-screen sheet (partially scaffolded via \`.wallet-connect-shell-mobile\` already)
- Tap-target audit (44px minimum) for sidebar nav and primary actions

## Carry-over
Includes \`.claude/launch.json\` \`--webpack\` flag for preview. No-op merge if PR #11 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)