### PR TITLE
Mobile per-route polish: 44px tap targets + wordmark shrink under 400px

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8680,6 +8680,43 @@
       backdrop-filter: blur(28px) saturate(170%);
     }
 
+    /*
+     * Tap-target audit: every interactive control in the topbar bumps to
+     * 44x44px on mobile so the hamburger, network/persona/theme dropdowns,
+     * and wallet trigger meet the iOS HIG minimum. The labels stay compact
+     * (font-size + letter-spacing already tuned in the parent block) but the
+     * hit area grows to satisfy a fingertip. Primary action buttons inside
+     * the workbench do not need this override since they are already block
+     * level with generous vertical padding.
+     */
+    .protocol-topbar-menu-button {
+      min-height: 2.75rem;
+      width: 2.75rem;
+    }
+
+    .protocol-toolbar-button {
+      min-height: 2.75rem;
+      min-width: 2.75rem;
+    }
+  }
+
+  /*
+   * Very narrow screens (<400px). The topbar wordmark, DEVNET pill, and
+   * three toolbar icons compete for ~280px of usable horizontal space after
+   * accounting for the hamburger and gutter padding. Without this shrink the
+   * wordmark visibly overlaps the network pill on iPhone SE-class viewports.
+   * Drop the wordmark image footprint so the network/persona/theme controls
+   * always have unambiguous separation.
+   */
+  @media (max-width: 399px) {
+    .protocol-topbar-wordmark-image {
+      width: 6rem;
+      max-width: min(22vw, 6rem);
+    }
+  }
+
+  @media (max-width: 899px) {
+
     .protocol-mobile-nav-link {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
Stacks on PR #16. Two follow-up fixes verified at 375px:

1. **Tap-target audit** — every interactive control in the topbar bumps to 44×44px on mobile so the hamburger, network/persona/theme dropdowns, and wallet trigger meet the iOS HIG minimum. Before: hamburger 32×32, controls 36×36 (all sub-fingertip). After: all 44+. Labels stay compact; only the hit area grows.
2. **Wordmark shrink under 400px** — on iPhone SE-class viewports the wordmark (max-width \`min(28vw, 11.25rem)\`) was visibly crowding the DEVNET pill. Drops to \`min(22vw, 6rem)\` below 400px so the network/persona/theme controls always have unambiguous separation. Brand mark stays visible, just smaller.

Refs **OX-PROTO-ROAST-010 (per-route follow-ups)**.

## Test plan
- [x] **375px (iPhone SE)**: zero buttons report below 44×44 in the topbar (\`tapTargetsBelow44: []\`); wordmark and DEVNET visually separated. Baseline before this PR showed 4 sub-44 buttons (hamburger 32×32, devnet 93×36, persona 36×36, theme 36×36).
- [x] **1280px (desktop)**: hamburger correctly \`display: none\`, network button back to native 36×108, wordmark back to native 180×11. No regression.

## Note on CSS structure
The new \`<400px\` breakpoint is positioned between two halves of the existing 899px block; both halves still apply when the viewport is mobile-class. Cosmetic reorganization into a single block can land in a follow-up if you prefer.

## Stacking
Base: \`frontend/mobile-responsive\` (PR #16). Once #16 merges, GitHub auto-rebases to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)