### PR TITLE
Scope DCO range to branch-unique commits on first push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,19 @@ jobs:
           else
             before="${{ github.event.before }}"
             if [[ -z "${before}" || "${before}" == "0000000000000000000000000000000000000000" ]]; then
-              range="${{ github.sha }}"
+              # First push to a new branch. Scoping the DCO range to commits
+              # unique to this branch (vs the default branch) avoids
+              # rescanning the entire repository history — old commits that
+              # predate the DCO requirement are already accepted on the
+              # default branch and should not block a fresh feature branch.
+              # Falls back to just HEAD if origin/${default_branch} is not
+              # available for any reason.
+              default_branch="${{ github.event.repository.default_branch }}"
+              if git rev-parse --verify "origin/${default_branch}" >/dev/null 2>&1; then
+                range="origin/${default_branch}..${{ github.sha }}"
+              else
+                range="${{ github.sha }}"
+              fi
             else
               range="${before}..${{ github.sha }}"
             fi


### PR DESCRIPTION
## Summary

Every first push to a new feature branch hits a DCO false-positive: the workflow uses `git rev-list \${head_sha}` when the push event reports a zero `before` SHA (i.e. a brand-new ref), enumerating the entire repository history and tripping on legacy commits that predate the DCO requirement.

Symptom on this repo: PR #19 and PR #20 each had two `verify` runs on the same SHA — one push-triggered **fail at ~5s** (DCO scan hitting old history), one PR-triggered **pass at ~3:20** (correctly scoped to PR-only commits). The push-triggered failure was a false-positive that didn't block merge but added noise to every branch.

## Fix

When `before` is the zero SHA, use `origin/\${default_branch}..\${head_sha}` to limit the DCO scan to commits unique to this branch. Falls back to the prior `\${head_sha}` behavior if `origin/\${default_branch}` is not available for any reason. The `actions/checkout` step already runs with `fetch-depth: 0`, so the default-branch ref is fetched.

## Self-validating

This PR's own push-triggered verify will use the new logic (push events read the workflow YAML from the pushed commit, not from main). Only this commit's diff against main will be DCO-checked, and this commit has a `Signed-off-by` trailer. So if the push-triggered verify passes here, the fix works.

## Test plan

- [ ] Push-triggered verify on `ci-dco-range-first-push` passes (was failing on every prior new branch)
- [ ] Pull-request-triggered verify on PR #21 passes
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)