### PR TITLE
Migrate operator-drawer call sites to post-sign toast lifecycle

### DIFF
--- a/frontend/components/capital-operator-drawer.tsx
+++ b/frontend/components/capital-operator-drawer.tsx
@@ -9,7 +9,7 @@ import type { Transaction } from "@solana/web3.js";
 import { useProtocolTransactionReviewPrompt } from "@/components/protocol-transaction-review";
 import { Term } from "@/components/term";
 import { WizardDetailSheet } from "@/components/wizard-detail-sheet";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildAllocateCapitalTx,
   buildCreateAllocationPositionTx,
@@ -180,7 +180,7 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
     setStatus(null);
     try {
       const tx = await factory();
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
@@ -199,13 +199,18 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
             ? ["Genesis reserve movement should stay paired with readiness and operator sign-off review."]
             : [],
         },
+        onConfirmed: async () => {
+          await props.onRefresh?.();
+        },
+        onRetry: () => {
+          void run(label, factory);
+        },
       });
       if (!result.ok) {
         setStatus({ tone: "error", message: result.error });
         return;
       }
       setStatus({ tone: "ok", message: result.message, explorerUrl: result.explorerUrl });
-      await props.onRefresh?.();
     } catch (err) {
       setStatus({
         tone: "error",

--- a/frontend/components/governance-console.tsx
+++ b/frontend/components/governance-console.tsx
@@ -12,7 +12,7 @@ import { Amount } from "@/components/amount";
 import { GovernanceProposalDetailPanel } from "@/components/governance-proposal-detail-panel";
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { RealmsActionsPanel } from "@/components/realms-actions-panel";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildDepositGoverningTokensTx,
   buildSchemaStateProposalPlan,
@@ -236,11 +236,14 @@ export function GovernanceConsole({
         connection,
         owner: publicKey,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Deposit governance tokens",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -250,7 +253,6 @@ export function GovernanceConsole({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Deposit failed.");
       setStatusTone("error");
@@ -269,11 +271,14 @@ export function GovernanceConsole({
         connection,
         owner: publicKey,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Withdraw governance tokens",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -283,7 +288,6 @@ export function GovernanceConsole({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Withdraw failed.");
       setStatusTone("error");
@@ -301,11 +305,14 @@ export function GovernanceConsole({
       const plan = await planBuilder();
       let lastExplorerUrl: string | null = null;
       for (const step of plan.steps) {
-        const result = await executeProtocolTransaction({
+        const result = await executeProtocolTransactionWithToast({
           connection,
           sendTransaction,
           tx: step.tx,
           label: step.label,
+          onRetry: () => {
+            void submitPlan(label, planBuilder);
+          },
         });
         if (!result.ok) {
           setStatus(result.error);
@@ -340,11 +347,14 @@ export function GovernanceConsole({
         recentBlockhash: blockhash,
         emergencyPaused,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: emergencyPaused ? "Enable protocol pause" : "Resume protocol",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -354,7 +364,6 @@ export function GovernanceConsole({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Protocol pause update failed.");
       setStatusTone("error");

--- a/frontend/components/governance-proposal-detail-panel.tsx
+++ b/frontend/components/governance-proposal-detail-panel.tsx
@@ -8,7 +8,7 @@ import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import { PublicKey } from "@solana/web3.js";
 import { CheckCircle2, ExternalLink, LoaderCircle, Vote as VoteIcon } from "lucide-react";
 
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildCastGovernanceVoteTx,
   buildExecuteGovernanceTransactionTx,
@@ -96,11 +96,14 @@ export function GovernanceProposalDetailPanel({
         owner: publicKey,
         proposalAddress: new PublicKey(proposalAddress),
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: approve ? "Cast yes vote" : "Cast no vote",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -110,7 +113,6 @@ export function GovernanceProposalDetailPanel({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Vote submission failed.");
       setStatusTone("error");
@@ -130,11 +132,14 @@ export function GovernanceProposalDetailPanel({
         owner: publicKey,
         proposalAddress: new PublicKey(proposalAddress),
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Relinquish vote",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -144,7 +149,6 @@ export function GovernanceProposalDetailPanel({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Relinquish vote failed.");
       setStatusTone("error");
@@ -168,11 +172,14 @@ export function GovernanceProposalDetailPanel({
         rawInstructions: proposalTransaction.rawInstructions,
         walletAddress: publicKey,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: `Execute instruction ${proposalTransaction.instructionIndex + 1}`,
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -182,7 +189,6 @@ export function GovernanceProposalDetailPanel({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Execution failed.");
       setStatusTone("error");

--- a/frontend/components/oracle-profile-wizard.tsx
+++ b/frontend/components/oracle-profile-wizard.tsx
@@ -13,7 +13,7 @@ import {
   resolveOracleWizardBootstrapState,
   type OracleWizardBlockingError,
 } from "@/lib/oracle-profile-wizard-bootstrap";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   ORACLE_TYPE_HEALTH_APP,
   ORACLE_TYPE_HOSPITAL_CLINIC,
@@ -568,11 +568,14 @@ export function OracleProfileWizard({ mode, oracleAddress = "" }: OracleProfileW
           supportedSchemaKeyHashesHex: selectedSchemaHashes,
         });
 
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: mode === "register" ? "Register oracle profile" : "Update oracle profile",
+        onConfirmed: async () => {
+          await loadWizardData();
+        },
       });
 
       if (!result.ok) {
@@ -585,7 +588,6 @@ export function OracleProfileWizard({ mode, oracleAddress = "" }: OracleProfileW
       setStatusMessage(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await loadWizardData();
     } finally {
       setBusyAction(null);
     }
@@ -629,11 +631,14 @@ export function OracleProfileWizard({ mode, oracleAddress = "" }: OracleProfileW
         oracle: publicKey,
         recentBlockhash: blockhash,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Claim oracle activation",
+        onConfirmed: async () => {
+          await loadWizardData();
+        },
       });
       if (!result.ok) {
         setClaimError(result.error);
@@ -641,7 +646,6 @@ export function OracleProfileWizard({ mode, oracleAddress = "" }: OracleProfileW
       }
       setClaimSuccess(result.message);
       setTxUrl(result.explorerUrl);
-      await loadWizardData();
     } finally {
       setClaimBusy(false);
     }

--- a/frontend/components/oracle-registry-verification-panel.tsx
+++ b/frontend/components/oracle-registry-verification-panel.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 
 import { buildCanonicalPoolHref } from "@/lib/canonical-routes";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   ORACLE_TYPE_OTHER,
   buildClaimOracleTx,
@@ -416,18 +416,20 @@ export function OracleRegistryVerificationPanel() {
         oracle: publicKey,
         recentBlockhash: blockhash,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Claim oracle activation",
+        onConfirmed: async () => {
+          await refreshData();
+        },
       });
       if (!result.ok) {
         setClaimError(result.error);
         return;
       }
       setClaimSuccess(result.message);
-      await refreshData();
     } finally {
       setClaimBusy(false);
     }

--- a/frontend/components/plan-creation-wizard.tsx
+++ b/frontend/components/plan-creation-wizard.tsx
@@ -62,7 +62,7 @@ import {
   fetchProtectionMetadataDocument,
   validateProtectionMetadataAgainstPosture,
 } from "@/lib/protection-metadata";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildCreateAllocationPositionTx,
   buildCreateCapitalClassTx,
@@ -1263,7 +1263,7 @@ export function PlanCreationWizard() {
 
     const createTransaction = async (label: string, instruction: ReturnType<typeof buildCreateHealthPlanInstruction>) => {
       const tx = new Transaction({ feePayer: publicKey }).add(instruction);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
@@ -1282,7 +1282,7 @@ export function PlanCreationWizard() {
       });
     };
     const createBuiltTransaction = async (label: string, tx: Transaction) => {
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,

--- a/frontend/components/plan-operator-drawer.tsx
+++ b/frontend/components/plan-operator-drawer.tsx
@@ -8,7 +8,7 @@ import type { Transaction } from "@solana/web3.js";
 
 import { useProtocolTransactionReviewPrompt } from "@/components/protocol-transaction-review";
 import { WizardDetailSheet } from "@/components/wizard-detail-sheet";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildAdjudicateClaimCaseTx,
   buildAttachClaimEvidenceRefTx,
@@ -532,7 +532,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
     setStatus(null);
     try {
       const tx = await factory();
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
@@ -549,13 +549,18 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
             ? ["Genesis launch copy must stay at readiness stage until reserve, oracle, and operator sign-off are complete."]
             : [],
         },
+        onConfirmed: async () => {
+          await props.onRefresh?.();
+        },
+        onRetry: () => {
+          void run(label, factory);
+        },
       });
       if (!result.ok) {
         setStatus({ tone: "error", message: result.error });
         return;
       }
       setStatus({ tone: "ok", message: result.message, explorerUrl: result.explorerUrl });
-      await props.onRefresh?.();
     } catch (err) {
       setStatus({
         tone: "error",

--- a/frontend/components/pool-claims-panel.tsx
+++ b/frontend/components/pool-claims-panel.tsx
@@ -11,7 +11,7 @@ import { CheckCircle2, FileText, RefreshCw } from "lucide-react";
 import { MemberClaimsPanel } from "@/components/member-claims-panel";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import { deriveCoverageClaimActionDraft } from "@/lib/protocol-workspace-mappers";
 import {
   AI_ROLE_CLAIM_PROCESSOR,
@@ -419,11 +419,17 @@ export function PoolClaimsPanel({ poolAddress }: PoolClaimsPanelProps) {
     try {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = buildTx(blockhash);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label,
+        onConfirmed: async () => {
+          await refresh();
+        },
+        onRetry: () => {
+          void runAction(label, buildTx);
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -433,7 +439,6 @@ export function PoolClaimsPanel({ poolAddress }: PoolClaimsPanelProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusyAction(null);
     }

--- a/frontend/components/pool-coverage-panel.tsx
+++ b/frontend/components/pool-coverage-panel.tsx
@@ -13,7 +13,7 @@ import { AdvancedOverride } from "@/components/advanced-override";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
 import { SearchableSelect } from "@/components/searchable-select";
 import { parseCycleQuotePayload, quoteUsesSolRail } from "@/lib/cycle-quote";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   PLAN_MODE_PROTECTION,
   POLICY_SERIES_STATUS_ACTIVE,
@@ -556,11 +556,17 @@ export function PoolCoveragePanel({ poolAddress }: PoolCoveragePanelProps) {
     try {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = await factory(blockhash);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label,
+        onConfirmed: async () => {
+          await refresh();
+        },
+        onRetry: () => {
+          void runProtocolAction(label, factory);
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -570,7 +576,6 @@ export function PoolCoveragePanel({ poolAddress }: PoolCoveragePanelProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusyAction(null);
     }

--- a/frontend/components/pool-governance-panel.tsx
+++ b/frontend/components/pool-governance-panel.tsx
@@ -9,7 +9,7 @@ import { PublicKey } from "@solana/web3.js";
 import { GovernanceConsole } from "@/components/governance-console";
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildInitializeProtocolTx,
   buildRotateGovernanceAuthorityTx,
@@ -129,11 +129,14 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
         defaultStakeMint,
         minOracleStake: BigInt(minOracleStake || "0"),
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Initialize protocol",
+        onConfirmed: async () => {
+          await refreshConfig();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -143,7 +146,6 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refreshConfig();
     } finally {
       setBusy(null);
     }
@@ -165,11 +167,14 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
         minOracleStake: BigInt(minOracleStake || "0"),
         emergencyPaused,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Update protocol params",
+        onConfirmed: async () => {
+          await refreshConfig();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -179,7 +184,6 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refreshConfig();
     } finally {
       setBusy(null);
     }
@@ -198,11 +202,14 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
         newAuthority: nextAuthority,
         recentBlockhash: blockhash,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Rotate governance authority",
+        onConfirmed: async () => {
+          await refreshConfig();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -212,7 +219,6 @@ export function PoolGovernancePanel({ protocolConfig, onRefresh }: PoolGovernanc
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refreshConfig();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "New governance authority is invalid.");
       setStatusTone("error");

--- a/frontend/components/pool-liquidity-console.tsx
+++ b/frontend/components/pool-liquidity-console.tsx
@@ -12,7 +12,7 @@ import { PoolLiquidityPanel as PoolLiquidityDirectPanel } from "@/components/poo
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import { deriveRedemptionQueueActionDraft } from "@/lib/protocol-workspace-mappers";
 import {
   CAPITAL_CLASS_MODE_HYBRID,
@@ -294,11 +294,17 @@ export function PoolLiquidityConsole({
     try {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = buildTx(blockhash);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label,
+        onConfirmed: async () => {
+          await refresh();
+        },
+        onRetry: () => {
+          void runAction(label, buildTx);
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -308,7 +314,6 @@ export function PoolLiquidityConsole({
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusyAction(null);
     }

--- a/frontend/components/pool-oracles-console.tsx
+++ b/frontend/components/pool-oracles-console.tsx
@@ -13,7 +13,7 @@ import { PoolOraclesPanel as PoolOraclePolicyPanel } from "@/components/pool-ora
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import { deriveOracleSettlementActionDraft } from "@/lib/protocol-workspace-mappers";
 import {
   AI_ROLE_ORACLE,
@@ -432,12 +432,18 @@ export function PoolOraclesConsole({ poolAddress }: PoolOraclesConsoleProps) {
     try {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = buildTx(blockhash);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         signers,
         label,
+        onConfirmed: async () => {
+          await refresh();
+        },
+        onRetry: () => {
+          void runAction(label, buildTx, signers);
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -447,7 +453,6 @@ export function PoolOraclesConsole({ poolAddress }: PoolOraclesConsoleProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusyAction(null);
     }

--- a/frontend/components/pool-oracles-panel.tsx
+++ b/frontend/components/pool-oracles-panel.tsx
@@ -9,7 +9,7 @@ import { PublicKey } from "@solana/web3.js";
 import { ExternalLink, RefreshCw, ShieldCheck } from "lucide-react";
 
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildSetPoolOraclePermissionsTx,
   buildSetPoolOraclePolicyTx,
@@ -269,11 +269,14 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
         recentBlockhash: blockhash,
         active: approvalActive,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: approvalActive ? "Approve oracle" : "Disable oracle approval",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -283,7 +286,6 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusy(null);
     }
@@ -303,11 +305,14 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
         permissions: Number.parseInt(permissionMask, 10) || 0,
         recentBlockhash: blockhash,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Set oracle permissions",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -317,7 +322,6 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusy(null);
     }
@@ -341,11 +345,14 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
         allowDelegateClaim,
         challengeWindowSecs: Number.parseInt(challengeWindowSecs, 10) || 0,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Set oracle policy",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -355,7 +362,6 @@ export function PoolOraclesPanel({ poolAddress, sectionMode = "standalone" }: Po
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusy(null);
     }

--- a/frontend/components/pool-schemas-panel.tsx
+++ b/frontend/components/pool-schemas-panel.tsx
@@ -9,7 +9,7 @@ import { PublicKey } from "@solana/web3.js";
 
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildBackfillSchemaDependencyLedgerTx,
   buildCloseOutcomeSchemaTx,
@@ -160,11 +160,14 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
         visibility: Number.parseInt(visibility, 10) || 0,
         metadataUri,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Register schema",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -174,7 +177,6 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusy(null);
     }
@@ -193,11 +195,14 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
         schemaKeyHashHex: selectedSchema.schemaKeyHashHex,
         verified: verifyState,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: verifyState ? "Verify schema" : "Unverify schema",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -207,7 +212,6 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } finally {
       setBusy(null);
     }
@@ -231,11 +235,14 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
         schemaKeyHashHex: selectedSchema.schemaKeyHashHex,
         poolRuleAddresses,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Backfill schema dependency ledger",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -245,7 +252,6 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Backfill inputs are invalid.");
       setStatusTone("error");
@@ -268,11 +274,14 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
         recentBlockhash: blockhash,
         schemaKeyHashHex: selectedSchema.schemaKeyHashHex,
       });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Close schema",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -282,7 +291,6 @@ export function PoolSchemasPanel({ poolAddress, onRefresh }: PoolSchemasPanelPro
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Close recipient is invalid.");
       setStatusTone("error");

--- a/frontend/components/pool-settings-panel.tsx
+++ b/frontend/components/pool-settings-panel.tsx
@@ -14,7 +14,7 @@ import { OperatorVisibilityPanel } from "@/components/operator-visibility-panel"
 import { PoolLifecyclePanel } from "@/components/pool-lifecycle-panel";
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   AI_ROLE_ALL_MASK,
   AUTOMATION_MODE_ADVISORY,
@@ -345,11 +345,17 @@ export function PoolSettingsPanel({ poolAddress, sectionMode = "standalone" }: P
     try {
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = buildTx(blockhash);
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label,
+        onConfirmed: async () => {
+          await refreshReadiness();
+        },
+        onRetry: () => {
+          void runAction(label, buildTx);
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -359,7 +365,6 @@ export function PoolSettingsPanel({ poolAddress, sectionMode = "standalone" }: P
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refreshReadiness();
     } finally {
       setBusyAction(null);
     }

--- a/frontend/components/pool-treasury-panel.tsx
+++ b/frontend/components/pool-treasury-panel.tsx
@@ -9,7 +9,7 @@ import { PublicKey } from "@solana/web3.js";
 import { ProtocolDetailDisclosure } from "@/components/protocol-detail-disclosure";
 import { usePoolWorkspaceContext } from "@/components/pool-workspace-context";
 import { SearchableSelect } from "@/components/searchable-select";
-import { executeProtocolTransaction } from "@/lib/protocol-action";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildWithdrawPoolOracleFeeSolTx,
   buildWithdrawPoolOracleFeeSplTx,
@@ -181,11 +181,14 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
             amount,
             recentBlockhash: blockhash,
           });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Withdraw pool treasury",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -195,7 +198,6 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Pool treasury withdrawal inputs are invalid.");
       setStatusTone("error");
@@ -226,11 +228,14 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
             amount,
             recentBlockhash: blockhash,
           });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Withdraw protocol fees",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -240,7 +245,6 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Protocol fee withdrawal inputs are invalid.");
       setStatusTone("error");
@@ -273,11 +277,14 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
             amount,
             recentBlockhash: blockhash,
           });
-      const result = await executeProtocolTransaction({
+      const result = await executeProtocolTransactionWithToast({
         connection,
         sendTransaction,
         tx,
         label: "Withdraw pool oracle fees",
+        onConfirmed: async () => {
+          await refresh();
+        },
       });
       if (!result.ok) {
         setStatus(result.error);
@@ -287,7 +294,6 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
       setStatus(result.message);
       setStatusTone("ok");
       setTxUrl(result.explorerUrl);
-      await refresh();
     } catch (cause) {
       setStatus(cause instanceof Error ? cause.message : "Oracle fee withdrawal inputs are invalid.");
       setStatusTone("error");

--- a/frontend/lib/protocol-action-toast.ts
+++ b/frontend/lib/protocol-action-toast.ts
@@ -8,6 +8,7 @@ import {
   executeProtocolTransaction,
   type ProtocolActionResult,
   type ProtocolActionSuccess,
+  type ProtocolTransactionReviewConfirmation,
   type ProtocolTransactionReviewMetadata,
 } from "@/lib/protocol-action";
 import { humanizeProtocolError } from "@/lib/protocol-error-map";
@@ -38,6 +39,15 @@ export type ProtocolActionToastParams = {
   signers?: Signer[];
   explorerCluster?: string | null;
   review?: ProtocolTransactionReviewMetadata;
+  /**
+   * Pre-sign review confirmation. Required whenever `review` is supplied —
+   * `executeProtocolTransaction` rejects the call (`requires a pre-sign
+   * review before wallet signing`) when review metadata is provided without
+   * a confirmation handler. The toast wrapper forwards this verbatim; it is
+   * the operator drawer's responsibility to provide the prompt
+   * (`useProtocolTransactionReviewPrompt`).
+   */
+  confirmReview?: ProtocolTransactionReviewConfirmation;
   onConfirmed?: (result: ProtocolActionSuccess) => void | Promise<void>;
   onRetry?: () => void | Promise<void>;
 };
@@ -59,6 +69,7 @@ export async function executeProtocolTransactionWithToast(
       signers: params.signers,
       explorerCluster: params.explorerCluster ?? null,
       review: params.review,
+      confirmReview: params.confirmReview,
       onLifecycle: (event) => {
         if (event.phase !== "submitted") return;
         toast.loading(`${params.label} submitted`, {

--- a/tests/security/pre_sign_review_coverage.test.ts
+++ b/tests/security/pre_sign_review_coverage.test.ts
@@ -38,7 +38,7 @@ function scanCallsites(): Callsite[] {
     if (!src.includes("executeProtocolTransaction")) continue;
     const lines = src.split("\n");
     for (let i = 0; i < lines.length; i += 1) {
-      if (!/executeProtocolTransaction\s*\(/.test(lines[i] ?? "")) continue;
+      if (!/executeProtocolTransaction(?:WithToast)?\s*\(/.test(lines[i] ?? "")) continue;
       // Walk forward, tracking paren depth, to find the matching close paren.
       let depth = 0;
       let started = false;


### PR DESCRIPTION
## Summary

Closes the bulk of the [Land and validate pre-sign transaction review across operator drawers](https://www.notion.so/34fe7028cbb981c8b785f1f3655d93fe) Notion task.

The post-sign toast lifecycle (loading → submitted → confirmed/failed) was wired in PR #12 (`Merge #11+#12`) and the `governance-operator-drawer` was migrated as a 1-of-30 proof of pattern. The other ~29 operator-drawer call sites still went straight through `executeProtocolTransaction` and didn't get the toast lifecycle.

This PR migrates the remaining **32 call sites across 16 component files**, plus extends the toast wrapper to forward `confirmReview` (the prior wrapper signature dropped pre-sign review on migration — a regression vs the original task acceptance criteria).

## Pattern applied

- `executeProtocolTransaction` (import + calls) → `executeProtocolTransactionWithToast`
- `confirmReview` + `review` preserved verbatim where present
- post-success refresh moved into `onConfirmed` callback
- `run(label, factory)`-style helpers gain `onRetry: () => { void run(label, factory); }`
- one-off `useCallback` handlers do not gain `onRetry` (form re-submit covers it)

## Files migrated (32 call sites)

| File | Calls |
|------|-------|
| capital-operator-drawer | 1 |
| plan-operator-drawer | 1 |
| pool-treasury-panel | 3 |
| pool-claims-panel | 1 |
| pool-oracles-panel | 3 |
| pool-settings-panel | 1 |
| pool-coverage-panel | 1 |
| pool-schemas-panel | 4 |
| pool-governance-panel | 3 |
| oracle-registry-verification-panel | 1 |
| pool-oracles-console | 1 |
| pool-liquidity-console | 1 |
| governance-console | 4 |
| oracle-profile-wizard | 2 |
| plan-creation-wizard | 2 |
| governance-proposal-detail-panel | 3 |

## Special-cased patterns (not regressions)

- **governance-console `submitPlan` multi-step loop**: per-step refresh in `onConfirmed` would be wrong semantics; post-loop refresh preserved. `onRetry` re-runs the whole `submitPlan` since per-step retry would skip instruction dependencies.
- **plan-creation-wizard launch flow**: simple rename only; the launch is an orchestrated multi-step sequence where single-step retry would skip the rest.

## Toast wrapper change

`frontend/lib/protocol-action-toast.ts` now accepts and forwards `confirmReview`. Required because `executeProtocolTransaction` rejects with `"requires a pre-sign review before wallet signing"` when `review` metadata is supplied without a confirm callback — without this, sites that pass `review` couldn't migrate at all.

## Test plan

- [x] `npm run frontend:build` — exit 0, no type errors
- [x] `npm run test:node` — **154/154** pass (PT-06 coverage map still finds the expected callsites under the renamed function name; regex updated to accept `executeProtocolTransactionWithToast`)
- [x] `npm run rust:test` — 39/39
- [x] `npm run rust:lint`, `idl:freshness:check`, `protocol:contract:check`, `semantic:readiness:check`, `public:hygiene:check` — all clean
- [ ] Public CI on this PR

## Notion impact

After this lands, [Land and validate pre-sign transaction review across operator drawers](https://www.notion.so/34fe7028cbb981c8b785f1f3655d93fe) is unblocked of its "29 of 30 callsites pending" gap. Remaining work on that task page: the original PR #12 acceptance criteria around blocking signing when simulation fails or required review metadata is missing is already enforced by the underlying `executeProtocolTransaction` gate that this wrapper now correctly forwards through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)