### PR TITLE
Phase 1.6/1.7 — Fee accumulation + withdrawal infrastructure (PT-03/PT-13 closure)

### DIFF
--- a/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
+++ b/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 768458fc073b448bff1d93767fbc1af813eb71643ebff40f57eb8e355b9c099e
+// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
 
 package com.omegax.protocol
 
@@ -27,6 +27,9 @@ object ProtocolContract {
         "deallocate_capital" to byteArrayOf(10u.toByte(), 97u.toByte(), 97u.toByte(), 189u.toByte(), 60u.toByte(), 170u.toByte(), 102u.toByte(), 29u.toByte()),
         "deposit_into_capital_class" to byteArrayOf(40u.toByte(), 215u.toByte(), 33u.toByte(), 115u.toByte(), 185u.toByte(), 101u.toByte(), 196u.toByte(), 167u.toByte()),
         "fund_sponsor_budget" to byteArrayOf(150u.toByte(), 210u.toByte(), 161u.toByte(), 31u.toByte(), 50u.toByte(), 12u.toByte(), 224u.toByte(), 32u.toByte()),
+        "init_pool_oracle_fee_vault" to byteArrayOf(68u.toByte(), 122u.toByte(), 148u.toByte(), 84u.toByte(), 91u.toByte(), 98u.toByte(), 198u.toByte(), 167u.toByte()),
+        "init_pool_treasury_vault" to byteArrayOf(96u.toByte(), 169u.toByte(), 51u.toByte(), 224u.toByte(), 0u.toByte(), 207u.toByte(), 141u.toByte(), 47u.toByte()),
+        "init_protocol_fee_vault" to byteArrayOf(212u.toByte(), 235u.toByte(), 61u.toByte(), 42u.toByte(), 96u.toByte(), 183u.toByte(), 225u.toByte(), 57u.toByte()),
         "initialize_protocol_governance" to byteArrayOf(220u.toByte(), 188u.toByte(), 231u.toByte(), 198u.toByte(), 20u.toByte(), 71u.toByte(), 42u.toByte(), 123u.toByte()),
         "mark_impairment" to byteArrayOf(58u.toByte(), 97u.toByte(), 30u.toByte(), 157u.toByte(), 211u.toByte(), 45u.toByte(), 174u.toByte(), 238u.toByte()),
         "open_claim_case" to byteArrayOf(151u.toByte(), 125u.toByte(), 231u.toByte(), 211u.toByte(), 63u.toByte(), 132u.toByte(), 248u.toByte(), 184u.toByte()),
@@ -109,8 +112,11 @@ object ProtocolContract {
         "PolicySeries" to byteArrayOf(196u.toByte(), 117u.toByte(), 121u.toByte(), 249u.toByte(), 37u.toByte(), 71u.toByte(), 245u.toByte(), 23u.toByte()),
         "PoolClassLedger" to byteArrayOf(147u.toByte(), 125u.toByte(), 17u.toByte(), 88u.toByte(), 188u.toByte(), 78u.toByte(), 109u.toByte(), 204u.toByte()),
         "PoolOracleApproval" to byteArrayOf(116u.toByte(), 241u.toByte(), 25u.toByte(), 184u.toByte(), 205u.toByte(), 21u.toByte(), 153u.toByte(), 29u.toByte()),
+        "PoolOracleFeeVault" to byteArrayOf(167u.toByte(), 128u.toByte(), 29u.toByte(), 44u.toByte(), 248u.toByte(), 197u.toByte(), 244u.toByte(), 23u.toByte()),
         "PoolOraclePermissionSet" to byteArrayOf(3u.toByte(), 136u.toByte(), 243u.toByte(), 231u.toByte(), 172u.toByte(), 143u.toByte(), 123u.toByte(), 245u.toByte()),
         "PoolOraclePolicy" to byteArrayOf(246u.toByte(), 134u.toByte(), 133u.toByte(), 108u.toByte(), 100u.toByte(), 203u.toByte(), 226u.toByte(), 43u.toByte()),
+        "PoolTreasuryVault" to byteArrayOf(93u.toByte(), 195u.toByte(), 95u.toByte(), 29u.toByte(), 127u.toByte(), 28u.toByte(), 59u.toByte(), 193u.toByte()),
+        "ProtocolFeeVault" to byteArrayOf(199u.toByte(), 15u.toByte(), 107u.toByte(), 45u.toByte(), 108u.toByte(), 244u.toByte(), 162u.toByte(), 105u.toByte()),
         "ProtocolGovernance" to byteArrayOf(71u.toByte(), 235u.toByte(), 253u.toByte(), 251u.toByte(), 202u.toByte(), 254u.toByte(), 132u.toByte(), 177u.toByte()),
         "ReserveDomain" to byteArrayOf(119u.toByte(), 76u.toByte(), 223u.toByte(), 192u.toByte(), 177u.toByte(), 116u.toByte(), 88u.toByte(), 178u.toByte()),
         "SchemaDependencyLedger" to byteArrayOf(87u.toByte(), 115u.toByte(), 211u.toByte(), 54u.toByte(), 36u.toByte(), 177u.toByte(), 77u.toByte(), 131u.toByte()),

--- a/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
+++ b/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
+// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
 
 package com.omegax.protocol
 
@@ -58,6 +58,12 @@ object ProtocolContract {
         "update_reserve_domain_controls" to byteArrayOf(3u.toByte(), 60u.toByte(), 38u.toByte(), 233u.toByte(), 198u.toByte(), 167u.toByte(), 116u.toByte(), 197u.toByte()),
         "verify_outcome_schema" to byteArrayOf(221u.toByte(), 10u.toByte(), 144u.toByte(), 137u.toByte(), 106u.toByte(), 214u.toByte(), 205u.toByte(), 170u.toByte()),
         "version_policy_series" to byteArrayOf(64u.toByte(), 76u.toByte(), 132u.toByte(), 253u.toByte(), 41u.toByte(), 220u.toByte(), 169u.toByte(), 146u.toByte()),
+        "withdraw_pool_oracle_fee_sol" to byteArrayOf(208u.toByte(), 223u.toByte(), 250u.toByte(), 62u.toByte(), 199u.toByte(), 8u.toByte(), 221u.toByte(), 185u.toByte()),
+        "withdraw_pool_oracle_fee_spl" to byteArrayOf(242u.toByte(), 75u.toByte(), 247u.toByte(), 122u.toByte(), 255u.toByte(), 183u.toByte(), 48u.toByte(), 189u.toByte()),
+        "withdraw_pool_treasury_sol" to byteArrayOf(50u.toByte(), 115u.toByte(), 51u.toByte(), 120u.toByte(), 221u.toByte(), 37u.toByte(), 200u.toByte(), 169u.toByte()),
+        "withdraw_pool_treasury_spl" to byteArrayOf(43u.toByte(), 146u.toByte(), 116u.toByte(), 123u.toByte(), 106u.toByte(), 69u.toByte(), 242u.toByte(), 104u.toByte()),
+        "withdraw_protocol_fee_sol" to byteArrayOf(193u.toByte(), 33u.toByte(), 140u.toByte(), 185u.toByte(), 45u.toByte(), 190u.toByte(), 112u.toByte(), 7u.toByte()),
+        "withdraw_protocol_fee_spl" to byteArrayOf(120u.toByte(), 62u.toByte(), 236u.toByte(), 14u.toByte(), 227u.toByte(), 240u.toByte(), 52u.toByte(), 253u.toByte()),
     )
 
     val pdaSeeds: Map<String, List<String>> = mapOf(

--- a/docs/security/pre-mainnet-pen-test-2026-04-27.md
+++ b/docs/security/pre-mainnet-pen-test-2026-04-27.md
@@ -1,6 +1,6 @@
 # Pre-Mainnet Penetration Test — OmegaX Protocol
 
-**Date:** 2026-04-27  
+**Date:** 2026-04-27 (original) · **Last updated:** 2026-04-29 (post-Phase 1.7 PR4)  
 **Reviewer:** Adversarial review pass, complementing CSO infrastructure audit ([2026-04-27](../../.superstack/security-reports/omegax-protocol-2026-04-27.md))  
 **Scope:** On-chain program, frontend pre-sign review gate, oracle/operator trust boundaries, Genesis launch configuration  
 **Methodology:** Static-source pen-test with PoC tests in `tests/security/`. Each finding has a runnable test that confirms or refutes the claim against the live source tree. PoCs ran via `npm run test:node` on 2026-04-27, all 18 assertions green.
@@ -9,7 +9,9 @@
 
 ## Executive summary
 
-**Verdict: NOT READY FOR MAINNET.** Two CRITICAL findings block launch as-is.
+**Verdict (2026-04-29): READY-WITH-FIXES.** All CRITICAL and HIGH on-chain findings remediated; PT-03 fully closed by Phase 1.6/1.7 PR1–PR4. Remaining items: multisig recommendation doc for governance authority, optional cleanup of dead UI components quarantined in tsconfig, and the LOW/INFO items (PT-09, PT-10, PT-12).
+
+**Original verdict (2026-04-27): NOT READY FOR MAINNET.** Two CRITICAL findings blocked launch as-is.
 
 The OmegaX program in `programs/omegax_protocol/` accepts SPL token deposits but has **no on-chain instruction that releases tokens back out**. Every "settle / process / release" handler updates ledger state and decrements the vault's `total_assets` counter, but **no `transfer_checked` CPI is called**. The IDL contains no `withdraw_*`, `sweep_*`, or fee-collection instruction. The frontend ships a treasury-panel UI whose imports point to nonexistent builders — `pool-treasury-panel.tsx:14-19` imports six `buildWithdraw*Tx` names from `@/lib/protocol`, none of which is exported by that file (49 builders enumerated; zero match).
 
@@ -463,20 +465,21 @@ No remediation required.
 
 ---
 
-## Remediation status (post-Phase 1, 2026-04-28)
+## Remediation status (post-Phase 1.7 PR4, 2026-04-29)
 
-Phase 1 of the remediation plan landed across 6 commits. On-chain
-remediation is substantially complete; PT-03/PT-06/PT-13 (frontend) and
-PT-05 (operator config) remain for Phase 2/3.
+Phases 1 + 1.6 + 1.7 of the remediation plan landed across 21 commits.
+All CRITICAL and HIGH findings are now REMEDIATED. Multisig
+recommendation for governance authority is the only remaining
+mainnet-readiness item from this report.
 
 | ID | Severity | Status | Notes |
 |---|---|---|---|
-| PT-01 | CRITICAL | **REMEDIATED** | All 3 real money-out handlers (`settle_claim_case`, `process_redemption_queue`, `settle_obligation`) now call `transfer_from_domain_vault` with PDA-signed CPI. Verified by [`tests/security/no_money_out_path.test.ts`](../../tests/security/no_money_out_path.test.ts) defense regression. |
+| PT-01 | CRITICAL | **REMEDIATED** | All 3 real money-out handlers (`settle_claim_case`, `process_redemption_queue`, `settle_obligation`) now call `transfer_from_domain_vault` with PDA-signed CPI. Phase 1.7 added 6 explicit `withdraw_*_fee_*` instructions for the fee rails. Verified by [`tests/security/no_money_out_path.test.ts`](../../tests/security/no_money_out_path.test.ts) defense regression — pins the 6 expected withdraw ix names. |
 | PT-02 | CRITICAL | **REMEDIATED** | Vault custody refactored: `create_domain_asset_vault` now `init`s the SPL token account at a new PDA seed with `token::authority = domain_asset_vault`, so the program signs outflows as the vault PDA. Bootstrap scripts updated to derive the new PDA via `deriveDomainAssetVaultTokenAccountPda`; `OMEGAX_*_VAULT_TOKEN_ACCOUNT` env vars no longer required. |
-| PT-03 | HIGH | OPEN | Frontend dead-imports persist on `main`. Phase 2 work (other agent on the UI). |
+| PT-03 | HIGH | **REMEDIATED (Phase 1.6/1.7)** | Phase 1.7 PR2 shipped 6 on-chain `withdraw_*_fee_*` instructions; PR3 added matching `buildWithdraw*Tx` builders + `list*` summary functions in `frontend/lib/protocol.ts`; PR4 mounted `pool-treasury-panel.tsx` into the capital workbench `treasury` tab and removed the broad `components/**/*` tsconfig exclusion (also closing PT-13 for the panel). All three originally-VULN-CONFIRMED PoC checks in [`tests/security/treasury_panel_imports_unresolved.test.ts`](../../tests/security/treasury_panel_imports_unresolved.test.ts) flipped to defense regressions. |
 | PT-04 | HIGH | **REMEDIATED** | `require_claim_intake_submitter` operator branch now constrains `args.claimant == member_position.wallet`; recipient routing moved to the new `ClaimCase.delegate_recipient` field set via `authorize_claim_recipient` (member-only signer). Verified by [`tests/security/program_authorization_gaps.test.ts::[PT-04 defense]`](../../tests/security/program_authorization_gaps.test.ts) and Rust unit tests `claim_intake_submitter_rejects_operator_with_attacker_claimant`, `claim_settlement_routes_to_*`. |
 | PT-05 | HIGH (config) | **REMEDIATED (opt-in)** | `genesis_live_bootstrap_config.ts` now validates distinct operator keypairs when `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1` is set in the operator environment. Mainnet operators must set this. The validation throws with a clear message identifying which two roles collapse. Verified by [`tests/genesis_live_bootstrap_config.test.ts`](../../tests/genesis_live_bootstrap_config.test.ts) — both rejection and acceptance paths tested. Multisig recommendation for governance authority is still future operator-runbook work. |
-| PT-13 | HIGH | OPEN | tsconfig restoration deferred to Phase 2 (other agent on the UI). |
+| PT-13 | HIGH | **REMEDIATED (Phase 1.7 PR4)** | Broad `components/**/*` tsconfig exclusion removed; `pool-treasury-panel.tsx`, `capital-workbench.tsx`, and `pool-workspace-context.tsx` are now in the explicit include list. Previously-excluded `lib/ui-capabilities.ts` is also typechecked. Dead components with stale imports are quarantined via specific includes (tracked as a follow-up cleanup). Defense regression in [`tests/security/treasury_panel_imports_unresolved.test.ts`](../../tests/security/treasury_panel_imports_unresolved.test.ts) pins both halves of the closure. |
 | PT-06 | MEDIUM | OPEN (branch-aware) | Branch divergence: this branch uses post-sign toast lifecycle; pre-sign review gate that the original report critiqued doesn't exist on this branch by design. PoC tests skip with a clear message. |
 | PT-07 | MEDIUM | **REMEDIATED** | `register_oracle` requires `args.oracle == ctx.accounts.admin.key()` via `require_keys_eq!`. Closes the squat-then-recover pattern. Verified by [`tests/security/program_authorization_gaps.test.ts::[PT-07 defense]`](../../tests/security/program_authorization_gaps.test.ts). |
 | PT-08 | MEDIUM | **INVALID** | Source verification on 2026-04-28 shows `mark_impairment` does NOT mutate `capital_class.nav_assets` or `liquidity_pool.total_value_locked` — those fields are only changed by `deposit_into_capital_class` (line 1709) and `process_redemption_queue` (line 1838). The original report claimed impairment lowers NAV; that claim was wrong. There is no first-mover advantage from impairment timing. Finding withdrawn. |
@@ -487,22 +490,44 @@ PT-05 (operator config) remain for Phase 2/3.
 
 ### Net result
 
-**Critical/High on-chain findings: all REMEDIATED.** The protocol can now release SPL tokens via PDA-signed CPI in claim settlement, redemption, and obligation settlement flows. The settlement recipient is controlled by the member (via `delegate_recipient`), preventing operator-routed diversion. Oracle profile squatting is closed at registration time.
+**All CRITICAL and HIGH findings REMEDIATED (2026-04-29).** The protocol can release SPL tokens via PDA-signed CPI in claim settlement, redemption, and obligation settlement flows. Phase 1.6/1.7 added explicit fee accumulation hooks across the four inflow handlers and 6 fee-vault withdrawal instructions (SOL + SPL × protocol/pool-treasury/pool-oracle rails) with per-rail authority gating. The settlement recipient is controlled by the member (via `delegate_recipient`), preventing operator-routed diversion. Oracle profile squatting is closed at registration time. Frontend builders + listers + summary types now resolve every panel import; pool-treasury-panel is mounted as a real workbench tab and typechecked.
 
 **Remaining for full mainnet readiness:**
-- Frontend (PT-03, PT-13) — other agent's domain
-- Operator config (PT-05) — distinct-keypair validation, multisig recommendation
-- Fee accumulation + withdrawal infrastructure (plan sections 1.6/1.7) — substantial Phase 1 follow-up
-- Update pen-test report's executive summary verdict from NOT-READY to READY-WITH-FIXES once PT-03/PT-05/PT-13 are addressed
+- Multisig recommendation doc for governance authority (operator-runbook work, not a code finding).
+- Optional cleanup of dead UI components quarantined in `frontend/tsconfig.json` (legacy MVP code with stale imports, not mounted in `app/`).
+- LOW/INFO follow-ups: PT-09, PT-10, PT-12.
+
+The four-PR ladder (PR1: init + accrual; PR2: 6 withdraw ix; PR3: frontend builders/listers/types; PR4: panel mount + tsconfig + report) closed PT-03 + PT-13 in full and PT-01 redundantly across both the settlement outflows (Phase 1) and the new fee rails (Phase 1.7).
 
 **Phase 1 commit history:**
+**Phase 1 commit history (2026-04-28):**
 - `ae50021` — Initial pen-test fixes (PT-04, PT-07) and outflow foundations
 - `ebc8a70` — Vault custody refactor (PT-01/02 prerequisite)
 - `383b924` — ClaimCase delegate_recipient + authorize_claim_recipient instruction
 - `1093f29` — Outflow CPI in settle_claim_case + process_redemption_queue
 - `f8ad166` — Outflow CPI in settle_obligation
 - `a5925b0` — Recipient resolver helper + routing tests + PT-08 withdrawal
-- (this commit) — PT-05 distinct-keypair validation + tests
+- `8c219fe` — PT-05 distinct-operator-keys guard for Genesis bootstrap
+
+**Phase 1.6/1.7 commit history (2026-04-28..2026-04-29) — fee accumulation + withdrawal infrastructure (PT-03 / PT-13 closure):**
+- `9cee4ef` — Fee-vault init scaffolding (3 init ix, accrual helpers, error variants, events)
+- `6634f79` — Wire protocol-fee accrual into `record_premium_payment`
+- `956d0f1` — Wire pool-treasury entry-fee accrual into `deposit_into_capital_class`
+- `8bf2849` — Wire pool-treasury exit-fee accrual into `process_redemption_queue`
+- `7171866` — Wire protocol+oracle fee accrual into `settle_claim_case`
+- `6e84309` — 7 Rust unit tests for fee accrual helpers
+- `db7f2ca` — Regenerate IDL + protocol contract artifacts (Phase 1.6)
+- `03d8c7f` — Extend `tests/protocol_contract.test.ts` with surface assertions
+- `42dba41` — 6 `withdraw_*_fee_*` instructions (SOL+SPL × 3 rails)
+- `aa0c954` — 5 Rust unit tests for `require_fee_vault_balance`
+- `d019e2f` — Regenerate IDL + protocol contract artifacts (Phase 1.7)
+- `a4ec339` — Extend Node tests + flip PT-01/PT-03 IDL assertions to defense regression
+- `0403596` — Frontend `buildWithdraw*Tx` builders, listers, summary types
+- `2cbed15` — Flip PT-03 builder-export assertion to defense regression
+- `2eefe83` — Node tests for builders, derivers, contract args
+- `576819a` — Mount `PoolTreasuryPanel` into capital workbench treasury tab
+- `c026348` — Restore components typecheck for the panel + flip last PT-03 PoC
+- (this commit) — Pen-test report verdict update to READY-WITH-FIXES
 
 ---
 
@@ -526,10 +551,18 @@ npm --prefix frontend run build
 npm run verify:public
 ```
 
-Last run (2026-04-27):
+Last run (2026-04-29, post-Phase 1.7 PR4):
+- `npm run test:node` — 162/162 green; all PT-01 / PT-03 / PT-04 / PT-07 / PT-11 / PT-12 PoCs are now defense regressions (flipped from VULN_CONFIRMED).
+- `npm run rust:test` — 51/51 green, including the seven Phase 1.6 fee-accrual helper tests and the five Phase 1.7 `require_fee_vault_balance` tests.
+- `npm run rust:fmt:check` — clean.
+- `npm run protocol:contract:check` — in sync (`contract_sha256 = f095fb3ee9dd…`).
+- `npm run idl:freshness:check` — IDL matches program source (4 files, `192d35a886c0…`).
+- `npm --prefix frontend run build` — exit 0; the previously-PT-03 dead imports now resolve through the new `buildWithdraw*Tx` exports and the panel typechecks via the explicit `tsconfig.json` include.
+
+Original (2026-04-27, pre-remediation):
 - `npm run test:node` — 114/114 green, including all 19 security PoCs (one added post-build for PT-13)
 - `npm run rust:test` — 36/36 green, including the four `claim_intake_submitter_*` tests cited under PT-11
-- `npm --prefix frontend run build` — exit 0; this is the **PT-03 / PT-13 evidence**: the build succeeds despite the dead imports because tsconfig excludes components from typecheck
+- `npm --prefix frontend run build` — exit 0; this was the original **PT-03 / PT-13 evidence**: the build succeeded despite the dead imports because tsconfig excluded components from typecheck.
 
 Each assertion's pass/fail is the verification record. When the team remediates a finding, the corresponding PoC should fail — at that point the PoC should either be deleted or flipped into a defense test.
 

--- a/e2e/localnet_protocol_surface.test.ts
+++ b/e2e/localnet_protocol_surface.test.ts
@@ -864,6 +864,14 @@ const scenarioAssertions: Record<ScenarioName, () => void> = {
     assert((impairedLedger.sheet.impaired ?? 0n) > 0n);
     assert(DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!.totalPendingRedemptions > 0n);
   },
+  fee_vault_lifecycle: () => {
+    // Phase 1.6/1.7 — Surface-ownership only. The 9 fee-vault instructions
+    // (3 init + 6 withdraw) are pinned by the canonical-instruction-ownership
+    // test above; deeper localnet-execution coverage (init → accrue →
+    // withdraw round-trip on the rails) lands in a follow-up that builds the
+    // matching fixture state. Until then this scenario is pure surface
+    // coverage so the manifest stays consistent.
+  },
 };
 
 for (const scenarioName of orderedScenarios) {

--- a/e2e/support/surface_manifest.ts
+++ b/e2e/support/surface_manifest.ts
@@ -12,6 +12,7 @@ export const SCENARIO_ORDER = [
   "liquidity_pool_and_capital_class_lifecycle",
   "allocation_and_deallocation_lifecycle",
   "impairment_and_redemption_queue_lifecycle",
+  "fee_vault_lifecycle",
 ] as const;
 
 export type ScenarioName = (typeof SCENARIO_ORDER)[number];
@@ -134,6 +135,22 @@ export const SCENARIO_DEFINITIONS: Record<ScenarioName, ScenarioDefinition> = {
     focus: "Impairment, restricted capital, and redemption queue pressure remain visible in class and allocation ledgers.",
     instructions: [
       "mark_impairment",
+    ],
+  },
+  fee_vault_lifecycle: {
+    title: "Fee Vault Lifecycle",
+    focus:
+      "Phase 1.6/1.7 fee accumulation + withdrawal infrastructure: governance-init fee vaults per rail, accrual hooks on the inflow handlers (premium / deposit / redemption / claim settle), and per-rail-authority withdrawals across SOL and SPL.",
+    instructions: [
+      "init_protocol_fee_vault",
+      "init_pool_treasury_vault",
+      "init_pool_oracle_fee_vault",
+      "withdraw_protocol_fee_sol",
+      "withdraw_protocol_fee_spl",
+      "withdraw_pool_treasury_sol",
+      "withdraw_pool_treasury_spl",
+      "withdraw_pool_oracle_fee_sol",
+      "withdraw_pool_oracle_fee_spl",
     ],
   },
 };

--- a/frontend/components/capital-workbench.tsx
+++ b/frontend/components/capital-workbench.tsx
@@ -5,12 +5,16 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useWallet } from "@solana/wallet-adapter-react";
 
 import {
   CapitalOperatorDrawer,
   type CapitalOperatorSection,
 } from "@/components/capital-operator-drawer";
+import { PoolTreasuryPanel } from "@/components/pool-treasury-panel";
+import { PoolWorkspaceProvider } from "@/components/pool-workspace-context";
 import { useWorkspacePersona } from "@/components/workspace-persona";
+import { deriveWalletCapabilities } from "@/lib/ui-capabilities";
 import { buildCanonicalConsoleStateFromSnapshot } from "@/lib/console-model";
 import { formatAmount } from "@/lib/canonical-ui";
 import { firstSearchParamValue, type RouteSearchParams, toURLSearchParams } from "@/lib/search-params";
@@ -26,7 +30,9 @@ import {
   describeLpQueueStatus,
   hasPendingRedemptionQueue,
   shortenAddress,
+  ZERO_PUBKEY,
 } from "@/lib/protocol";
+import type { ProtocolConfigSummary } from "@/lib/protocol";
 import { cn } from "@/lib/cn";
 
 /* ── Constants ──────────────────────────────────────── */
@@ -71,6 +77,14 @@ const TAB_HEROES: Record<CapitalTabId, TabHero> = {
     emphasis: "Plans.",
     tail: "",
     subtitle: "Plans currently drawing from this reserve.",
+  },
+  treasury: {
+    eyebrow: "Fee treasury",
+    title: "Treasury",
+    emphasis: "Withdrawals.",
+    tail: "",
+    subtitle:
+      "Sweep accrued protocol, pool, and oracle fees once the matching authority is connected.",
   },
 };
 
@@ -180,6 +194,7 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
   const { effectivePersona } = useWorkspacePersona();
   const { snapshot, loading, error, refresh } = useProtocolConsoleSnapshot();
   const consoleState = useMemo(() => buildCanonicalConsoleStateFromSnapshot(snapshot), [snapshot]);
+  const wallet = useWallet();
 
   /* ── Selection state ── */
 
@@ -330,6 +345,75 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
   const hero = TAB_HEROES[activeTab];
   const eyebrow = activeTab === "overview" ? personaEyebrow(effectivePersona) : hero.eyebrow;
 
+  /* ── Treasury-tab capabilities ── */
+  // Phase 1.7 PR4 — minimal capabilities derivation for the treasury tab.
+  // Builds a synthetic ProtocolConfigSummary from the snapshot's
+  // ProtocolGovernance so canManageProtocolConfig (and therefore
+  // canWithdrawProtocolFees) detects the governance-authority wallet without
+  // requiring an extra RPC fetch. PoolSummary has the curator field that
+  // canWithdrawPoolTreasury (per-rail authority) reads. walletOracle is
+  // resolved by matching the wallet against any oracle profile in the snapshot.
+  // walletMembership / walletClaimDelegate / walletCapitalPosition are out of
+  // scope for the treasury tab.
+  const walletAddress = wallet.publicKey?.toBase58() ?? null;
+  const treasuryProtocolConfig = useMemo<ProtocolConfigSummary | null>(() => {
+    const governance = snapshot.protocolGovernance;
+    if (!governance) return null;
+    return {
+      address: governance.address,
+      admin: governance.governanceAuthority,
+      governanceAuthority: governance.governanceAuthority,
+      governanceRealm: ZERO_PUBKEY,
+      governanceConfig: ZERO_PUBKEY,
+      protocolFeeBps: governance.protocolFeeBps,
+      defaultStakeMint: ZERO_PUBKEY,
+      minOracleStake: 0n,
+      emergencyPaused: governance.emergencyPause,
+      allowedPayoutMintsHashHex: "",
+    };
+  }, [snapshot.protocolGovernance]);
+  const treasuryPoolSummary = useMemo(() => {
+    if (!selectedPool) return null;
+    return {
+      address: selectedPool.address,
+      poolId: selectedPool.poolId,
+      displayName: selectedPool.displayName,
+      reserveDomain: selectedPool.reserveDomain,
+      depositAssetMint: selectedPool.depositAssetMint,
+      authority: selectedPool.curator ?? ZERO_PUBKEY,
+      organizationRef: "",
+      active: selectedPool.active,
+    };
+  }, [selectedPool]);
+  const treasuryWalletOracle = useMemo(() => {
+    if (!walletAddress) return null;
+    const profile = snapshot.oracleProfiles.find((entry) => entry.oracle === walletAddress);
+    if (!profile) return null;
+    return {
+      address: profile.address,
+      oracle: profile.oracle,
+      active: profile.active,
+      claimed: profile.claimed,
+      admin: profile.admin,
+      bump: 0,
+      metadataUri: "",
+    };
+  }, [snapshot.oracleProfiles, walletAddress]);
+  const treasuryCapabilities = useMemo(
+    () =>
+      deriveWalletCapabilities({
+        walletAddress,
+        pool: treasuryPoolSummary,
+        protocolConfig: treasuryProtocolConfig,
+        poolControlAuthority: null,
+        walletMembership: null,
+        walletOracle: treasuryWalletOracle,
+        walletClaimDelegate: null,
+        walletCapitalPosition: null,
+      }),
+    [treasuryPoolSummary, treasuryProtocolConfig, treasuryWalletOracle, walletAddress],
+  );
+
   /* ── Operator drawer ── */
 
   const canOperate = OPERATOR_PERSONAS.has(effectivePersona);
@@ -347,6 +431,10 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
     allocations: "allocate",
     queue: "queue",
     "linked-plans": "allocate",
+    // Treasury tab opens the operator drawer's provision section by default;
+    // actual fee withdrawals happen in the embedded PoolTreasuryPanel below
+    // the tab heading, not via the drawer.
+    treasury: "provision",
   };
 
   /* ── Invalid selection guard ── */
@@ -917,6 +1005,20 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
                     />
                   )}
                 </article>
+              ) : null}
+
+              {/* ── TREASURY ── */}
+              {activeTab === "treasury" ? (
+                selectedPool ? (
+                  <PoolWorkspaceProvider capabilities={treasuryCapabilities}>
+                    <PoolTreasuryPanel poolAddress={selectedPool.address} />
+                  </PoolWorkspaceProvider>
+                ) : (
+                  <CapitalEmptyState
+                    title="Select a pool"
+                    copy="Choose a liquidity pool above to inspect its fee treasury rails and (when authorized) sweep accrued protocol, pool, and oracle fees."
+                  />
+                )
               ) : null}
             </section>
 

--- a/frontend/components/pool-treasury-panel.tsx
+++ b/frontend/components/pool-treasury-panel.tsx
@@ -176,6 +176,7 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
         : buildWithdrawPoolTreasurySplTx({
             oracle: publicKey,
             poolAddress: new PublicKey(poolAddress),
+            reserveDomainAddress: new PublicKey(selectedReserve.reserveDomain),
             paymentMint: new PublicKey(selectedReserve.paymentMint),
             recipientTokenAccount: new PublicKey(treasuryRecipientTokenAccount.trim()),
             amount,
@@ -217,12 +218,14 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
       const tx = selectedProtocolFeeVault.paymentMint === ZERO_PUBKEY
         ? buildWithdrawProtocolFeeSolTx({
             governanceAuthority: publicKey,
+            reserveDomainAddress: new PublicKey(selectedProtocolFeeVault.reserveDomain),
             recipientSystemAccount: new PublicKey(protocolFeeRecipient.trim()),
             amount,
             recentBlockhash: blockhash,
           })
         : buildWithdrawProtocolFeeSplTx({
             governanceAuthority: publicKey,
+            reserveDomainAddress: new PublicKey(selectedProtocolFeeVault.reserveDomain),
             paymentMint: new PublicKey(selectedProtocolFeeVault.paymentMint),
             recipientTokenAccount: new PublicKey(protocolFeeRecipientTokenAccount.trim()),
             amount,
@@ -264,6 +267,7 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
       const tx = selectedOracleFeeVault.paymentMint === ZERO_PUBKEY
         ? buildWithdrawPoolOracleFeeSolTx({
             oracle: publicKey,
+            oracleAddress: new PublicKey(selectedOracleFeeVault.oracle),
             poolAddress: new PublicKey(poolAddress),
             recipientSystemAccount: new PublicKey(oracleFeeRecipient.trim()),
             amount,
@@ -271,7 +275,9 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
           })
         : buildWithdrawPoolOracleFeeSplTx({
             oracle: publicKey,
+            oracleAddress: new PublicKey(selectedOracleFeeVault.oracle),
             poolAddress: new PublicKey(poolAddress),
+            reserveDomainAddress: new PublicKey(selectedOracleFeeVault.reserveDomain),
             paymentMint: new PublicKey(selectedOracleFeeVault.paymentMint),
             recipientTokenAccount: new PublicKey(oracleFeeRecipientTokenAccount.trim()),
             amount,

--- a/frontend/lib/generated/protocol-contract.js
+++ b/frontend/lib/generated/protocol-contract.js
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
+// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
 export const PROTOCOL_PROGRAM_ID = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B";
 export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "adjudicate_claim_case": Uint8Array.from([146, 99, 255, 26, 223, 88, 235, 114]),
@@ -53,6 +53,12 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "update_reserve_domain_controls": Uint8Array.from([3, 60, 38, 233, 198, 167, 116, 197]),
     "verify_outcome_schema": Uint8Array.from([221, 10, 144, 137, 106, 214, 205, 170]),
     "version_policy_series": Uint8Array.from([64, 76, 132, 253, 41, 220, 169, 146]),
+    "withdraw_pool_oracle_fee_sol": Uint8Array.from([208, 223, 250, 62, 199, 8, 221, 185]),
+    "withdraw_pool_oracle_fee_spl": Uint8Array.from([242, 75, 247, 122, 255, 183, 48, 189]),
+    "withdraw_pool_treasury_sol": Uint8Array.from([50, 115, 51, 120, 221, 37, 200, 169]),
+    "withdraw_pool_treasury_spl": Uint8Array.from([43, 146, 116, 123, 106, 69, 242, 104]),
+    "withdraw_protocol_fee_sol": Uint8Array.from([193, 33, 140, 185, 45, 190, 112, 7]),
+    "withdraw_protocol_fee_spl": Uint8Array.from([120, 62, 236, 14, 227, 240, 52, 253]),
 };
 export const PROTOCOL_INSTRUCTION_ARGS = {
     "adjudicate_claim_case": [
@@ -204,6 +210,24 @@ export const PROTOCOL_INSTRUCTION_ARGS = {
     ],
     "version_policy_series": [
         { name: "args", type: {"defined":{"name":"VersionPolicySeriesArgs"}} },
+    ],
+    "withdraw_pool_oracle_fee_sol": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+    ],
+    "withdraw_pool_oracle_fee_spl": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+    ],
+    "withdraw_pool_treasury_sol": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+    ],
+    "withdraw_pool_treasury_spl": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+    ],
+    "withdraw_protocol_fee_sol": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+    ],
+    "withdraw_protocol_fee_spl": [
+        { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
     ],
 };
 export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
@@ -664,6 +688,65 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "next_policy_series", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 108, 105, 99, 121, 95, 115, 101, 114, 105, 101, 115] }, { kind: "account", path: "health_plan" }, { kind: "arg", path: "args.series_id" }] },
         { name: "next_series_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [115, 101, 114, 105, 101, 115, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "next_policy_series" }, { kind: "account", path: "current_policy_series.asset_mint" }] },
         { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "withdraw_pool_oracle_fee_sol": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
+        { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+        { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "withdraw_pool_oracle_fee_spl": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
+        { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+        { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+        { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+    ],
+    "withdraw_pool_treasury_sol": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+        { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "withdraw_pool_treasury_spl": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+        { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+        { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+    ],
+    "withdraw_protocol_fee_sol": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+        { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "withdraw_protocol_fee_spl": [
+        { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+        { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+        { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
     ],
 };
 export const PROTOCOL_ACCOUNT_DISCRIMINATORS = {

--- a/frontend/lib/generated/protocol-contract.js
+++ b/frontend/lib/generated/protocol-contract.js
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 768458fc073b448bff1d93767fbc1af813eb71643ebff40f57eb8e355b9c099e
+// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
 export const PROTOCOL_PROGRAM_ID = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B";
 export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "adjudicate_claim_case": Uint8Array.from([146, 99, 255, 26, 223, 88, 235, 114]),
@@ -22,6 +22,9 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "deallocate_capital": Uint8Array.from([10, 97, 97, 189, 60, 170, 102, 29]),
     "deposit_into_capital_class": Uint8Array.from([40, 215, 33, 115, 185, 101, 196, 167]),
     "fund_sponsor_budget": Uint8Array.from([150, 210, 161, 31, 50, 12, 224, 32]),
+    "init_pool_oracle_fee_vault": Uint8Array.from([68, 122, 148, 84, 91, 98, 198, 167]),
+    "init_pool_treasury_vault": Uint8Array.from([96, 169, 51, 224, 0, 207, 141, 47]),
+    "init_protocol_fee_vault": Uint8Array.from([212, 235, 61, 42, 96, 183, 225, 57]),
     "initialize_protocol_governance": Uint8Array.from([220, 188, 231, 198, 20, 71, 42, 123]),
     "mark_impairment": Uint8Array.from([58, 97, 30, 157, 211, 45, 174, 238]),
     "open_claim_case": Uint8Array.from([151, 125, 231, 211, 63, 132, 248, 184]),
@@ -108,6 +111,15 @@ export const PROTOCOL_INSTRUCTION_ARGS = {
     ],
     "fund_sponsor_budget": [
         { name: "args", type: {"defined":{"name":"FundSponsorBudgetArgs"}} },
+    ],
+    "init_pool_oracle_fee_vault": [
+        { name: "args", type: {"defined":{"name":"InitPoolOracleFeeVaultArgs"}} },
+    ],
+    "init_pool_treasury_vault": [
+        { name: "args", type: {"defined":{"name":"InitPoolTreasuryVaultArgs"}} },
+    ],
+    "init_protocol_fee_vault": [
+        { name: "args", type: {"defined":{"name":"InitProtocolFeeVaultArgs"}} },
     ],
     "initialize_protocol_governance": [
         { name: "args", type: {"defined":{"name":"InitializeProtocolGovernanceArgs"}} },
@@ -342,6 +354,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
         { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "owner" }] },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -362,6 +375,32 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+    ],
+    "init_pool_oracle_fee_vault": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "arg", path: "args.oracle" }] },
+        { name: "pool_oracle_approval", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 97, 112, 112, 114, 111, 118, 97, 108] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.oracle" }] },
+        { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.oracle" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "init_pool_treasury_vault": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+        { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "init_protocol_fee_vault": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+        { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
     ],
     "initialize_protocol_governance": [
         { name: "governance_authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
@@ -421,6 +460,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
         { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "lp_position.owner" }] },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -436,6 +476,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "funding_line_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [102, 117, 110, 100, 105, 110, 103, 95, 108, 105, 110, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "funding_line" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "plan_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 108, 97, 110, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "series_reserve_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -538,6 +579,9 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "allocation_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "claim_case", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 108, 97, 105, 109, 95, 99, 97, 115, 101] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "claim_case.claim_id" }] },
         { name: "obligation", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "pool_oracle_policy", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "member_position", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -644,8 +688,11 @@ export const PROTOCOL_ACCOUNT_DISCRIMINATORS = {
     "PolicySeries": Uint8Array.from([196, 117, 121, 249, 37, 71, 245, 23]),
     "PoolClassLedger": Uint8Array.from([147, 125, 17, 88, 188, 78, 109, 204]),
     "PoolOracleApproval": Uint8Array.from([116, 241, 25, 184, 205, 21, 153, 29]),
+    "PoolOracleFeeVault": Uint8Array.from([167, 128, 29, 44, 248, 197, 244, 23]),
     "PoolOraclePermissionSet": Uint8Array.from([3, 136, 243, 231, 172, 143, 123, 245]),
     "PoolOraclePolicy": Uint8Array.from([246, 134, 133, 108, 100, 203, 226, 43]),
+    "PoolTreasuryVault": Uint8Array.from([93, 195, 95, 29, 127, 28, 59, 193]),
+    "ProtocolFeeVault": Uint8Array.from([199, 15, 107, 45, 108, 244, 162, 105]),
     "ProtocolGovernance": Uint8Array.from([71, 235, 253, 251, 202, 254, 132, 177]),
     "ReserveDomain": Uint8Array.from([119, 76, 223, 192, 177, 116, 88, 178]),
     "SchemaDependencyLedger": Uint8Array.from([87, 115, 211, 54, 36, 177, 77, 131]),

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 768458fc073b448bff1d93767fbc1af813eb71643ebff40f57eb8e355b9c099e
+// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
 
 export type ProtocolInstructionName =
   | "adjudicate_claim_case"
@@ -22,6 +22,9 @@ export type ProtocolInstructionName =
   | "deallocate_capital"
   | "deposit_into_capital_class"
   | "fund_sponsor_budget"
+  | "init_pool_oracle_fee_vault"
+  | "init_pool_treasury_vault"
+  | "init_protocol_fee_vault"
   | "initialize_protocol_governance"
   | "mark_impairment"
   | "open_claim_case"
@@ -87,6 +90,9 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS: Record<ProtocolInstructionName
   "deallocate_capital": Uint8Array.from([10, 97, 97, 189, 60, 170, 102, 29]),
   "deposit_into_capital_class": Uint8Array.from([40, 215, 33, 115, 185, 101, 196, 167]),
   "fund_sponsor_budget": Uint8Array.from([150, 210, 161, 31, 50, 12, 224, 32]),
+  "init_pool_oracle_fee_vault": Uint8Array.from([68, 122, 148, 84, 91, 98, 198, 167]),
+  "init_pool_treasury_vault": Uint8Array.from([96, 169, 51, 224, 0, 207, 141, 47]),
+  "init_protocol_fee_vault": Uint8Array.from([212, 235, 61, 42, 96, 183, 225, 57]),
   "initialize_protocol_governance": Uint8Array.from([220, 188, 231, 198, 20, 71, 42, 123]),
   "mark_impairment": Uint8Array.from([58, 97, 30, 157, 211, 45, 174, 238]),
   "open_claim_case": Uint8Array.from([151, 125, 231, 211, 63, 132, 248, 184]),
@@ -174,6 +180,15 @@ export const PROTOCOL_INSTRUCTION_ARGS: Record<ProtocolInstructionName, Protocol
   ],
   "fund_sponsor_budget": [
       { name: "args", type: {"defined":{"name":"FundSponsorBudgetArgs"}} },
+  ],
+  "init_pool_oracle_fee_vault": [
+      { name: "args", type: {"defined":{"name":"InitPoolOracleFeeVaultArgs"}} },
+  ],
+  "init_pool_treasury_vault": [
+      { name: "args", type: {"defined":{"name":"InitPoolTreasuryVaultArgs"}} },
+  ],
+  "init_protocol_fee_vault": [
+      { name: "args", type: {"defined":{"name":"InitProtocolFeeVaultArgs"}} },
   ],
   "initialize_protocol_governance": [
       { name: "args", type: {"defined":{"name":"InitializeProtocolGovernanceArgs"}} },
@@ -409,6 +424,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
       { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "owner" }] },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -429,6 +445,32 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+  ],
+  "init_pool_oracle_fee_vault": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "arg", path: "args.oracle" }] },
+      { name: "pool_oracle_approval", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 97, 112, 112, 114, 111, 118, 97, 108] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.oracle" }] },
+      { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.oracle" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "init_pool_treasury_vault": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "init_protocol_fee_vault": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+      { name: "domain_asset_vault", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
   ],
   "initialize_protocol_governance": [
       { name: "governance_authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
@@ -488,6 +530,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
       { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "lp_position.owner" }] },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -503,6 +546,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "funding_line_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [102, 117, 110, 100, 105, 110, 103, 95, 108, 105, 110, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "funding_line" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "plan_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 108, 97, 110, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "series_reserve_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -605,6 +649,9 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "allocation_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "claim_case", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 108, 97, 105, 109, 95, 99, 97, 115, 101] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "claim_case.claim_id" }] },
       { name: "obligation", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "pool_oracle_policy", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "member_position", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -712,8 +759,11 @@ export const PROTOCOL_ACCOUNT_DISCRIMINATORS: Record<string, Uint8Array> = {
   "PolicySeries": Uint8Array.from([196, 117, 121, 249, 37, 71, 245, 23]),
   "PoolClassLedger": Uint8Array.from([147, 125, 17, 88, 188, 78, 109, 204]),
   "PoolOracleApproval": Uint8Array.from([116, 241, 25, 184, 205, 21, 153, 29]),
+  "PoolOracleFeeVault": Uint8Array.from([167, 128, 29, 44, 248, 197, 244, 23]),
   "PoolOraclePermissionSet": Uint8Array.from([3, 136, 243, 231, 172, 143, 123, 245]),
   "PoolOraclePolicy": Uint8Array.from([246, 134, 133, 108, 100, 203, 226, 43]),
+  "PoolTreasuryVault": Uint8Array.from([93, 195, 95, 29, 127, 28, 59, 193]),
+  "ProtocolFeeVault": Uint8Array.from([199, 15, 107, 45, 108, 244, 162, 105]),
   "ProtocolGovernance": Uint8Array.from([71, 235, 253, 251, 202, 254, 132, 177]),
   "ReserveDomain": Uint8Array.from([119, 76, 223, 192, 177, 116, 88, 178]),
   "SchemaDependencyLedger": Uint8Array.from([87, 115, 211, 54, 36, 177, 77, 131]),

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 781c80fc8fe60497e37d904af964bdcff006468aabd6bb4dcb4255d971307fd6
+// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
 
 export type ProtocolInstructionName =
   | "adjudicate_claim_case"
@@ -52,7 +52,13 @@ export type ProtocolInstructionName =
   | "update_oracle_profile"
   | "update_reserve_domain_controls"
   | "verify_outcome_schema"
-  | "version_policy_series";
+  | "version_policy_series"
+  | "withdraw_pool_oracle_fee_sol"
+  | "withdraw_pool_oracle_fee_spl"
+  | "withdraw_pool_treasury_sol"
+  | "withdraw_pool_treasury_spl"
+  | "withdraw_protocol_fee_sol"
+  | "withdraw_protocol_fee_spl";
 
 export type ProtocolInstructionArg = {
   name: string;
@@ -121,6 +127,12 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS: Record<ProtocolInstructionName
   "update_reserve_domain_controls": Uint8Array.from([3, 60, 38, 233, 198, 167, 116, 197]),
   "verify_outcome_schema": Uint8Array.from([221, 10, 144, 137, 106, 214, 205, 170]),
   "version_policy_series": Uint8Array.from([64, 76, 132, 253, 41, 220, 169, 146]),
+  "withdraw_pool_oracle_fee_sol": Uint8Array.from([208, 223, 250, 62, 199, 8, 221, 185]),
+  "withdraw_pool_oracle_fee_spl": Uint8Array.from([242, 75, 247, 122, 255, 183, 48, 189]),
+  "withdraw_pool_treasury_sol": Uint8Array.from([50, 115, 51, 120, 221, 37, 200, 169]),
+  "withdraw_pool_treasury_spl": Uint8Array.from([43, 146, 116, 123, 106, 69, 242, 104]),
+  "withdraw_protocol_fee_sol": Uint8Array.from([193, 33, 140, 185, 45, 190, 112, 7]),
+  "withdraw_protocol_fee_spl": Uint8Array.from([120, 62, 236, 14, 227, 240, 52, 253]),
 };
 
 export const PROTOCOL_INSTRUCTION_ARGS: Record<ProtocolInstructionName, ProtocolInstructionArg[]> = {
@@ -273,6 +285,24 @@ export const PROTOCOL_INSTRUCTION_ARGS: Record<ProtocolInstructionName, Protocol
   ],
   "version_policy_series": [
       { name: "args", type: {"defined":{"name":"VersionPolicySeriesArgs"}} },
+  ],
+  "withdraw_pool_oracle_fee_sol": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+  ],
+  "withdraw_pool_oracle_fee_spl": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+  ],
+  "withdraw_pool_treasury_sol": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+  ],
+  "withdraw_pool_treasury_spl": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+  ],
+  "withdraw_protocol_fee_sol": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
+  ],
+  "withdraw_protocol_fee_spl": [
+      { name: "args", type: {"defined":{"name":"WithdrawArgs"}} },
   ],
 };
 
@@ -734,6 +764,65 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "next_policy_series", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 108, 105, 99, 121, 95, 115, 101, 114, 105, 101, 115] }, { kind: "account", path: "health_plan" }, { kind: "arg", path: "args.series_id" }] },
       { name: "next_series_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [115, 101, 114, 105, 101, 115, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "next_policy_series" }, { kind: "account", path: "current_policy_series.asset_mint" }] },
       { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "withdraw_pool_oracle_fee_sol": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
+      { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+      { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "withdraw_pool_oracle_fee_spl": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
+      { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+      { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+      { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+  ],
+  "withdraw_pool_treasury_sol": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+      { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "withdraw_pool_treasury_spl": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+      { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+      { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+  ],
+  "withdraw_protocol_fee_sol": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+      { name: "recipient", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "withdraw_protocol_fee_spl": [
+      { name: "authority", writable: false, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+      { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+      { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "token_program", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
   ],
 };
 

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -29,6 +29,17 @@ const PROGRAM_ID = new PublicKey(PROTOCOL_PROGRAM_ID);
 
 export const ZERO_PUBKEY = "11111111111111111111111111111111";
 export const ZERO_PUBKEY_KEY = new PublicKey(ZERO_PUBKEY);
+
+// Phase 1.7 — wrapped-SOL mint sentinel mirrors the on-chain `NATIVE_SOL_MINT`
+// constant in `programs/omegax_protocol/src/lib.rs`. SOL-rail fee vaults use
+// this as their `asset_mint` so the on-chain seeds and rail-mismatch guards
+// can distinguish lamport accounting from SPL accounting. The pool-treasury
+// panel UI surfaces SOL rails as `paymentMint === ZERO_PUBKEY` (a UI-friendly
+// sentinel that doesn't depend on the WSOL mint magic string); listers map
+// `vault.asset_mint == NATIVE_SOL_MINT` to `paymentMint = ZERO_PUBKEY` in the
+// returned summaries.
+export const NATIVE_SOL_MINT = "So11111111111111111111111111111111111111112";
+export const NATIVE_SOL_MINT_KEY = new PublicKey(NATIVE_SOL_MINT);
 export const MAX_ID_SEED_BYTES = 32;
 
 export const SEED_PROTOCOL_GOVERNANCE = "protocol_governance";
@@ -36,6 +47,9 @@ export const SEED_RESERVE_DOMAIN = "reserve_domain";
 export const SEED_DOMAIN_ASSET_VAULT = "domain_asset_vault";
 export const SEED_DOMAIN_ASSET_VAULT_TOKEN = "domain_asset_vault_token";
 export const SEED_DOMAIN_ASSET_LEDGER = "domain_asset_ledger";
+export const SEED_PROTOCOL_FEE_VAULT = "protocol_fee_vault";
+export const SEED_POOL_TREASURY_VAULT = "pool_treasury_vault";
+export const SEED_POOL_ORACLE_FEE_VAULT = "pool_oracle_fee_vault";
 export const SEED_HEALTH_PLAN = "health_plan";
 export const SEED_PLAN_RESERVE_LEDGER = "plan_reserve_ledger";
 export const SEED_POLICY_SERIES = "policy_series";
@@ -213,6 +227,37 @@ export type DomainAssetVaultSnapshot = {
   assetMint: string;
   vaultTokenAccount: string;
   totalAssets: BigNumberish;
+  bump: number;
+};
+
+// Phase 1.6/1.7 — Fee-vault snapshot types. The panel surfaces SOL rails
+// as `paymentMint === ZERO_PUBKEY`; the listers below translate
+// `assetMint === NATIVE_SOL_MINT` to that UI sentinel.
+export type ProtocolFeeVaultSnapshot = {
+  address: string;
+  reserveDomain: string;
+  assetMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
+  bump: number;
+};
+
+export type PoolTreasuryVaultSnapshot = {
+  address: string;
+  liquidityPool: string;
+  assetMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
+  bump: number;
+};
+
+export type PoolOracleFeeVaultSnapshot = {
+  address: string;
+  liquidityPool: string;
+  oracle: string;
+  assetMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
   bump: number;
 };
 
@@ -542,6 +587,9 @@ export type ProtocolConsoleSnapshot = {
   outcomeSchemas: OutcomeSchemaSnapshot[];
   schemaDependencyLedgers: SchemaDependencyLedgerSnapshot[];
   claimAttestations: ClaimAttestationSnapshot[];
+  protocolFeeVaults: ProtocolFeeVaultSnapshot[];
+  poolTreasuryVaults: PoolTreasuryVaultSnapshot[];
+  poolOracleFeeVaults: PoolOracleFeeVaultSnapshot[];
 };
 
 export type SponsorReadModel = {
@@ -636,6 +684,67 @@ export type PoolOracleApprovalSummary = PoolOracleApprovalSnapshot;
 export type PoolOraclePolicySummary = PoolOraclePolicySnapshot;
 
 export type PoolOraclePermissionSetSummary = PoolOraclePermissionSetSnapshot;
+
+// Phase 1.6/1.7 — Fee-vault summaries surfaced to the pool-treasury panel.
+//
+// `paymentMint` is the panel's UI sentinel: SOL rails expose
+// `paymentMint === ZERO_PUBKEY` (the all-zeros system program key, not the
+// real wrapped-SOL mint). Listers translate the on-chain
+// `assetMint === NATIVE_SOL_MINT` to that sentinel so the panel's
+// `paymentMint === ZERO_PUBKEY ? sol : spl` switching code can stay simple.
+//
+// `availableFees = accruedFees - withdrawnFees` is the safe withdrawable
+// headroom; computed via saturating subtraction so a misordered chain read
+// (e.g., withdrawn briefly leading accrued during indexing) doesn't surface
+// as a bigint underflow in the UI.
+
+export type ProtocolFeeVaultSummary = {
+  address: string;
+  reserveDomain: string;
+  /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
+  paymentMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
+  availableFees: bigint;
+  bump: number;
+};
+
+export type PoolTreasuryReserveSummary = {
+  address: string;
+  /** Pool the treasury vault is scoped to. */
+  pool: string;
+  reserveDomain: string;
+  /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
+  paymentMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
+  availableFees: bigint;
+  // Display-only ledger counters surfaced by the panel. The on-chain
+  // PoolTreasuryVault tracks only accrued/withdrawn fees — these aliases
+  // are populated by joining DomainAssetLedger / PolicySeries / Obligation
+  // sums in a follow-up. PR3 ships them as 0n placeholders so the panel
+  // renders zeros without crashing; they are NOT used for any withdrawal
+  // safety check (only `availableFees` gates the panel).
+  reservedRewardAmount: bigint;
+  reservedCoverageClaimAmount: bigint;
+  paidCoverageClaimAmount: bigint;
+  impairedAmount: bigint;
+  bump: number;
+};
+
+export type PoolOracleFeeVaultSummary = {
+  address: string;
+  /** Pool the oracle-fee vault is scoped to. */
+  pool: string;
+  /** Registered oracle wallet receiving the fee accruals. */
+  oracle: string;
+  /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
+  paymentMint: string;
+  accruedFees: bigint;
+  withdrawnFees: bigint;
+  availableFees: bigint;
+  bump: number;
+};
 
 export type SchemaSummary = OutcomeSchemaSnapshot;
 
@@ -788,6 +897,59 @@ export function deriveDomainAssetLedgerPda(params: {
     [
       TEXT_ENCODER.encode(SEED_DOMAIN_ASSET_LEDGER),
       toPublicKey(params.reserveDomain).toBytes(),
+      toPublicKey(params.assetMint).toBytes(),
+    ],
+    params.programId ?? PROGRAM_ID,
+  );
+}
+
+// Phase 1.6/1.7 — Fee-vault PDA derivers. SPL rails pass `assetMint = the
+// SPL mint pubkey`; SOL rails pass `assetMint = NATIVE_SOL_MINT_KEY` (the
+// canonical wrapped-SOL mint). The on-chain seeds are identical for both
+// rails — the rail is selected at withdraw time by which asset_mint the
+// vault was initialized with.
+
+export function deriveProtocolFeeVaultPda(params: {
+  reserveDomain: PublicKeyish;
+  assetMint: PublicKeyish;
+  programId?: PublicKey;
+}): PublicKey {
+  return derivePda(
+    [
+      TEXT_ENCODER.encode(SEED_PROTOCOL_FEE_VAULT),
+      toPublicKey(params.reserveDomain).toBytes(),
+      toPublicKey(params.assetMint).toBytes(),
+    ],
+    params.programId ?? PROGRAM_ID,
+  );
+}
+
+export function derivePoolTreasuryVaultPda(params: {
+  liquidityPool: PublicKeyish;
+  assetMint: PublicKeyish;
+  programId?: PublicKey;
+}): PublicKey {
+  return derivePda(
+    [
+      TEXT_ENCODER.encode(SEED_POOL_TREASURY_VAULT),
+      toPublicKey(params.liquidityPool).toBytes(),
+      toPublicKey(params.assetMint).toBytes(),
+    ],
+    params.programId ?? PROGRAM_ID,
+  );
+}
+
+export function derivePoolOracleFeeVaultPda(params: {
+  liquidityPool: PublicKeyish;
+  oracle: PublicKeyish;
+  assetMint: PublicKeyish;
+  programId?: PublicKey;
+}): PublicKey {
+  return derivePda(
+    [
+      TEXT_ENCODER.encode(SEED_POOL_ORACLE_FEE_VAULT),
+      toPublicKey(params.liquidityPool).toBytes(),
+      toPublicKey(params.oracle).toBytes(),
       toPublicKey(params.assetMint).toBytes(),
     ],
     params.programId ?? PROGRAM_ID,
@@ -1778,6 +1940,9 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
     outcomeSchemas: [],
     schemaDependencyLedgers: [],
     claimAttestations: [],
+    protocolFeeVaults: [],
+    poolTreasuryVaults: [],
+    poolOracleFeeVaults: [],
   };
 
   const planLedgersRaw: Array<{ address: string; healthPlan: string; assetMint: string; sheet: unknown }> = [];
@@ -1823,6 +1988,37 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           assetMint: asAddress(decodedField(decoded, "assetMint")),
           vaultTokenAccount: asAddress(decodedField(decoded, "vaultTokenAccount")),
           totalAssets: bigintFromAnchorValue(decodedField(decoded, "totalAssets")),
+          bump: Number(decodedField(decoded, "bump") ?? 0),
+        });
+        break;
+      case "ProtocolFeeVault":
+        snapshot.protocolFeeVaults.push({
+          address,
+          reserveDomain: asAddress(decodedField(decoded, "reserveDomain")),
+          assetMint: asAddress(decodedField(decoded, "assetMint")),
+          accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
+          withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
+          bump: Number(decodedField(decoded, "bump") ?? 0),
+        });
+        break;
+      case "PoolTreasuryVault":
+        snapshot.poolTreasuryVaults.push({
+          address,
+          liquidityPool: asAddress(decodedField(decoded, "liquidityPool")),
+          assetMint: asAddress(decodedField(decoded, "assetMint")),
+          accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
+          withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
+          bump: Number(decodedField(decoded, "bump") ?? 0),
+        });
+        break;
+      case "PoolOracleFeeVault":
+        snapshot.poolOracleFeeVaults.push({
+          address,
+          liquidityPool: asAddress(decodedField(decoded, "liquidityPool")),
+          oracle: asAddress(decodedField(decoded, "oracle")),
+          assetMint: asAddress(decodedField(decoded, "assetMint")),
+          accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
+          withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
           bump: Number(decodedField(decoded, "bump") ?? 0),
         });
         break;
@@ -2618,6 +2814,95 @@ export async function listPoolOracleApprovals(params: {
   );
 }
 
+// Phase 1.6/1.7 — Fee-vault listers. All three follow the snapshot-derived
+// pattern (one chain read in `loadProtocolConsoleSnapshot`, then in-memory
+// filtering). `paymentMint` is mapped: NATIVE_SOL_MINT → ZERO_PUBKEY for the
+// panel's SOL detection; everything else passes through verbatim.
+
+function paymentMintForUi(assetMint: string): string {
+  return assetMint === NATIVE_SOL_MINT ? ZERO_PUBKEY : assetMint;
+}
+
+function feeVaultAvailable(accrued: bigint, withdrawn: bigint): bigint {
+  // Saturating sub: defends against a transient indexing race where the
+  // chain reads `withdrawn > accrued` momentarily.
+  return withdrawn >= accrued ? 0n : accrued - withdrawn;
+}
+
+export async function listProtocolFeeVaults(params: {
+  connection: Connection;
+  reserveDomainAddress?: string | null;
+  paymentMint?: string | null;
+}): Promise<ProtocolFeeVaultSummary[]> {
+  const snapshot = await loadProtocolConsoleSnapshot(params.connection);
+  return snapshot.protocolFeeVaults
+    .filter((vault) => !params.reserveDomainAddress || vault.reserveDomain === params.reserveDomainAddress)
+    .filter((vault) => !params.paymentMint || paymentMintForUi(vault.assetMint) === params.paymentMint)
+    .map((vault) => ({
+      address: vault.address,
+      reserveDomain: vault.reserveDomain,
+      paymentMint: paymentMintForUi(vault.assetMint),
+      accruedFees: vault.accruedFees,
+      withdrawnFees: vault.withdrawnFees,
+      availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
+      bump: vault.bump,
+    }));
+}
+
+export async function listPoolTreasuryReserves(params: {
+  connection: Connection;
+  poolAddress: string;
+  paymentMint?: string | null;
+}): Promise<PoolTreasuryReserveSummary[]> {
+  const snapshot = await loadProtocolConsoleSnapshot(params.connection);
+  // Resolve reserve domain for each pool by joining with the pool snapshot.
+  const poolByAddress = new Map(snapshot.liquidityPools.map((pool) => [pool.address, pool]));
+  return snapshot.poolTreasuryVaults
+    .filter((vault) => vault.liquidityPool === params.poolAddress)
+    .filter((vault) => !params.paymentMint || paymentMintForUi(vault.assetMint) === params.paymentMint)
+    .map((vault) => ({
+      address: vault.address,
+      pool: vault.liquidityPool,
+      reserveDomain: poolByAddress.get(vault.liquidityPool)?.reserveDomain ?? ZERO_PUBKEY,
+      paymentMint: paymentMintForUi(vault.assetMint),
+      accruedFees: vault.accruedFees,
+      withdrawnFees: vault.withdrawnFees,
+      availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
+      // TODO (PR3 follow-up): populate by joining DomainAssetLedger sheets
+      // for the matching (reserve_domain, asset_mint) so the panel's display
+      // counters match the on-chain ledger. The panel renders these read-only
+      // and PR3 ships them as 0n so the UI doesn't crash.
+      reservedRewardAmount: 0n,
+      reservedCoverageClaimAmount: 0n,
+      paidCoverageClaimAmount: 0n,
+      impairedAmount: 0n,
+      bump: vault.bump,
+    }));
+}
+
+export async function listPoolOracleFeeVaults(params: {
+  connection: Connection;
+  poolAddress: string;
+  oracleAddress?: string | null;
+  paymentMint?: string | null;
+}): Promise<PoolOracleFeeVaultSummary[]> {
+  const snapshot = await loadProtocolConsoleSnapshot(params.connection);
+  return snapshot.poolOracleFeeVaults
+    .filter((vault) => vault.liquidityPool === params.poolAddress)
+    .filter((vault) => !params.oracleAddress || vault.oracle === params.oracleAddress)
+    .filter((vault) => !params.paymentMint || paymentMintForUi(vault.assetMint) === params.paymentMint)
+    .map((vault) => ({
+      address: vault.address,
+      pool: vault.liquidityPool,
+      oracle: vault.oracle,
+      paymentMint: paymentMintForUi(vault.assetMint),
+      accruedFees: vault.accruedFees,
+      withdrawnFees: vault.withdrawnFees,
+      availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
+      bump: vault.bump,
+    }));
+}
+
 export async function listPoolOraclePolicies(params: {
   connection: Connection;
   poolAddress?: string | null;
@@ -3055,6 +3340,281 @@ export function buildSetProtocolEmergencyPauseTx(params: {
     accounts: [
       { pubkey: authority, isSigner: true },
       { pubkey: deriveProtocolGovernancePda(), isWritable: true },
+    ],
+  });
+}
+
+// Phase 1.6/1.7 — Fee-vault withdrawal builders.
+//
+// Six builders mirror the on-chain instruction matrix (SOL + SPL × 3 rails).
+// Each takes the per-rail authority as the signer + fee payer, plus the
+// rail-scope identifier (reserve_domain / liquidity_pool / oracle), the
+// payment mint, the recipient, and the amount.
+//
+// Per-rail authority (enforced on-chain by PR2):
+//   - withdraw_protocol_fee_*       → governance authority
+//   - withdraw_pool_treasury_*      → pool curator OR governance
+//   - withdraw_pool_oracle_fee_*    → oracle wallet OR oracle admin OR governance
+//
+// The pool-treasury panel calls these builders with `oracle: publicKey`
+// (the connected wallet) for treasury+oracle-fee flows. That naming is a
+// vestige of the panel's first draft; semantically the param is the rail's
+// authority signer. Tests should use the builders with whichever wallet
+// matches the on-chain authority requirement above.
+//
+// SPL builders need `reserveDomainAddress` to derive the matching
+// `DomainAssetVault` (where SPL fee tokens physically reside). SOL builders
+// don't reference DomainAssetVault — lamports come straight off the
+// fee-vault PDA via `transfer_lamports_from_fee_vault`.
+
+export function buildWithdrawProtocolFeeSplTx(params: {
+  governanceAuthority: PublicKeyish;
+  reserveDomainAddress: PublicKeyish;
+  paymentMint: PublicKeyish;
+  recipientTokenAccount: PublicKeyish;
+  amount: bigint;
+  tokenProgramId?: PublicKeyish | null;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.governanceAuthority);
+  const reserveDomain = toPublicKey(params.reserveDomainAddress);
+  const assetMint = toPublicKey(params.paymentMint);
+  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_protocol_fee_spl",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: reserveDomain },
+      {
+        pubkey: deriveProtocolFeeVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: assetMint },
+      {
+        pubkey: deriveDomainAssetVaultTokenAccountPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientTokenAccount, isWritable: true },
+      { pubkey: tokenProgramId },
+    ],
+  });
+}
+
+export function buildWithdrawProtocolFeeSolTx(params: {
+  governanceAuthority: PublicKeyish;
+  reserveDomainAddress: PublicKeyish;
+  recipientSystemAccount: PublicKeyish;
+  amount: bigint;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.governanceAuthority);
+  const reserveDomain = toPublicKey(params.reserveDomainAddress);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_protocol_fee_sol",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: reserveDomain },
+      {
+        pubkey: deriveProtocolFeeVaultPda({
+          reserveDomain,
+          assetMint: NATIVE_SOL_MINT_KEY,
+        }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientSystemAccount, isWritable: true },
+      { pubkey: SystemProgram.programId },
+    ],
+  });
+}
+
+export function buildWithdrawPoolTreasurySplTx(params: {
+  /** Pool authority signer (curator or governance). Named `oracle` historically
+   *  to match the dead pool-treasury-panel first draft; semantically this is
+   *  the rail authority, not the registered oracle wallet. */
+  oracle: PublicKeyish;
+  poolAddress: PublicKeyish;
+  reserveDomainAddress: PublicKeyish;
+  paymentMint: PublicKeyish;
+  recipientTokenAccount: PublicKeyish;
+  amount: bigint;
+  tokenProgramId?: PublicKeyish | null;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.oracle);
+  const pool = toPublicKey(params.poolAddress);
+  const reserveDomain = toPublicKey(params.reserveDomainAddress);
+  const assetMint = toPublicKey(params.paymentMint);
+  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_pool_treasury_spl",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: pool },
+      {
+        pubkey: derivePoolTreasuryVaultPda({ liquidityPool: pool, assetMint }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: assetMint },
+      {
+        pubkey: deriveDomainAssetVaultTokenAccountPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientTokenAccount, isWritable: true },
+      { pubkey: tokenProgramId },
+    ],
+  });
+}
+
+export function buildWithdrawPoolTreasurySolTx(params: {
+  /** Pool authority signer; see naming note on the SPL variant. */
+  oracle: PublicKeyish;
+  poolAddress: PublicKeyish;
+  recipientSystemAccount: PublicKeyish;
+  amount: bigint;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.oracle);
+  const pool = toPublicKey(params.poolAddress);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_pool_treasury_sol",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: pool },
+      {
+        pubkey: derivePoolTreasuryVaultPda({
+          liquidityPool: pool,
+          assetMint: NATIVE_SOL_MINT_KEY,
+        }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientSystemAccount, isWritable: true },
+      { pubkey: SystemProgram.programId },
+    ],
+  });
+}
+
+export function buildWithdrawPoolOracleFeeSplTx(params: {
+  /** Oracle authority signer (oracle wallet, oracle admin, or governance).
+   *  By default this also identifies the registered oracle whose vault is
+   *  being drained — pass `oracleAddress` separately if the signer is an
+   *  admin/governance rather than the oracle wallet itself. */
+  oracle: PublicKeyish;
+  oracleAddress?: PublicKeyish;
+  poolAddress: PublicKeyish;
+  reserveDomainAddress: PublicKeyish;
+  paymentMint: PublicKeyish;
+  recipientTokenAccount: PublicKeyish;
+  amount: bigint;
+  tokenProgramId?: PublicKeyish | null;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.oracle);
+  const oracleKey = toPublicKey(params.oracleAddress ?? params.oracle);
+  const pool = toPublicKey(params.poolAddress);
+  const reserveDomain = toPublicKey(params.reserveDomainAddress);
+  const assetMint = toPublicKey(params.paymentMint);
+  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_pool_oracle_fee_spl",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: pool },
+      { pubkey: deriveOracleProfilePda({ oracle: oracleKey }) },
+      {
+        pubkey: derivePoolOracleFeeVaultPda({
+          liquidityPool: pool,
+          oracle: oracleKey,
+          assetMint,
+        }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: assetMint },
+      {
+        pubkey: deriveDomainAssetVaultTokenAccountPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientTokenAccount, isWritable: true },
+      { pubkey: tokenProgramId },
+    ],
+  });
+}
+
+export function buildWithdrawPoolOracleFeeSolTx(params: {
+  /** Oracle authority signer; see naming note on the SPL variant. */
+  oracle: PublicKeyish;
+  oracleAddress?: PublicKeyish;
+  poolAddress: PublicKeyish;
+  recipientSystemAccount: PublicKeyish;
+  amount: bigint;
+  recentBlockhash: string;
+}): Transaction {
+  const authority = toPublicKey(params.oracle);
+  const oracleKey = toPublicKey(params.oracleAddress ?? params.oracle);
+  const pool = toPublicKey(params.poolAddress);
+  return buildProtocolTransactionFromInstruction({
+    feePayer: authority,
+    recentBlockhash: params.recentBlockhash,
+    instructionName: "withdraw_pool_oracle_fee_sol",
+    args: {
+      amount: params.amount,
+    },
+    accounts: [
+      { pubkey: authority, isSigner: true },
+      { pubkey: deriveProtocolGovernancePda() },
+      { pubkey: pool },
+      { pubkey: deriveOracleProfilePda({ oracle: oracleKey }) },
+      {
+        pubkey: derivePoolOracleFeeVaultPda({
+          liquidityPool: pool,
+          oracle: oracleKey,
+          assetMint: NATIVE_SOL_MINT_KEY,
+        }),
+        isWritable: true,
+      },
+      { pubkey: params.recipientSystemAccount, isWritable: true },
+      { pubkey: SystemProgram.programId },
     ],
   });
 }

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -736,6 +736,9 @@ export type PoolOracleFeeVaultSummary = {
   address: string;
   /** Pool the oracle-fee vault is scoped to. */
   pool: string;
+  /** Reserve domain (joined via the pool's `liquidityPool.reserveDomain`).
+   *  Required by SPL withdraw builders to derive the matching DomainAssetVault. */
+  reserveDomain: string;
   /** Registered oracle wallet receiving the fee accruals. */
   oracle: string;
   /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
@@ -783,6 +786,51 @@ export type RuleSummary = {
   enabled: boolean;
   policySeries: string;
   healthPlan: string;
+};
+
+// Phase 1.7 PR4 — Stub summary types referenced by lib/ui-capabilities.ts.
+// These were imported there before the file was added to the typecheck graph;
+// adding minimal shapes here lets ui-capabilities compile without a separate
+// migration. They preserve the structural contract of the field accesses
+// already in ui-capabilities (`walletClaimDelegate?.active`, etc.) — wider
+// definitions land in a follow-up that wires the actual data sources.
+
+export type ClaimDelegateAuthorizationSummary = {
+  active: boolean;
+  delegate: string;
+};
+
+export type CoverageClaimSummary = {
+  address: string;
+};
+
+export type MembershipSummary = {
+  address: string;
+  member: string;
+  status?: string;
+};
+
+export type OutcomeAggregateSummary = {
+  address: string;
+  passed?: boolean;
+  claimed?: boolean;
+};
+
+export type PoolControlAuthoritySummary = {
+  operatorAuthority?: string;
+  riskManagerAuthority?: string;
+  complianceAuthority?: string;
+  guardianAuthority?: string;
+};
+
+export type PoolRedemptionRequestSummary = {
+  address: string;
+};
+
+export type WalletPoolPositionSummary = {
+  capitalPositionActive: boolean;
+  pendingRedemptionRequestCount: number;
+  pendingCoverageClaimCount: number;
 };
 
 export function getProgramId(): PublicKey {
@@ -2727,6 +2775,8 @@ function mapPoolSummary(
 
 export type ProtocolReadiness = {
   protocolConfigExists: boolean;
+  /** Alias of protocolConfigExists for legacy ui-capabilities call sites. */
+  configInitialized?: boolean;
   poolExists: boolean;
   oracleRegistered: boolean;
   oracleProfileExists: boolean;
@@ -2887,6 +2937,7 @@ export async function listPoolOracleFeeVaults(params: {
   paymentMint?: string | null;
 }): Promise<PoolOracleFeeVaultSummary[]> {
   const snapshot = await loadProtocolConsoleSnapshot(params.connection);
+  const poolByAddress = new Map(snapshot.liquidityPools.map((pool) => [pool.address, pool]));
   return snapshot.poolOracleFeeVaults
     .filter((vault) => vault.liquidityPool === params.poolAddress)
     .filter((vault) => !params.oracleAddress || vault.oracle === params.oracleAddress)
@@ -2894,6 +2945,7 @@ export async function listPoolOracleFeeVaults(params: {
     .map((vault) => ({
       address: vault.address,
       pool: vault.liquidityPool,
+      reserveDomain: poolByAddress.get(vault.liquidityPool)?.reserveDomain ?? ZERO_PUBKEY,
       oracle: vault.oracle,
       paymentMint: paymentMintForUi(vault.assetMint),
       accruedFees: vault.accruedFees,

--- a/frontend/lib/ui-capabilities.ts
+++ b/frontend/lib/ui-capabilities.ts
@@ -498,9 +498,17 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
     canSettleCycles: isRegisteredOracle,
     canOpenDisputes,
     canResolveDisputes: canManageProtocolConfig,
-    canWithdrawPoolTreasury: isRegisteredOracle,
+    // Phase 1.7 — Per-rail authority for the on-chain withdraw_*_fee_* ix:
+    //   protocol_fee  → governance authority (require_governance)
+    //   pool_treasury → pool curator OR governance (require_curator_control)
+    //   pool_oracle   → registered oracle OR oracle admin OR governance
+    //                   (require_oracle_profile_control)
+    // Pool treasury was previously gated on isRegisteredOracle by mistake;
+    // now matches the on-chain require_curator_control. The UI hint surfaces
+    // disabled/enabled state before the chain rejects.
+    canWithdrawPoolTreasury: isPoolAuthority || isPoolOperator || canManageProtocolConfig,
     canWithdrawProtocolFees: canManageProtocolConfig,
-    canWithdrawOracleFees: isRegisteredOracle,
+    canWithdrawOracleFees: isRegisteredOracle || canManageProtocolConfig,
     canOperateOwnedRedemptionQueue,
     canOperateQueueAsOperator,
     canUseExpertTools:

--- a/frontend/lib/use-protocol-console-snapshot.ts
+++ b/frontend/lib/use-protocol-console-snapshot.ts
@@ -38,6 +38,9 @@ const EMPTY_PROTOCOL_CONSOLE_SNAPSHOT: ProtocolConsoleSnapshot = {
   outcomeSchemas: [],
   schemaDependencyLedgers: [],
   claimAttestations: [],
+  protocolFeeVaults: [],
+  poolTreasuryVaults: [],
+  poolOracleFeeVaults: [],
 };
 
 export function useProtocolConsoleSnapshot() {

--- a/frontend/lib/workbench.ts
+++ b/frontend/lib/workbench.ts
@@ -62,6 +62,7 @@ export const CAPITAL_TABS = [
   { id: "allocations", label: "Allocations" },
   { id: "queue", label: "Queue" },
   { id: "linked-plans", label: "Linked plans" },
+  { id: "treasury", label: "Treasury" },
 ] as const satisfies readonly WorkbenchTab[];
 
 export const GOVERNANCE_TABS = [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -36,9 +36,14 @@
     "next-env.d.ts",
     "app/**/*.ts",
     "app/**/*.tsx",
+    "components/capital-workbench.tsx",
+    "components/pool-treasury-panel.tsx",
+    "components/pool-workspace-context.tsx",
     "lib/console-model.ts",
     "lib/devnet-fixtures.ts",
     "lib/protocol.ts",
+    "lib/ui-capabilities.ts",
+    "lib/use-protocol-console-snapshot.ts",
     "lib/generated/**/*.ts",
     ".next/types/**/*.ts",
     ".next-dev-*/types/**/*.ts",
@@ -51,14 +56,6 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "components/**/*",
-    "lib/cycle-quote.ts",
-    "lib/governance.ts",
-    "lib/pool-defi-metrics.ts",
-    "lib/protocol-action.ts",
-    "lib/protocol-workspace-mappers.ts",
-    "lib/schema-metadata.ts",
-    "lib/ui-capabilities.ts"
+    "node_modules"
   ]
 }

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -9584,6 +9584,1107 @@
           }
         }
       ]
+    },
+    {
+      "name": "withdraw_pool_oracle_fee_sol",
+      "docs": [
+        "Sweep accrued pool-oracle fees (SOL rail) to a recipient system account.",
+        "Authority: registered oracle wallet OR oracle profile admin OR governance."
+      ],
+      "discriminator": [
+        208,
+        223,
+        250,
+        62,
+        199,
+        8,
+        221,
+        185
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "oracle_profile.oracle",
+                "account": "OracleProfile"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.oracle",
+                "account": "PoolOracleFeeVault"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_oracle_fee_spl",
+      "docs": [
+        "Sweep accrued pool-oracle fees (SPL rail) to a recipient ATA.",
+        "Authority: registered oracle wallet OR oracle profile admin OR governance."
+      ],
+      "discriminator": [
+        242,
+        75,
+        247,
+        122,
+        255,
+        183,
+        48,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "oracle_profile.oracle",
+                "account": "OracleProfile"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.oracle",
+                "account": "PoolOracleFeeVault"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint"
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_treasury_sol",
+      "docs": [
+        "Sweep accrued pool-treasury fees (SOL rail).",
+        "Authority: pool curator OR governance."
+      ],
+      "discriminator": [
+        50,
+        115,
+        51,
+        120,
+        221,
+        37,
+        200,
+        169
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_treasury_spl",
+      "docs": [
+        "Sweep accrued pool-treasury fees (SPL rail).",
+        "Authority: pool curator OR governance."
+      ],
+      "discriminator": [
+        43,
+        146,
+        116,
+        123,
+        106,
+        69,
+        242,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint"
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee_sol",
+      "docs": [
+        "Sweep accrued protocol fees (SOL rail) to a recipient system account.",
+        "Authority: governance only. Lamports come straight off the fee-vault",
+        "PDA; rent-exempt minimum is preserved."
+      ],
+      "discriminator": [
+        193,
+        33,
+        140,
+        185,
+        45,
+        190,
+        112,
+        7
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee_spl",
+      "docs": [
+        "Sweep accrued protocol fees (SPL rail) to a recipient ATA.",
+        "Authority: governance only. Fees physically reside in the matching",
+        "DomainAssetVault.vault_token_account; the CPI is PDA-signed via",
+        "transfer_from_domain_vault."
+      ],
+      "discriminator": [
+        120,
+        62,
+        236,
+        14,
+        227,
+        240,
+        52,
+        253
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint"
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ]
     }
   ],
   "accounts": [
@@ -14955,6 +16056,24 @@
           {
             "name": "cycle_seconds",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": [
+              "Amount to withdraw, in the rail's native units (lamports for SOL,",
+              "SPL base units for SPL). Must satisfy",
+              "`withdrawn_fees + amount <= accrued_fees` on the rail's fee vault,",
+              "and must not breach rent-exemption on the SOL rail."
+            ],
+            "type": "u64"
           }
         ]
       }

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -3271,6 +3271,16 @@
           }
         },
         {
+          "name": "pool_treasury_vault",
+          "docs": [
+            "Phase 1.6 — optional pool-treasury vault for entry-fee accrual.",
+            "When supplied, must match (liquidity_pool, deposit_asset_mint).",
+            "Validated at runtime; absent means entry-fee accrual is skipped (backward compat)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
           "name": "source_token_account",
           "writable": true
         },
@@ -3606,6 +3616,643 @@
           "type": {
             "defined": {
               "name": "FundSponsorBudgetArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_pool_oracle_fee_vault",
+      "docs": [
+        "Phase 1.6 — Initialize the pool-oracle fee vault for a (liquidity_pool,",
+        "oracle, asset_mint) rail. Governance-only init; the registered oracle",
+        "wallet (or oracle profile admin) signs withdrawals (PR2)."
+      ],
+      "discriminator": [
+        68,
+        122,
+        148,
+        84,
+        91,
+        98,
+        198,
+        167
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_approval",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  97,
+                  112,
+                  112,
+                  114,
+                  111,
+                  118,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "docs": [
+            "Required for SPL rails. The oracle fee vault accrues claims against the",
+            "same DomainAssetVault used by the pool."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitPoolOracleFeeVaultArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_pool_treasury_vault",
+      "docs": [
+        "Phase 1.6 — Initialize the pool-treasury vault for a (liquidity_pool, asset_mint)",
+        "rail. Governance-only init; pool-admin signs withdrawals (PR2)."
+      ],
+      "discriminator": [
+        96,
+        169,
+        51,
+        224,
+        0,
+        207,
+        141,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "docs": [
+            "Required for SPL rails. Must match (liquidity_pool.reserve_domain, args.asset_mint)."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitPoolTreasuryVaultArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "init_protocol_fee_vault",
+      "docs": [
+        "Phase 1.6 — Initialize the protocol-fee vault for a (reserve_domain, asset_mint)",
+        "rail. Governance-only; binds the rail to the asset mint at the program edge.",
+        "Withdrawal authority is governance (PR2). Accrual is wired in PR1 hooks."
+      ],
+      "discriminator": [
+        212,
+        235,
+        61,
+        42,
+        96,
+        183,
+        225,
+        57
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "docs": [
+            "Optional anchor to the SPL-rail DomainAssetVault. Required when",
+            "`args.asset_mint != NATIVE_SOL_MINT`; absent for SOL-rail vaults."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitProtocolFeeVaultArgs"
             }
           }
         }
@@ -4888,6 +5535,16 @@
           }
         },
         {
+          "name": "pool_treasury_vault",
+          "docs": [
+            "Phase 1.6 — optional pool-treasury vault for exit-fee accrual.",
+            "When supplied, must match (liquidity_pool, deposit_asset_mint).",
+            "Validated at runtime; absent means exit-fee accrual is skipped (backward compat)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
           "name": "asset_mint"
         },
         {
@@ -5195,6 +5852,16 @@
         },
         {
           "name": "series_reserve_ledger",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "protocol_fee_vault",
+          "docs": [
+            "Phase 1.6 — optional protocol fee vault for accrual at premium time.",
+            "When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).",
+            "Validated at runtime; absent means premium accrual is skipped (backward compat)."
+          ],
           "writable": true,
           "optional": true
         },
@@ -7303,6 +7970,39 @@
           "optional": true
         },
         {
+          "name": "protocol_fee_vault",
+          "docs": [
+            "Phase 1.6 — optional protocol fee vault for claim-settlement accrual.",
+            "When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).",
+            "Validated at runtime; absent means protocol-fee accrual is skipped (backward compat)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "docs": [
+            "Phase 1.6 — optional pool-oracle fee vault for adjudicator revshare.",
+            "When supplied alongside `pool_oracle_policy`, the bps from policy is",
+            "applied to the gross amount and credited to the supplied oracle vault.",
+            "Asset mint must match funding_line.asset_mint; pool ref must match",
+            "pool_oracle_policy.liquidity_pool. Single-attester scope: callers",
+            "credit the adjudicator (not all M attesters) — multi-attester revshare",
+            "is a follow-up beyond PR1 (documented in plan)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "pool_oracle_policy",
+          "docs": [
+            "Phase 1.6 — pairs with pool_oracle_fee_vault. The handler reads",
+            "`oracle_fee_bps` from policy. Required when pool_oracle_fee_vault is Some;",
+            "ignored otherwise. Validated at runtime."
+          ],
+          "optional": true
+        },
+        {
           "name": "member_position"
         },
         {
@@ -9161,6 +9861,19 @@
       ]
     },
     {
+      "name": "PoolOracleFeeVault",
+      "discriminator": [
+        167,
+        128,
+        29,
+        44,
+        248,
+        197,
+        244,
+        23
+      ]
+    },
+    {
       "name": "PoolOraclePermissionSet",
       "discriminator": [
         3,
@@ -9184,6 +9897,32 @@
         203,
         226,
         43
+      ]
+    },
+    {
+      "name": "PoolTreasuryVault",
+      "discriminator": [
+        93,
+        195,
+        95,
+        29,
+        127,
+        28,
+        59,
+        193
+      ]
+    },
+    {
+      "name": "ProtocolFeeVault",
+      "discriminator": [
+        199,
+        15,
+        107,
+        45,
+        108,
+        244,
+        162,
+        105
       ]
     },
     {
@@ -9290,6 +10029,45 @@
         18,
         240,
         208
+      ]
+    },
+    {
+      "name": "FeeAccruedEvent",
+      "discriminator": [
+        7,
+        169,
+        161,
+        187,
+        109,
+        43,
+        5,
+        157
+      ]
+    },
+    {
+      "name": "FeeVaultInitializedEvent",
+      "discriminator": [
+        219,
+        138,
+        2,
+        184,
+        253,
+        99,
+        165,
+        51
+      ]
+    },
+    {
+      "name": "FeeWithdrawnEvent",
+      "discriminator": [
+        206,
+        148,
+        200,
+        231,
+        65,
+        75,
+        11,
+        150
       ]
     },
     {
@@ -9918,6 +10696,46 @@
       "code": 6059,
       "name": "TooManySchemaDependencies",
       "msg": "Too many schema dependency addresses were provided"
+    },
+    {
+      "code": 6060,
+      "name": "DomainAssetVaultRequired",
+      "msg": "Fee vault initialization requires the matching domain asset vault to exist"
+    },
+    {
+      "code": 6061,
+      "name": "LiquidityPoolMismatch",
+      "msg": "Liquidity pool reference does not match the supplied account"
+    },
+    {
+      "code": 6062,
+      "name": "OracleProfileMismatch",
+      "msg": "Oracle profile reference does not match the supplied account"
+    },
+    {
+      "code": 6063,
+      "name": "FeeVaultMismatch",
+      "msg": "Fee vault account does not match the expected scope"
+    },
+    {
+      "code": 6064,
+      "name": "FeeVaultInsufficientBalance",
+      "msg": "Fee vault has insufficient accrued balance for this withdrawal"
+    },
+    {
+      "code": 6065,
+      "name": "FeeVaultRentExemptionBreach",
+      "msg": "Fee vault withdrawal would breach the rent-exempt minimum balance"
+    },
+    {
+      "code": 6066,
+      "name": "FeeVaultRailMismatch",
+      "msg": "Fee vault rail and asset mint disagree (SOL vault used on SPL path or vice versa)"
+    },
+    {
+      "code": 6067,
+      "name": "FeeVaultBpsMisconfigured",
+      "msg": "Fee vault basis-points configuration is out of range"
     }
   ],
   "types": [
@@ -11161,6 +11979,85 @@
       }
     },
     {
+      "name": "FeeAccruedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "accrued_total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeVaultInitializedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "scope",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "rail",
+            "docs": [
+              "0 = ProtocolFeeVault, 1 = PoolTreasuryVault, 2 = PoolOracleFeeVault."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeWithdrawnEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "recipient",
+            "type": "pubkey"
+          },
+          {
+            "name": "withdrawn_total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "FundSponsorBudgetArgs",
       "type": {
         "kind": "struct",
@@ -11485,6 +12382,60 @@
                 32
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPoolOracleFeeVaultArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "docs": [
+              "Oracle wallet whose fee vault is being initialized. Must match",
+              "`oracle_profile.oracle` and have an active `PoolOracleApproval` on the pool."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "docs": [
+              "Asset mint of the rail (use `NATIVE_SOL_MINT` for SOL)."
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPoolTreasuryVaultArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_mint",
+            "docs": [
+              "Asset mint must equal `liquidity_pool.deposit_asset_mint` for SPL pools, or",
+              "`NATIVE_SOL_MINT` for the SOL rail."
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitProtocolFeeVaultArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_mint",
+            "docs": [
+              "SPL mint for the fee rail. Pass `NATIVE_SOL_MINT` to bind a SOL-rail vault."
+            ],
+            "type": "pubkey"
           }
         ]
       }
@@ -12769,6 +13720,38 @@
       }
     },
     {
+      "name": "PoolOracleFeeVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "accrued_fees",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawn_fees",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "PoolOraclePermissionSet",
       "type": {
         "kind": "struct",
@@ -12893,6 +13876,34 @@
       }
     },
     {
+      "name": "PoolTreasuryVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "accrued_fees",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawn_fees",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "ProcessRedemptionQueueArgs",
       "type": {
         "kind": "struct",
@@ -12900,6 +13911,34 @@
           {
             "name": "shares",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFeeVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reserve_domain",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "accrued_fees",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawn_fees",
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
           }
         ]
       }

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-21ccc9dad0e91905aed92f34cdc6999419d182e6940578691e6cdadcf5f5d85b
+ae39029cf6ee2478f8416d5bdff00728a42ff97063c9efb95986d1fa68b4eed3
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-ae39029cf6ee2478f8416d5bdff00728a42ff97063c9efb95986d1fa68b4eed3
+192d35a886c013dbaa52584952cad7fcaf11dd65d0584ae6e50ef288f44785aa
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -8370,4 +8370,75 @@ mod tests {
             [0; 32]
         ));
     }
+
+    // -------- Phase 1.6 fee-vault helper tests --------
+
+    #[test]
+    fn fee_share_from_bps_zero_bps_or_zero_amount_returns_zero() {
+        // bps == 0 short-circuits regardless of amount.
+        assert_eq!(fee_share_from_bps(1_000_000, 0).unwrap(), 0);
+        // amount == 0 short-circuits regardless of bps.
+        assert_eq!(fee_share_from_bps(0, 50).unwrap(), 0);
+        // both zero is OK too.
+        assert_eq!(fee_share_from_bps(0, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn fee_share_from_bps_typical_50_bps_yields_half_percent() {
+        // 1_000_000_000 lamports * 50 / 10_000 = 5_000_000.
+        assert_eq!(fee_share_from_bps(1_000_000_000, 50).unwrap(), 5_000_000);
+        // 1_000_000 USDC base units (6 decimals = $1) * 25 / 10_000 = 2_500
+        // (= 0.0025 USDC = 0.25%).
+        assert_eq!(fee_share_from_bps(1_000_000, 25).unwrap(), 2_500);
+    }
+
+    #[test]
+    fn fee_share_from_bps_floors_to_zero_below_one_unit() {
+        // 100 * 50 / 10_000 = 0.5 — Solana convention floors to zero.
+        assert_eq!(fee_share_from_bps(100, 50).unwrap(), 0);
+        // 199 * 1 / 10_000 = 0.0199 — also floors to zero.
+        assert_eq!(fee_share_from_bps(199, 1).unwrap(), 0);
+        // 10_000 * 1 / 10_000 = 1 — first non-zero share.
+        assert_eq!(fee_share_from_bps(10_000, 1).unwrap(), 1);
+    }
+
+    #[test]
+    fn fee_share_from_bps_rejects_bps_above_10000() {
+        // 100% (10_000 bps) is the maximum legal bps; anything higher is a
+        // configuration error and returns FeeVaultBpsMisconfigured.
+        assert_eq!(fee_share_from_bps(1_000_000, 10_000).unwrap(), 1_000_000);
+        assert!(fee_share_from_bps(1_000_000, 10_001).is_err());
+    }
+
+    #[test]
+    fn accrue_fee_increments_running_total() {
+        let mut accrued: u64 = 100;
+        let new_total = accrue_fee(&mut accrued, 50).unwrap();
+        assert_eq!(new_total, 150);
+        assert_eq!(accrued, 150);
+        // Subsequent accrual continues to add.
+        let next = accrue_fee(&mut accrued, 25).unwrap();
+        assert_eq!(next, 175);
+        assert_eq!(accrued, 175);
+    }
+
+    #[test]
+    fn accrue_fee_zero_amount_returns_existing_total_unchanged() {
+        let mut accrued: u64 = 12_345;
+        let total = accrue_fee(&mut accrued, 0).unwrap();
+        assert_eq!(total, 12_345);
+        assert_eq!(accrued, 12_345);
+    }
+
+    #[test]
+    fn accrue_fee_overflow_errors() {
+        let mut accrued: u64 = u64::MAX - 10;
+        // 11 onto MAX-10 overflows.
+        assert!(accrue_fee(&mut accrued, 11).is_err());
+        // The accrued value is unchanged on error (checked_add returns None).
+        assert_eq!(accrued, u64::MAX - 10);
+        // Accruing exactly to MAX is allowed.
+        let total = accrue_fee(&mut accrued, 10).unwrap();
+        assert_eq!(total, u64::MAX);
+    }
 }

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -948,6 +948,13 @@ pub mod omegax_protocol {
         )?;
 
         let amount = args.amount;
+        // Capture immutable values needed after the mutable borrow on funding_line
+        // and during the protocol_fee_vault accrual block below.
+        let funding_line_key = ctx.accounts.funding_line.key();
+        let funding_line_asset_mint = ctx.accounts.funding_line.asset_mint;
+        let health_plan_reserve_domain = ctx.accounts.health_plan.reserve_domain;
+        let protocol_fee_bps = ctx.accounts.protocol_governance.protocol_fee_bps;
+
         let funding_line = &mut ctx.accounts.funding_line;
         funding_line.funded_amount = checked_add(funding_line.funded_amount, amount)?;
         book_inflow(&mut ctx.accounts.domain_asset_vault.total_assets, amount)?;
@@ -959,8 +966,40 @@ pub mod omegax_protocol {
             book_inflow_sheet(&mut series_ledger.sheet, amount)?;
         }
 
+        // Phase 1.6 — Protocol fee accrual on premium income.
+        // The full premium amount is booked into the vault; the fee is an
+        // internal claim that decrements `accrued_fees - withdrawn_fees`
+        // headroom. No user-facing payout reduction here (premiums are not
+        // refundable). Accrual is skipped silently when `protocol_fee_vault`
+        // is None to preserve backward compatibility for callers that have
+        // not yet initialized the fee infrastructure.
+        if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
+            require_keys_eq!(
+                vault.reserve_domain,
+                health_plan_reserve_domain,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            require_keys_eq!(
+                vault.asset_mint,
+                funding_line_asset_mint,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
+            if fee > 0 {
+                let vault_key = vault.key();
+                let vault_mint = vault.asset_mint;
+                let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: vault_key,
+                    asset_mint: vault_mint,
+                    amount: fee,
+                    accrued_total,
+                });
+            }
+        }
+
         emit!(FundingFlowRecordedEvent {
-            funding_line: funding_line.key(),
+            funding_line: funding_line_key,
             amount,
             flow_kind: FundingFlowKind::PremiumRecorded as u8,
         });
@@ -3030,6 +3069,11 @@ pub struct RecordPremiumPayment<'info> {
     pub plan_reserve_ledger: Box<Account<'info, PlanReserveLedger>>,
     #[account(mut)]
     pub series_reserve_ledger: Option<Box<Account<'info, SeriesReserveLedger>>>,
+    /// Phase 1.6 — optional protocol fee vault for accrual at premium time.
+    /// When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).
+    /// Validated at runtime; absent means premium accrual is skipped (backward compat).
+    #[account(mut)]
+    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -2254,6 +2254,246 @@ pub mod omegax_protocol {
         Ok(())
     }
 
+    // -------- Phase 1.7 — Fee-vault withdraw instructions --------
+
+    /// Sweep accrued protocol fees (SPL rail) to a recipient ATA.
+    /// Authority: governance only. Fees physically reside in the matching
+    /// DomainAssetVault.vault_token_account; the CPI is PDA-signed via
+    /// transfer_from_domain_vault.
+    pub fn withdraw_protocol_fee_spl(
+        ctx: Context<WithdrawProtocolFeeSpl>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_governance(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.protocol_fee_vault.accrued_fees,
+            ctx.accounts.protocol_fee_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        transfer_from_domain_vault(
+            args.amount,
+            &ctx.accounts.domain_asset_vault,
+            &ctx.accounts.vault_token_account,
+            &ctx.accounts.recipient_token_account,
+            &ctx.accounts.asset_mint,
+            &ctx.accounts.token_program,
+        )?;
+
+        let vault = &mut ctx.accounts.protocol_fee_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient_token_account.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
+    /// Sweep accrued protocol fees (SOL rail) to a recipient system account.
+    /// Authority: governance only. Lamports come straight off the fee-vault
+    /// PDA; rent-exempt minimum is preserved.
+    pub fn withdraw_protocol_fee_sol(
+        ctx: Context<WithdrawProtocolFeeSol>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_governance(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.protocol_fee_vault.accrued_fees,
+            ctx.accounts.protocol_fee_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        let rent = Rent::get()?;
+        let vault_ai = ctx.accounts.protocol_fee_vault.to_account_info();
+        let recipient_ai = ctx.accounts.recipient.to_account_info();
+        let vault_data_len = vault_ai.data_len();
+        transfer_lamports_from_fee_vault(
+            &vault_ai,
+            &recipient_ai,
+            args.amount,
+            &rent,
+            vault_data_len,
+        )?;
+
+        let vault = &mut ctx.accounts.protocol_fee_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
+    /// Sweep accrued pool-treasury fees (SPL rail).
+    /// Authority: pool curator OR governance.
+    pub fn withdraw_pool_treasury_spl(
+        ctx: Context<WithdrawPoolTreasurySpl>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_curator_control(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+            &ctx.accounts.liquidity_pool,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.pool_treasury_vault.accrued_fees,
+            ctx.accounts.pool_treasury_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        transfer_from_domain_vault(
+            args.amount,
+            &ctx.accounts.domain_asset_vault,
+            &ctx.accounts.vault_token_account,
+            &ctx.accounts.recipient_token_account,
+            &ctx.accounts.asset_mint,
+            &ctx.accounts.token_program,
+        )?;
+
+        let vault = &mut ctx.accounts.pool_treasury_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient_token_account.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
+    /// Sweep accrued pool-treasury fees (SOL rail).
+    /// Authority: pool curator OR governance.
+    pub fn withdraw_pool_treasury_sol(
+        ctx: Context<WithdrawPoolTreasurySol>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_curator_control(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+            &ctx.accounts.liquidity_pool,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.pool_treasury_vault.accrued_fees,
+            ctx.accounts.pool_treasury_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        let rent = Rent::get()?;
+        let vault_ai = ctx.accounts.pool_treasury_vault.to_account_info();
+        let recipient_ai = ctx.accounts.recipient.to_account_info();
+        let vault_data_len = vault_ai.data_len();
+        transfer_lamports_from_fee_vault(
+            &vault_ai,
+            &recipient_ai,
+            args.amount,
+            &rent,
+            vault_data_len,
+        )?;
+
+        let vault = &mut ctx.accounts.pool_treasury_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
+    /// Sweep accrued pool-oracle fees (SPL rail) to a recipient ATA.
+    /// Authority: registered oracle wallet OR oracle profile admin OR governance.
+    pub fn withdraw_pool_oracle_fee_spl(
+        ctx: Context<WithdrawPoolOracleFeeSpl>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_oracle_profile_control(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+            &ctx.accounts.oracle_profile,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.pool_oracle_fee_vault.accrued_fees,
+            ctx.accounts.pool_oracle_fee_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        transfer_from_domain_vault(
+            args.amount,
+            &ctx.accounts.domain_asset_vault,
+            &ctx.accounts.vault_token_account,
+            &ctx.accounts.recipient_token_account,
+            &ctx.accounts.asset_mint,
+            &ctx.accounts.token_program,
+        )?;
+
+        let vault = &mut ctx.accounts.pool_oracle_fee_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient_token_account.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
+    /// Sweep accrued pool-oracle fees (SOL rail) to a recipient system account.
+    /// Authority: registered oracle wallet OR oracle profile admin OR governance.
+    pub fn withdraw_pool_oracle_fee_sol(
+        ctx: Context<WithdrawPoolOracleFeeSol>,
+        args: WithdrawArgs,
+    ) -> Result<()> {
+        require_oracle_profile_control(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+            &ctx.accounts.oracle_profile,
+        )?;
+        let new_withdrawn = require_fee_vault_balance(
+            ctx.accounts.pool_oracle_fee_vault.accrued_fees,
+            ctx.accounts.pool_oracle_fee_vault.withdrawn_fees,
+            args.amount,
+        )?;
+
+        let rent = Rent::get()?;
+        let vault_ai = ctx.accounts.pool_oracle_fee_vault.to_account_info();
+        let recipient_ai = ctx.accounts.recipient.to_account_info();
+        let vault_data_len = vault_ai.data_len();
+        transfer_lamports_from_fee_vault(
+            &vault_ai,
+            &recipient_ai,
+            args.amount,
+            &rent,
+            vault_data_len,
+        )?;
+
+        let vault = &mut ctx.accounts.pool_oracle_fee_vault;
+        vault.withdrawn_fees = new_withdrawn;
+        emit!(FeeWithdrawnEvent {
+            vault: vault.key(),
+            asset_mint: vault.asset_mint,
+            amount: args.amount,
+            recipient: ctx.accounts.recipient.key(),
+            withdrawn_total: new_withdrawn,
+        });
+        Ok(())
+    }
+
     pub fn create_allocation_position(
         ctx: Context<CreateAllocationPosition>,
         args: CreateAllocationPositionArgs,
@@ -3784,6 +4024,211 @@ pub struct ProcessRedemptionQueue<'info> {
     pub token_program: Interface<'info, TokenInterface>,
 }
 
+// Phase 1.7 — Fee-vault withdrawal account structs. Six instructions
+// (SOL + SPL × 3 rails) move accrued fee balances out to a recipient
+// authorized by the per-rail authority.
+//
+// Rail authority model:
+//   - Protocol fee:        governance authority only (require_governance)
+//   - Pool treasury:       pool curator OR governance (require_curator_control)
+//   - Pool oracle fee:     oracle wallet OR oracle admin OR governance
+//                          (require_oracle_profile_control)
+//
+// Custody model:
+//   - SPL: tokens reside in DomainAssetVault.vault_token_account; CPI is
+//          PDA-signed via transfer_from_domain_vault (existing helper).
+//   - SOL: lamports reside on the fee-vault PDA itself; transfer_lamports_from_fee_vault
+//          mutates lamports directly while preserving rent-exempt minimum.
+
+#[derive(Accounts)]
+pub struct WithdrawProtocolFeeSpl<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(seeds = [SEED_RESERVE_DOMAIN, reserve_domain.domain_id.as_bytes()], bump = reserve_domain.bump)]
+    pub reserve_domain: Box<Account<'info, ReserveDomain>>,
+    #[account(
+        mut,
+        seeds = [SEED_PROTOCOL_FEE_VAULT, reserve_domain.key().as_ref(), protocol_fee_vault.asset_mint.as_ref()],
+        bump = protocol_fee_vault.bump,
+        constraint = protocol_fee_vault.reserve_domain == reserve_domain.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = protocol_fee_vault.asset_mint != NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
+    #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_VAULT, reserve_domain.key().as_ref(), protocol_fee_vault.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+    )]
+    pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
+    #[account(
+        constraint = asset_mint.key() == protocol_fee_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub asset_mint: InterfaceAccount<'info, Mint>,
+    #[account(
+        mut,
+        constraint = vault_token_account.key() == domain_asset_vault.vault_token_account @ OmegaXProtocolError::VaultTokenAccountMismatch,
+    )]
+    pub vault_token_account: InterfaceAccount<'info, TokenAccount>,
+    #[account(mut)]
+    pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawProtocolFeeSol<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(seeds = [SEED_RESERVE_DOMAIN, reserve_domain.domain_id.as_bytes()], bump = reserve_domain.bump)]
+    pub reserve_domain: Box<Account<'info, ReserveDomain>>,
+    #[account(
+        mut,
+        seeds = [SEED_PROTOCOL_FEE_VAULT, reserve_domain.key().as_ref(), protocol_fee_vault.asset_mint.as_ref()],
+        bump = protocol_fee_vault.bump,
+        constraint = protocol_fee_vault.reserve_domain == reserve_domain.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = protocol_fee_vault.asset_mint == NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
+    #[account(mut)]
+    pub recipient: SystemAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawPoolTreasurySpl<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), pool_treasury_vault.asset_mint.as_ref()],
+        bump = pool_treasury_vault.bump,
+        constraint = pool_treasury_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_treasury_vault.asset_mint != NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub pool_treasury_vault: Box<Account<'info, PoolTreasuryVault>>,
+    #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_VAULT, liquidity_pool.reserve_domain.as_ref(), pool_treasury_vault.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+    )]
+    pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
+    #[account(
+        constraint = asset_mint.key() == pool_treasury_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub asset_mint: InterfaceAccount<'info, Mint>,
+    #[account(
+        mut,
+        constraint = vault_token_account.key() == domain_asset_vault.vault_token_account @ OmegaXProtocolError::VaultTokenAccountMismatch,
+    )]
+    pub vault_token_account: InterfaceAccount<'info, TokenAccount>,
+    #[account(mut)]
+    pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawPoolTreasurySol<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), pool_treasury_vault.asset_mint.as_ref()],
+        bump = pool_treasury_vault.bump,
+        constraint = pool_treasury_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_treasury_vault.asset_mint == NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub pool_treasury_vault: Box<Account<'info, PoolTreasuryVault>>,
+    #[account(mut)]
+    pub recipient: SystemAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawPoolOracleFeeSpl<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        seeds = [SEED_ORACLE_PROFILE, oracle_profile.oracle.as_ref()],
+        bump = oracle_profile.bump,
+    )]
+    pub oracle_profile: Box<Account<'info, OracleProfile>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_ORACLE_FEE_VAULT, liquidity_pool.key().as_ref(), pool_oracle_fee_vault.oracle.as_ref(), pool_oracle_fee_vault.asset_mint.as_ref()],
+        bump = pool_oracle_fee_vault.bump,
+        constraint = pool_oracle_fee_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_oracle_fee_vault.oracle == oracle_profile.oracle @ OmegaXProtocolError::OracleProfileMismatch,
+        constraint = pool_oracle_fee_vault.asset_mint != NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub pool_oracle_fee_vault: Box<Account<'info, PoolOracleFeeVault>>,
+    #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_VAULT, liquidity_pool.reserve_domain.as_ref(), pool_oracle_fee_vault.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+    )]
+    pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
+    #[account(
+        constraint = asset_mint.key() == pool_oracle_fee_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub asset_mint: InterfaceAccount<'info, Mint>,
+    #[account(
+        mut,
+        constraint = vault_token_account.key() == domain_asset_vault.vault_token_account @ OmegaXProtocolError::VaultTokenAccountMismatch,
+    )]
+    pub vault_token_account: InterfaceAccount<'info, TokenAccount>,
+    #[account(mut)]
+    pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
+    pub token_program: Interface<'info, TokenInterface>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawPoolOracleFeeSol<'info> {
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Box<Account<'info, ProtocolGovernance>>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        seeds = [SEED_ORACLE_PROFILE, oracle_profile.oracle.as_ref()],
+        bump = oracle_profile.bump,
+    )]
+    pub oracle_profile: Box<Account<'info, OracleProfile>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_ORACLE_FEE_VAULT, liquidity_pool.key().as_ref(), pool_oracle_fee_vault.oracle.as_ref(), pool_oracle_fee_vault.asset_mint.as_ref()],
+        bump = pool_oracle_fee_vault.bump,
+        constraint = pool_oracle_fee_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_oracle_fee_vault.oracle == oracle_profile.oracle @ OmegaXProtocolError::OracleProfileMismatch,
+        constraint = pool_oracle_fee_vault.asset_mint == NATIVE_SOL_MINT @ OmegaXProtocolError::FeeVaultRailMismatch,
+    )]
+    pub pool_oracle_fee_vault: Box<Account<'info, PoolOracleFeeVault>>,
+    #[account(mut)]
+    pub recipient: SystemAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
 #[derive(Accounts)]
 pub struct CreateAllocationPosition<'info> {
     #[account(mut)]
@@ -4706,6 +5151,15 @@ pub struct InitPoolOracleFeeVaultArgs {
     pub oracle: Pubkey,
     /// Asset mint of the rail (use `NATIVE_SOL_MINT` for SOL).
     pub asset_mint: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct WithdrawArgs {
+    /// Amount to withdraw, in the rail's native units (lamports for SOL,
+    /// SPL base units for SPL). Must satisfy
+    /// `withdrawn_fees + amount <= accrued_fees` on the rail's fee vault,
+    /// and must not breach rent-exemption on the SOL rail.
+    pub amount: u64,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
@@ -6371,6 +6825,55 @@ fn accrue_fee(accrued: &mut u64, amount: u64) -> Result<u64> {
     let new_total = checked_add(*accrued, amount)?;
     *accrued = new_total;
     Ok(new_total)
+}
+
+// Phase 1.7 — Verifies a withdrawal amount fits within the vault's claim.
+// `withdrawn + requested <= accrued` must hold; otherwise the rail would
+// over-withdraw beyond what's been accrued. Returns the new withdrawn total.
+fn require_fee_vault_balance(accrued: u64, withdrawn: u64, requested: u64) -> Result<u64> {
+    require_positive_amount(requested)?;
+    let new_withdrawn = checked_add(withdrawn, requested)?;
+    require!(
+        new_withdrawn <= accrued,
+        OmegaXProtocolError::FeeVaultInsufficientBalance
+    );
+    Ok(new_withdrawn)
+}
+
+// Phase 1.7 — SOL-rail withdrawal. Mutates the fee-vault PDA's lamports
+// directly (SystemProgram::transfer cannot move lamports out of program-owned
+// accounts). Rejects withdrawals that would breach the PDA's rent-exempt
+// minimum so the account stays alive across operations.
+//
+// Caller must pass `vault_data_len = vault_account.data_len()` so the
+// rent-minimum lookup uses the live account size; passing a stale or
+// constructed value would mis-compute the rent floor.
+fn transfer_lamports_from_fee_vault<'info>(
+    vault_ai: &AccountInfo<'info>,
+    recipient_ai: &AccountInfo<'info>,
+    amount: u64,
+    rent: &Rent,
+    vault_data_len: usize,
+) -> Result<()> {
+    if amount == 0 {
+        return Ok(());
+    }
+    let rent_minimum = rent.minimum_balance(vault_data_len);
+    let vault_lamports = vault_ai.lamports();
+    let vault_after = vault_lamports
+        .checked_sub(amount)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?;
+    require!(
+        vault_after >= rent_minimum,
+        OmegaXProtocolError::FeeVaultRentExemptionBreach
+    );
+    let recipient_lamports = recipient_ai.lamports();
+    let recipient_after = recipient_lamports
+        .checked_add(amount)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?;
+    **vault_ai.try_borrow_mut_lamports()? = vault_after;
+    **recipient_ai.try_borrow_mut_lamports()? = recipient_after;
+    Ok(())
 }
 
 // PDA-signed outflow helper. Unblocks PT-2026-04-27-01 and PT-2026-04-27-02:

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -8940,4 +8940,44 @@ mod tests {
         let total = accrue_fee(&mut accrued, 10).unwrap();
         assert_eq!(total, u64::MAX);
     }
+
+    // -------- Phase 1.7 withdraw-helper tests --------
+
+    #[test]
+    fn fee_vault_balance_accepts_within_headroom() {
+        // accrued = 100, withdrawn = 30, requesting 50 → new_withdrawn = 80 ≤ 100.
+        let new_withdrawn = require_fee_vault_balance(100, 30, 50).unwrap();
+        assert_eq!(new_withdrawn, 80);
+    }
+
+    #[test]
+    fn fee_vault_balance_accepts_exact_remaining() {
+        // Drain to zero remaining headroom in a single call.
+        let new_withdrawn = require_fee_vault_balance(1_000, 250, 750).unwrap();
+        assert_eq!(new_withdrawn, 1_000);
+    }
+
+    #[test]
+    fn fee_vault_balance_rejects_overdraw() {
+        // accrued = 100, withdrawn = 80, requesting 21 → new_withdrawn = 101 > 100.
+        let err = require_fee_vault_balance(100, 80, 21).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("FeeVaultInsufficientBalance"),
+            "expected FeeVaultInsufficientBalance, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fee_vault_balance_rejects_zero_amount() {
+        // Zero-amount withdrawals are rejected by require_positive_amount —
+        // matches the existing convention used for premium/deposit/redemption.
+        assert!(require_fee_vault_balance(100, 0, 0).is_err());
+    }
+
+    #[test]
+    fn fee_vault_balance_rejects_overflow_on_withdrawn_sum() {
+        // withdrawn near MAX, requesting any positive amount overflows.
+        assert!(require_fee_vault_balance(u64::MAX, u64::MAX - 5, 10).is_err());
+    }
 }

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1731,10 +1731,8 @@ pub mod omegax_protocol {
             amount,
         )?;
         if total_fee > 0 {
-            ctx.accounts.domain_asset_vault.total_assets = checked_add(
-                ctx.accounts.domain_asset_vault.total_assets,
-                total_fee,
-            )?;
+            ctx.accounts.domain_asset_vault.total_assets =
+                checked_add(ctx.accounts.domain_asset_vault.total_assets, total_fee)?;
         }
 
         // PT-01/02 fix: actually move the SPL tokens. The vault token account
@@ -2174,10 +2172,8 @@ pub mod omegax_protocol {
         ctx.accounts.lp_position.shares =
             checked_sub(ctx.accounts.lp_position.shares, args.shares)?;
         // realized_distributions tracks what the LP actually received (post-fee).
-        ctx.accounts.lp_position.realized_distributions = checked_add(
-            ctx.accounts.lp_position.realized_distributions,
-            net_to_lp,
-        )?;
+        ctx.accounts.lp_position.realized_distributions =
+            checked_add(ctx.accounts.lp_position.realized_distributions, net_to_lp)?;
         ctx.accounts.lp_position.queue_status =
             if ctx.accounts.lp_position.pending_redemption_shares == 0 {
                 LP_QUEUE_STATUS_PROCESSED

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1638,6 +1638,65 @@ pub mod omegax_protocol {
         );
 
         let amount = args.amount;
+
+        // Phase 1.6 — Compute protocol fee + adjudicator-oracle fee carve-outs.
+        // The full `amount` is what the claim is settling against (claim_case.paid_amount
+        // increments by amount, funding_line.spent_amount increments by amount, sheets
+        // record the full obligation delivery). But only `net_to_recipient = amount -
+        // total_fee` physically leaves the vault — fee tokens stay as treasury claims.
+        let reserve_domain = ctx.accounts.health_plan.reserve_domain;
+        let asset_mint_key = ctx.accounts.funding_line.asset_mint;
+        let protocol_fee_bps = ctx.accounts.protocol_governance.protocol_fee_bps;
+
+        let protocol_fee = if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref() {
+            require_keys_eq!(
+                vault.reserve_domain,
+                reserve_domain,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            require_keys_eq!(
+                vault.asset_mint,
+                asset_mint_key,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            fee_share_from_bps(amount, protocol_fee_bps)?
+        } else {
+            0
+        };
+
+        // Adjudicator oracle fee: requires BOTH pool_oracle_fee_vault and
+        // pool_oracle_policy to be supplied. The vault fixes the recipient
+        // oracle's revshare destination; the policy supplies oracle_fee_bps.
+        // PR1 single-attester model: caller credits the adjudicator only;
+        // multi-attester revshare is a follow-up.
+        let oracle_fee = match (
+            ctx.accounts.pool_oracle_fee_vault.as_deref(),
+            ctx.accounts.pool_oracle_policy.as_deref(),
+        ) {
+            (Some(vault), Some(policy)) => {
+                require_keys_eq!(
+                    vault.asset_mint,
+                    asset_mint_key,
+                    OmegaXProtocolError::FeeVaultMismatch
+                );
+                require_keys_eq!(
+                    vault.liquidity_pool,
+                    policy.liquidity_pool,
+                    OmegaXProtocolError::LiquidityPoolMismatch
+                );
+                fee_share_from_bps(amount, policy.oracle_fee_bps)?
+            }
+            (None, _) => 0,
+            (Some(_), None) => {
+                // Vault provided without policy is a configuration error;
+                // refuse to silently zero the bps.
+                return Err(OmegaXProtocolError::FeeVaultBpsMisconfigured.into());
+            }
+        };
+
+        let total_fee = checked_add(protocol_fee, oracle_fee)?;
+        let net_to_recipient = checked_sub(amount, total_fee)?;
+
         let claim_case = &mut ctx.accounts.claim_case;
         claim_case.paid_amount = checked_add(claim_case.paid_amount, amount)?;
         claim_case.reserved_amount = claim_case.reserved_amount.saturating_sub(amount);
@@ -1653,6 +1712,12 @@ pub mod omegax_protocol {
         };
         claim_case.updated_at = Clock::get()?.unix_timestamp;
 
+        // Book the full obligation settlement. This decrements
+        // domain_asset_vault.total_assets by `amount`, but only
+        // `net_to_recipient` physically leaves the vault. The fee tokens
+        // remain in the SPL token account as treasury claims; we add them
+        // back to total_assets immediately below to keep the counter in
+        // sync with the physical balance.
         book_settlement_from_delivery(
             &mut ctx.accounts.domain_asset_vault.total_assets,
             &mut ctx.accounts.domain_asset_ledger.sheet,
@@ -1665,17 +1730,54 @@ pub mod omegax_protocol {
             &mut ctx.accounts.funding_line,
             amount,
         )?;
+        if total_fee > 0 {
+            ctx.accounts.domain_asset_vault.total_assets = checked_add(
+                ctx.accounts.domain_asset_vault.total_assets,
+                total_fee,
+            )?;
+        }
 
         // PT-01/02 fix: actually move the SPL tokens. The vault token account
         // is owned by the domain_asset_vault PDA, which signs via seeds.
+        // Phase 1.6: outflow is net_to_recipient; fee tokens stay in vault.
         transfer_from_domain_vault(
-            amount,
+            net_to_recipient,
             &ctx.accounts.domain_asset_vault,
             &ctx.accounts.vault_token_account,
             &ctx.accounts.recipient_token_account,
             &ctx.accounts.asset_mint,
             &ctx.accounts.token_program,
         )?;
+
+        // Accrue the protocol fee carve-out.
+        if protocol_fee > 0 {
+            if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
+                let key = vault.key();
+                let mint = vault.asset_mint;
+                let total = accrue_fee(&mut vault.accrued_fees, protocol_fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: key,
+                    asset_mint: mint,
+                    amount: protocol_fee,
+                    accrued_total: total,
+                });
+            }
+        }
+
+        // Accrue the adjudicator-oracle fee carve-out.
+        if oracle_fee > 0 {
+            if let Some(vault) = ctx.accounts.pool_oracle_fee_vault.as_deref_mut() {
+                let key = vault.key();
+                let mint = vault.asset_mint;
+                let total = accrue_fee(&mut vault.accrued_fees, oracle_fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: key,
+                    asset_mint: mint,
+                    amount: oracle_fee,
+                    accrued_total: total,
+                });
+            }
+        }
 
         let claim_case_key = ctx.accounts.claim_case.key();
         let intake_status = ctx.accounts.claim_case.intake_status;
@@ -3469,6 +3571,24 @@ pub struct SettleClaimCase<'info> {
     pub claim_case: Box<Account<'info, ClaimCase>>,
     #[account(mut)]
     pub obligation: Option<Box<Account<'info, Obligation>>>,
+    /// Phase 1.6 — optional protocol fee vault for claim-settlement accrual.
+    /// When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).
+    /// Validated at runtime; absent means protocol-fee accrual is skipped (backward compat).
+    #[account(mut)]
+    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
+    /// Phase 1.6 — optional pool-oracle fee vault for adjudicator revshare.
+    /// When supplied alongside `pool_oracle_policy`, the bps from policy is
+    /// applied to the gross amount and credited to the supplied oracle vault.
+    /// Asset mint must match funding_line.asset_mint; pool ref must match
+    /// pool_oracle_policy.liquidity_pool. Single-attester scope: callers
+    /// credit the adjudicator (not all M attesters) — multi-attester revshare
+    /// is a follow-up beyond PR1 (documented in plan).
+    #[account(mut)]
+    pub pool_oracle_fee_vault: Option<Box<Account<'info, PoolOracleFeeVault>>>,
+    /// Phase 1.6 — pairs with pool_oracle_fee_vault. The handler reads
+    /// `oracle_fee_bps` from policy. Required when pool_oracle_fee_vault is Some;
+    /// ignored otherwise. Validated at runtime.
+    pub pool_oracle_policy: Option<Box<Account<'info, PoolOraclePolicy>>>,
     // PT-2026-04-27-01/02 fix: outflow CPI accounts. The handler resolves the
     // settlement recipient as `claim_case.delegate_recipient` if non-zero,
     // else `member_position.wallet`, and asserts

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -148,6 +148,15 @@ pub const PAUSE_FLAG_ALLOCATION_FREEZE: u32 = 1 << 7;
 
 pub const ZERO_PUBKEY: Pubkey = Pubkey::new_from_array([0u8; 32]);
 
+// Native SOL "mint" sentinel used by fee-vault rails to distinguish lamport
+// accounting from SPL token accounting. Matches `spl_token::native_mint::ID`
+// (canonical wrapped-SOL mint). For SOL fee vaults the lamports physically
+// reside on the fee-vault PDA itself and `transfer_lamports_from_fee_vault`
+// drains them with rent-exemption preserved. For SPL fee vaults the tokens
+// physically reside in the matching `DomainAssetVault.vault_token_account`
+// and `transfer_from_domain_vault` (PDA-signed) drains them.
+pub const NATIVE_SOL_MINT: Pubkey = anchor_spl::token::spl_token::native_mint::ID;
+
 #[program]
 pub mod omegax_protocol {
     use super::*;
@@ -320,6 +329,143 @@ pub mod omegax_protocol {
             scope_kind: ScopeKind::DomainAssetVault as u8,
             scope: vault.key(),
             asset_mint: args.asset_mint,
+        });
+
+        Ok(())
+    }
+
+    /// Phase 1.6 — Initialize the protocol-fee vault for a (reserve_domain, asset_mint)
+    /// rail. Governance-only; binds the rail to the asset mint at the program edge.
+    /// Withdrawal authority is governance (PR2). Accrual is wired in PR1 hooks.
+    pub fn init_protocol_fee_vault(
+        ctx: Context<InitProtocolFeeVault>,
+        args: InitProtocolFeeVaultArgs,
+    ) -> Result<()> {
+        require_governance(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+        )?;
+        require!(
+            args.asset_mint != ZERO_PUBKEY,
+            OmegaXProtocolError::AssetMintMismatch
+        );
+        // SPL rails MUST present a DomainAssetVault; SOL rail keeps lamports on the
+        // fee-vault PDA itself.
+        if args.asset_mint != NATIVE_SOL_MINT {
+            require!(
+                ctx.accounts.domain_asset_vault.is_some(),
+                OmegaXProtocolError::DomainAssetVaultRequired
+            );
+        }
+
+        let vault = &mut ctx.accounts.protocol_fee_vault;
+        vault.reserve_domain = ctx.accounts.reserve_domain.key();
+        vault.asset_mint = args.asset_mint;
+        vault.accrued_fees = 0;
+        vault.withdrawn_fees = 0;
+        vault.bump = ctx.bumps.protocol_fee_vault;
+
+        emit!(FeeVaultInitializedEvent {
+            vault: vault.key(),
+            scope: vault.reserve_domain,
+            asset_mint: vault.asset_mint,
+            rail: 0,
+        });
+
+        Ok(())
+    }
+
+    /// Phase 1.6 — Initialize the pool-treasury vault for a (liquidity_pool, asset_mint)
+    /// rail. Governance-only init; pool-admin signs withdrawals (PR2).
+    pub fn init_pool_treasury_vault(
+        ctx: Context<InitPoolTreasuryVault>,
+        args: InitPoolTreasuryVaultArgs,
+    ) -> Result<()> {
+        require_governance(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+        )?;
+        require!(
+            args.asset_mint != ZERO_PUBKEY,
+            OmegaXProtocolError::AssetMintMismatch
+        );
+        // Either SOL rail or matching the pool's SPL deposit mint.
+        require!(
+            args.asset_mint == NATIVE_SOL_MINT
+                || args.asset_mint == ctx.accounts.liquidity_pool.deposit_asset_mint,
+            OmegaXProtocolError::AssetMintMismatch
+        );
+        if args.asset_mint != NATIVE_SOL_MINT {
+            require!(
+                ctx.accounts.domain_asset_vault.is_some(),
+                OmegaXProtocolError::DomainAssetVaultRequired
+            );
+        }
+
+        let vault = &mut ctx.accounts.pool_treasury_vault;
+        vault.liquidity_pool = ctx.accounts.liquidity_pool.key();
+        vault.asset_mint = args.asset_mint;
+        vault.accrued_fees = 0;
+        vault.withdrawn_fees = 0;
+        vault.bump = ctx.bumps.pool_treasury_vault;
+
+        emit!(FeeVaultInitializedEvent {
+            vault: vault.key(),
+            scope: vault.liquidity_pool,
+            asset_mint: vault.asset_mint,
+            rail: 1,
+        });
+
+        Ok(())
+    }
+
+    /// Phase 1.6 — Initialize the pool-oracle fee vault for a (liquidity_pool,
+    /// oracle, asset_mint) rail. Governance-only init; the registered oracle
+    /// wallet (or oracle profile admin) signs withdrawals (PR2).
+    pub fn init_pool_oracle_fee_vault(
+        ctx: Context<InitPoolOracleFeeVault>,
+        args: InitPoolOracleFeeVaultArgs,
+    ) -> Result<()> {
+        require_governance(
+            &ctx.accounts.authority.key(),
+            &ctx.accounts.protocol_governance,
+        )?;
+        require!(
+            args.asset_mint != ZERO_PUBKEY,
+            OmegaXProtocolError::AssetMintMismatch
+        );
+        require!(
+            args.oracle != ZERO_PUBKEY,
+            OmegaXProtocolError::OracleProfileMismatch
+        );
+        require!(
+            ctx.accounts.oracle_profile.active,
+            OmegaXProtocolError::OracleProfileInactive
+        );
+        require!(
+            ctx.accounts.oracle_profile.claimed,
+            OmegaXProtocolError::OracleProfileUnclaimed
+        );
+        if args.asset_mint != NATIVE_SOL_MINT {
+            require!(
+                ctx.accounts.domain_asset_vault.is_some(),
+                OmegaXProtocolError::DomainAssetVaultRequired
+            );
+        }
+
+        let vault = &mut ctx.accounts.pool_oracle_fee_vault;
+        vault.liquidity_pool = ctx.accounts.liquidity_pool.key();
+        vault.oracle = args.oracle;
+        vault.asset_mint = args.asset_mint;
+        vault.accrued_fees = 0;
+        vault.withdrawn_fees = 0;
+        vault.bump = ctx.bumps.pool_oracle_fee_vault;
+
+        emit!(FeeVaultInitializedEvent {
+            vault: vault.key(),
+            scope: vault.liquidity_pool,
+            asset_mint: vault.asset_mint,
+            rail: 2,
         });
 
         Ok(())
@@ -2550,6 +2696,123 @@ pub struct CreateDomainAssetVault<'info> {
     pub system_program: Program<'info, System>,
 }
 
+// Phase 1.6 — Fee-vault initialization. Three governance-init instructions
+// bind the existing `ProtocolFeeVault` / `PoolTreasuryVault` / `PoolOracleFeeVault`
+// account types (declared at the bottom of this file) to a specific rail
+// scope and asset mint. Withdrawals are gated by per-rail authority in PR2.
+//
+// SOL rail: `args.asset_mint == NATIVE_SOL_MINT`. The fee-vault PDA stores
+// lamports directly (no DomainAssetVault required).
+//
+// SPL rail: a matching `DomainAssetVault` MUST exist for the (scope, mint)
+// pair so accrued fees can be paid out via PDA-signed `transfer_from_domain_vault`.
+
+#[derive(Accounts)]
+#[instruction(args: InitProtocolFeeVaultArgs)]
+pub struct InitProtocolFeeVault<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Account<'info, ProtocolGovernance>,
+    #[account(seeds = [SEED_RESERVE_DOMAIN, reserve_domain.domain_id.as_bytes()], bump = reserve_domain.bump)]
+    pub reserve_domain: Account<'info, ReserveDomain>,
+    /// Optional anchor to the SPL-rail DomainAssetVault. Required when
+    /// `args.asset_mint != NATIVE_SOL_MINT`; absent for SOL-rail vaults.
+    #[account(
+        seeds = [SEED_DOMAIN_ASSET_VAULT, reserve_domain.key().as_ref(), args.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+        constraint = domain_asset_vault.reserve_domain == reserve_domain.key() @ OmegaXProtocolError::DomainAssetVaultRequired,
+        constraint = domain_asset_vault.asset_mint == args.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub domain_asset_vault: Option<Box<Account<'info, DomainAssetVault>>>,
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + ProtocolFeeVault::INIT_SPACE,
+        seeds = [SEED_PROTOCOL_FEE_VAULT, reserve_domain.key().as_ref(), args.asset_mint.as_ref()],
+        bump,
+    )]
+    pub protocol_fee_vault: Account<'info, ProtocolFeeVault>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(args: InitPoolTreasuryVaultArgs)]
+pub struct InitPoolTreasuryVault<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Account<'info, ProtocolGovernance>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    /// Required for SPL rails. Must match (liquidity_pool.reserve_domain, args.asset_mint).
+    #[account(
+        seeds = [SEED_DOMAIN_ASSET_VAULT, liquidity_pool.reserve_domain.as_ref(), args.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+        constraint = domain_asset_vault.reserve_domain == liquidity_pool.reserve_domain @ OmegaXProtocolError::DomainAssetVaultRequired,
+        constraint = domain_asset_vault.asset_mint == args.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub domain_asset_vault: Option<Box<Account<'info, DomainAssetVault>>>,
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + PoolTreasuryVault::INIT_SPACE,
+        seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), args.asset_mint.as_ref()],
+        bump,
+    )]
+    pub pool_treasury_vault: Account<'info, PoolTreasuryVault>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(args: InitPoolOracleFeeVaultArgs)]
+pub struct InitPoolOracleFeeVault<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(seeds = [SEED_PROTOCOL_GOVERNANCE], bump = protocol_governance.bump)]
+    pub protocol_governance: Account<'info, ProtocolGovernance>,
+    #[account(
+        seeds = [SEED_LIQUIDITY_POOL, liquidity_pool.reserve_domain.as_ref(), liquidity_pool.pool_id.as_bytes()],
+        bump = liquidity_pool.bump,
+    )]
+    pub liquidity_pool: Box<Account<'info, LiquidityPool>>,
+    #[account(
+        seeds = [SEED_ORACLE_PROFILE, args.oracle.as_ref()],
+        bump = oracle_profile.bump,
+        constraint = oracle_profile.oracle == args.oracle @ OmegaXProtocolError::OracleProfileMismatch,
+    )]
+    pub oracle_profile: Box<Account<'info, OracleProfile>>,
+    #[account(
+        seeds = [SEED_POOL_ORACLE_APPROVAL, liquidity_pool.key().as_ref(), args.oracle.as_ref()],
+        bump = pool_oracle_approval.bump,
+        constraint = pool_oracle_approval.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::LiquidityPoolMismatch,
+        constraint = pool_oracle_approval.oracle == args.oracle @ OmegaXProtocolError::OracleProfileMismatch,
+        constraint = pool_oracle_approval.active @ OmegaXProtocolError::PoolOracleApprovalRequired,
+    )]
+    pub pool_oracle_approval: Box<Account<'info, PoolOracleApproval>>,
+    /// Required for SPL rails. The oracle fee vault accrues claims against the
+    /// same DomainAssetVault used by the pool.
+    #[account(
+        seeds = [SEED_DOMAIN_ASSET_VAULT, liquidity_pool.reserve_domain.as_ref(), args.asset_mint.as_ref()],
+        bump = domain_asset_vault.bump,
+        constraint = domain_asset_vault.reserve_domain == liquidity_pool.reserve_domain @ OmegaXProtocolError::DomainAssetVaultRequired,
+        constraint = domain_asset_vault.asset_mint == args.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+    )]
+    pub domain_asset_vault: Option<Box<Account<'info, DomainAssetVault>>>,
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + PoolOracleFeeVault::INIT_SPACE,
+        seeds = [SEED_POOL_ORACLE_FEE_VAULT, liquidity_pool.key().as_ref(), args.oracle.as_ref(), args.asset_mint.as_ref()],
+        bump,
+    )]
+    pub pool_oracle_fee_vault: Account<'info, PoolOracleFeeVault>,
+    pub system_program: Program<'info, System>,
+}
+
 #[derive(Accounts)]
 #[instruction(args: CreateHealthPlanArgs)]
 pub struct CreateHealthPlan<'info> {
@@ -4153,6 +4416,28 @@ pub struct CreateDomainAssetVaultArgs {
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct InitProtocolFeeVaultArgs {
+    /// SPL mint for the fee rail. Pass `NATIVE_SOL_MINT` to bind a SOL-rail vault.
+    pub asset_mint: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct InitPoolTreasuryVaultArgs {
+    /// Asset mint must equal `liquidity_pool.deposit_asset_mint` for SPL pools, or
+    /// `NATIVE_SOL_MINT` for the SOL rail.
+    pub asset_mint: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct InitPoolOracleFeeVaultArgs {
+    /// Oracle wallet whose fee vault is being initialized. Must match
+    /// `oracle_profile.oracle` and have an active `PoolOracleApproval` on the pool.
+    pub oracle: Pubkey,
+    /// Asset mint of the rail (use `NATIVE_SOL_MINT` for SOL).
+    pub asset_mint: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct CreateHealthPlanArgs {
     #[max_len(MAX_ID_LEN)]
     pub plan_id: String,
@@ -4697,6 +4982,32 @@ pub struct LedgerInitializedEvent {
 }
 
 #[event]
+pub struct FeeVaultInitializedEvent {
+    pub vault: Pubkey,
+    pub scope: Pubkey,
+    pub asset_mint: Pubkey,
+    /// 0 = ProtocolFeeVault, 1 = PoolTreasuryVault, 2 = PoolOracleFeeVault.
+    pub rail: u8,
+}
+
+#[event]
+pub struct FeeAccruedEvent {
+    pub vault: Pubkey,
+    pub asset_mint: Pubkey,
+    pub amount: u64,
+    pub accrued_total: u64,
+}
+
+#[event]
+pub struct FeeWithdrawnEvent {
+    pub vault: Pubkey,
+    pub asset_mint: Pubkey,
+    pub amount: u64,
+    pub recipient: Pubkey,
+    pub withdrawn_total: u64,
+}
+
+#[event]
 pub struct OracleProfileRegisteredEvent {
     pub oracle_profile: Pubkey,
     pub oracle: Pubkey,
@@ -4918,6 +5229,22 @@ pub enum OmegaXProtocolError {
     ClaimAttestationSchemaUnsupported,
     #[msg("Too many schema dependency addresses were provided")]
     TooManySchemaDependencies,
+    #[msg("Fee vault initialization requires the matching domain asset vault to exist")]
+    DomainAssetVaultRequired,
+    #[msg("Liquidity pool reference does not match the supplied account")]
+    LiquidityPoolMismatch,
+    #[msg("Oracle profile reference does not match the supplied account")]
+    OracleProfileMismatch,
+    #[msg("Fee vault account does not match the expected scope")]
+    FeeVaultMismatch,
+    #[msg("Fee vault has insufficient accrued balance for this withdrawal")]
+    FeeVaultInsufficientBalance,
+    #[msg("Fee vault withdrawal would breach the rent-exempt minimum balance")]
+    FeeVaultRentExemptionBreach,
+    #[msg("Fee vault rail and asset mint disagree (SOL vault used on SPL path or vice versa)")]
+    FeeVaultRailMismatch,
+    #[msg("Fee vault basis-points configuration is out of range")]
+    FeeVaultBpsMisconfigured,
 }
 
 fn require_id(value: &str) -> Result<()> {
@@ -5734,6 +6061,45 @@ fn transfer_to_domain_vault<'info>(
         amount,
         asset_mint.decimals,
     )
+}
+
+// Phase 1.6 — Fee accrual helpers. Inflow handlers (record_premium_payment,
+// deposit_into_capital_class, process_redemption_queue, settle_claim_case)
+// call `fee_share_from_bps` to compute the carve-out from a user-facing
+// amount, then `accrue_fee` to credit the vault's `accrued_fees` counter.
+// SPL tokens physically remain in the matching `DomainAssetVault.vault_token_account`;
+// the fee-vault account only tracks the rail's claim. SOL fees physically
+// reside on the fee-vault PDA itself (lamport math, not SPL CPI).
+//
+// Floors to zero (Solana convention). Returns 0 when bps == 0 or amount == 0,
+// so callers can blindly invoke without conditional skips.
+fn fee_share_from_bps(amount: u64, bps: u16) -> Result<u64> {
+    if bps == 0 || amount == 0 {
+        return Ok(0);
+    }
+    require!(bps <= 10_000, OmegaXProtocolError::FeeVaultBpsMisconfigured);
+    let scaled = (amount as u128)
+        .checked_mul(bps as u128)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?
+        .checked_div(10_000u128)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?;
+    let fee = checked_u128_to_u64(scaled)?;
+    // Defensive: fee can never exceed amount.
+    require!(fee <= amount, OmegaXProtocolError::ArithmeticError);
+    Ok(fee)
+}
+
+// Credits `amount` to the running accrued counter and returns the new total.
+// Callers emit `FeeAccruedEvent` with the returned total. No-op when amount == 0
+// (still returns the unchanged total) so callers can blindly invoke after a
+// `fee_share_from_bps(...)` that may yield zero.
+fn accrue_fee(accrued: &mut u64, amount: u64) -> Result<u64> {
+    if amount == 0 {
+        return Ok(*accrued);
+    }
+    let new_total = checked_add(*accrued, amount)?;
+    *accrued = new_total;
+    Ok(new_total)
 }
 
 // PDA-signed outflow helper. Unblocks PT-2026-04-27-01 and PT-2026-04-27-02:

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1865,8 +1865,37 @@ pub mod omegax_protocol {
         )?;
 
         let amount = args.amount;
+
+        // Phase 1.6 — Pool-treasury entry fee. Validate the optional fee vault
+        // matches (liquidity_pool, deposit_asset_mint), then compute the fee
+        // against capital_class.fee_bps. The full `amount` remains physically
+        // locked in the DomainAssetVault; the fee carve-out is removed from
+        // the LP-side accounting only (subscription_basis, NAV, default shares).
+        // pool.total_value_locked still tracks the full physical balance.
+        let pool_key = ctx.accounts.liquidity_pool.key();
+        let pool_deposit_mint = ctx.accounts.liquidity_pool.deposit_asset_mint;
+        let class_fee_bps = ctx.accounts.capital_class.fee_bps;
+        let entry_fee = if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref() {
+            require_keys_eq!(
+                vault.liquidity_pool,
+                pool_key,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            require_keys_eq!(
+                vault.asset_mint,
+                pool_deposit_mint,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            fee_share_from_bps(amount, class_fee_bps)?
+        } else {
+            0
+        };
+        let net_amount = checked_sub(amount, entry_fee)?;
+
+        // Default shares track the LP's net contribution (post-fee). Caller-supplied
+        // shares are honored verbatim — caller is responsible for accounting.
         let shares = if args.shares == 0 {
-            amount
+            net_amount
         } else {
             args.shares
         };
@@ -1879,11 +1908,11 @@ pub mod omegax_protocol {
         let lp_position = &mut ctx.accounts.lp_position;
         ensure_lp_position_binding(lp_position, capital_class_key, owner, ctx.bumps.lp_position)?;
         require_class_access_mode(restriction_mode, lp_position.credentialed)?;
-        apply_lp_position_deposit(lp_position, amount, shares, min_lockup_seconds, now_ts)?;
+        apply_lp_position_deposit(lp_position, net_amount, shares, min_lockup_seconds, now_ts)?;
 
         let capital_class = &mut ctx.accounts.capital_class;
         capital_class.total_shares = checked_add(capital_class.total_shares, shares)?;
-        capital_class.nav_assets = checked_add(capital_class.nav_assets, amount)?;
+        capital_class.nav_assets = checked_add(capital_class.nav_assets, net_amount)?;
 
         let pool = &mut ctx.accounts.liquidity_pool;
         pool.total_value_locked = checked_add(pool.total_value_locked, amount)?;
@@ -1893,6 +1922,24 @@ pub mod omegax_protocol {
         book_inflow_sheet(&mut ctx.accounts.pool_class_ledger.sheet, amount)?;
         ctx.accounts.pool_class_ledger.total_shares =
             checked_add(ctx.accounts.pool_class_ledger.total_shares, shares)?;
+
+        // Accrue the entry fee to the pool-treasury vault. SPL tokens already
+        // sit in the DomainAssetVault from the transfer above; this only updates
+        // the rail's claim counter. Skipped silently when entry_fee == 0 (either
+        // pool_treasury_vault is None or capital_class.fee_bps == 0).
+        if entry_fee > 0 {
+            if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
+                let vault_key = vault.key();
+                let vault_mint = vault.asset_mint;
+                let accrued_total = accrue_fee(&mut vault.accrued_fees, entry_fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: vault_key,
+                    asset_mint: vault_mint,
+                    amount: entry_fee,
+                    accrued_total,
+                });
+            }
+        }
 
         emit!(CapitalClassDepositEvent {
             capital_class: capital_class.key(),
@@ -3498,6 +3545,11 @@ pub struct DepositIntoCapitalClass<'info> {
         bump
     )]
     pub lp_position: Box<Account<'info, LPPosition>>,
+    /// Phase 1.6 — optional pool-treasury vault for entry-fee accrual.
+    /// When supplied, must match (liquidity_pool, deposit_asset_mint).
+    /// Validated at runtime; absent means entry-fee accrual is skipped (backward compat).
+    #[account(mut)]
+    pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -2035,6 +2035,32 @@ pub mod omegax_protocol {
             ctx.accounts.lp_position.pending_redemption_shares,
             ctx.accounts.lp_position.pending_redemption_assets,
         )?;
+
+        // Phase 1.6 — Pool-treasury exit fee. Validate the optional fee vault
+        // matches (liquidity_pool, deposit_asset_mint), then compute the carve-out.
+        // The full pending request is resolved (LP gives up claim on asset_amount),
+        // but only `net_to_lp` physically leaves the vault — the fee carve-out
+        // stays in the SPL token account as a treasury claim accrued below.
+        let pool_key = ctx.accounts.liquidity_pool.key();
+        let pool_deposit_mint = ctx.accounts.liquidity_pool.deposit_asset_mint;
+        let class_fee_bps = ctx.accounts.capital_class.fee_bps;
+        let exit_fee = if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref() {
+            require_keys_eq!(
+                vault.liquidity_pool,
+                pool_key,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            require_keys_eq!(
+                vault.asset_mint,
+                pool_deposit_mint,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            fee_share_from_bps(asset_amount, class_fee_bps)?
+        } else {
+            0
+        };
+        let net_to_lp = checked_sub(asset_amount, exit_fee)?;
+
         ctx.accounts.lp_position.pending_redemption_shares = checked_sub(
             ctx.accounts.lp_position.pending_redemption_shares,
             args.shares,
@@ -2045,9 +2071,10 @@ pub mod omegax_protocol {
         )?;
         ctx.accounts.lp_position.shares =
             checked_sub(ctx.accounts.lp_position.shares, args.shares)?;
+        // realized_distributions tracks what the LP actually received (post-fee).
         ctx.accounts.lp_position.realized_distributions = checked_add(
             ctx.accounts.lp_position.realized_distributions,
-            asset_amount,
+            net_to_lp,
         )?;
         ctx.accounts.lp_position.queue_status =
             if ctx.accounts.lp_position.pending_redemption_shares == 0 {
@@ -2056,22 +2083,32 @@ pub mod omegax_protocol {
                 LP_QUEUE_STATUS_PENDING
             };
 
+        // capital_class: LP claim reduced by the full asset_amount (the LP
+        // gives up claim on the entire pending payout; the fee portion is
+        // reclassified to treasury, not retained by LPs).
         ctx.accounts.capital_class.total_shares =
             checked_sub(ctx.accounts.capital_class.total_shares, args.shares)?;
         ctx.accounts.capital_class.nav_assets =
             checked_sub(ctx.accounts.capital_class.nav_assets, asset_amount)?;
         ctx.accounts.capital_class.pending_redemptions =
             checked_sub(ctx.accounts.capital_class.pending_redemptions, asset_amount)?;
+        // pool: total_value_locked tracks physical lock, decreases only by
+        // net_to_lp (fee tokens stay locked as treasury claim).
         ctx.accounts.liquidity_pool.total_value_locked =
-            checked_sub(ctx.accounts.liquidity_pool.total_value_locked, asset_amount)?;
+            checked_sub(ctx.accounts.liquidity_pool.total_value_locked, net_to_lp)?;
         ctx.accounts.liquidity_pool.total_pending_redemptions = checked_sub(
             ctx.accounts.liquidity_pool.total_pending_redemptions,
             asset_amount,
         )?;
 
+        // Physical vault counter — only net_to_lp leaves the SPL token account.
         ctx.accounts.domain_asset_vault.total_assets =
-            checked_sub(ctx.accounts.domain_asset_vault.total_assets, asset_amount)?;
+            checked_sub(ctx.accounts.domain_asset_vault.total_assets, net_to_lp)?;
 
+        // Ledger sheets: track the full pending → settled transition. When fee
+        // is taken, the sheet temporarily over-states LP outflow vs physical
+        // outflow; treasury accrual reconciles via the accrued_fees counter.
+        // TODO: fee-aware ledger semantics in a follow-up.
         settle_pending_redemption(
             &mut ctx.accounts.pool_class_ledger,
             asset_amount,
@@ -2091,13 +2128,30 @@ pub mod omegax_protocol {
             OmegaXProtocolError::Unauthorized
         );
         transfer_from_domain_vault(
-            asset_amount,
+            net_to_lp,
             &ctx.accounts.domain_asset_vault,
             &ctx.accounts.vault_token_account,
             &ctx.accounts.recipient_token_account,
             &ctx.accounts.asset_mint,
             &ctx.accounts.token_program,
         )?;
+
+        // Accrue the exit fee to the pool-treasury vault. SPL tokens are still
+        // physically in the vault_token_account; only the rail's claim counter
+        // changes. Skipped silently when exit_fee == 0.
+        if exit_fee > 0 {
+            if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
+                let vault_key = vault.key();
+                let vault_mint = vault.asset_mint;
+                let accrued_total = accrue_fee(&mut vault.accrued_fees, exit_fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: vault_key,
+                    asset_mint: vault_mint,
+                    amount: exit_fee,
+                    accrued_total,
+                });
+            }
+        }
 
         Ok(())
     }
@@ -3593,6 +3647,11 @@ pub struct ProcessRedemptionQueue<'info> {
     pub pool_class_ledger: Box<Account<'info, PoolClassLedger>>,
     #[account(mut, seeds = [SEED_LP_POSITION, capital_class.key().as_ref(), lp_position.owner.as_ref()], bump = lp_position.bump)]
     pub lp_position: Box<Account<'info, LPPosition>>,
+    /// Phase 1.6 — optional pool-treasury vault for exit-fee accrual.
+    /// When supplied, must match (liquidity_pool, deposit_asset_mint).
+    /// Validated at runtime; absent means exit-fee accrual is skipped (backward compat).
+    #[account(mut)]
+    pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
     // PT-2026-04-27-01/02 fix: outflow CPI accounts. Recipient must be the LP
     // position's owner — there is no delegate-recipient pattern for redemptions.
     #[account(

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -10300,6 +10300,1197 @@
           "address": "11111111111111111111111111111111"
         }
       ]
+    },
+    {
+      "name": "withdraw_pool_oracle_fee_sol",
+      "discriminator": [
+        208,
+        223,
+        250,
+        62,
+        199,
+        8,
+        221,
+        185
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "oracle_profile.oracle",
+                "account": "OracleProfile"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.oracle",
+                "account": "PoolOracleFeeVault"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_oracle_fee_spl",
+      "discriminator": [
+        242,
+        75,
+        247,
+        122,
+        255,
+        183,
+        48,
+        189
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "oracle_profile.oracle",
+                "account": "OracleProfile"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.oracle",
+                "account": "PoolOracleFeeVault"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "token_program",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_treasury_sol",
+      "discriminator": [
+        50,
+        115,
+        51,
+        120,
+        221,
+        37,
+        200,
+        169
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_pool_treasury_spl",
+      "discriminator": [
+        43,
+        146,
+        116,
+        123,
+        106,
+        69,
+        242,
+        104
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "token_program",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee_sol",
+      "discriminator": [
+        193,
+        33,
+        140,
+        185,
+        45,
+        190,
+        112,
+        7
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "recipient",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee_spl",
+      "discriminator": [
+        120,
+        62,
+        236,
+        14,
+        227,
+        240,
+        52,
+        253
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "WithdrawArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": false,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "asset_mint",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "vault_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "recipient_token_account",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "token_program",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        }
+      ]
     }
   ],
   "accountDiscriminators": {

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -3533,6 +3533,12 @@
           }
         },
         {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "signer": false,
+          "optional": true
+        },
+        {
           "name": "source_token_account",
           "writable": true,
           "signer": false,
@@ -3902,6 +3908,666 @@
           "writable": false,
           "signer": false,
           "optional": false
+        }
+      ]
+    },
+    {
+      "name": "init_pool_oracle_fee_vault",
+      "discriminator": [
+        68,
+        122,
+        148,
+        84,
+        91,
+        98,
+        198,
+        167
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitPoolOracleFeeVaultArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle_profile",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  112,
+                  114,
+                  111,
+                  102,
+                  105,
+                  108,
+                  101
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_approval",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  97,
+                  112,
+                  112,
+                  114,
+                  111,
+                  118,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": false,
+          "signer": false,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  111,
+                  114,
+                  97,
+                  99,
+                  108,
+                  101,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.oracle"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "init_pool_treasury_vault",
+      "discriminator": [
+        96,
+        169,
+        51,
+        224,
+        0,
+        207,
+        141,
+        47
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitPoolTreasuryVaultArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  105,
+                  113,
+                  117,
+                  105,
+                  100,
+                  105,
+                  116,
+                  121,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.pool_id",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": false,
+          "signer": false,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "init_protocol_fee_vault",
+      "discriminator": [
+        212,
+        235,
+        61,
+        42,
+        96,
+        183,
+        225,
+        57
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "InitProtocolFeeVaultArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_domain",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  115,
+                  101,
+                  114,
+                  118,
+                  101,
+                  95,
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain.domain_id",
+                "account": "ReserveDomain"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_vault",
+          "writable": false,
+          "signer": false,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "arg",
+                "path": "args.asset_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
         }
       ]
     },
@@ -5289,6 +5955,12 @@
           }
         },
         {
+          "name": "pool_treasury_vault",
+          "writable": true,
+          "signer": false,
+          "optional": true
+        },
+        {
           "name": "asset_mint",
           "writable": false,
           "signer": false,
@@ -5624,6 +6296,12 @@
         },
         {
           "name": "series_reserve_ledger",
+          "writable": true,
+          "signer": false,
+          "optional": true
+        },
+        {
+          "name": "protocol_fee_vault",
           "writable": true,
           "signer": false,
           "optional": true
@@ -7896,6 +8574,24 @@
           "optional": true
         },
         {
+          "name": "protocol_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": true
+        },
+        {
+          "name": "pool_oracle_fee_vault",
+          "writable": true,
+          "signer": false,
+          "optional": true
+        },
+        {
+          "name": "pool_oracle_policy",
+          "writable": false,
+          "signer": false,
+          "optional": true
+        },
+        {
           "name": "member_position",
           "writable": false,
           "signer": false,
@@ -9817,6 +10513,16 @@
       153,
       29
     ],
+    "PoolOracleFeeVault": [
+      167,
+      128,
+      29,
+      44,
+      248,
+      197,
+      244,
+      23
+    ],
     "PoolOraclePermissionSet": [
       3,
       136,
@@ -9836,6 +10542,26 @@
       203,
       226,
       43
+    ],
+    "PoolTreasuryVault": [
+      93,
+      195,
+      95,
+      29,
+      127,
+      28,
+      59,
+      193
+    ],
+    "ProtocolFeeVault": [
+      199,
+      15,
+      107,
+      45,
+      108,
+      244,
+      162,
+      105
     ],
     "ProtocolGovernance": [
       71,

--- a/tests/protocol_contract.test.ts
+++ b/tests/protocol_contract.test.ts
@@ -47,6 +47,14 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert(instructionNames.includes("init_pool_treasury_vault"));
   assert(instructionNames.includes("init_pool_oracle_fee_vault"));
 
+  // Phase 1.7 — fee-vault withdraw instructions (SOL + SPL × 3 rails)
+  assert(instructionNames.includes("withdraw_protocol_fee_sol"));
+  assert(instructionNames.includes("withdraw_protocol_fee_spl"));
+  assert(instructionNames.includes("withdraw_pool_treasury_sol"));
+  assert(instructionNames.includes("withdraw_pool_treasury_spl"));
+  assert(instructionNames.includes("withdraw_pool_oracle_fee_sol"));
+  assert(instructionNames.includes("withdraw_pool_oracle_fee_spl"));
+
   assert(accountNames.includes("ReserveDomain"));
   assert(accountNames.includes("HealthPlan"));
   assert(accountNames.includes("PolicySeries"));
@@ -99,6 +107,33 @@ test("canonical contract exposes the health-capital-markets surface", () => {
     PROTOCOL_INSTRUCTION_ACCOUNTS.settle_claim_case.some(
       (account) => account.name === "pool_oracle_policy",
     ),
+  );
+
+  // Phase 1.7 — withdraw ix account lists encode per-rail authority and
+  // physical-custody routing.
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.withdraw_protocol_fee_spl.some(
+      (account) => account.name === "domain_asset_vault",
+    ),
+    "protocol-fee SPL withdraw must thread DomainAssetVault for PDA-signed CPI",
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.withdraw_protocol_fee_sol.some(
+      (account) => account.name === "recipient",
+    ),
+    "protocol-fee SOL withdraw must take a system-account recipient",
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.withdraw_pool_treasury_spl.some(
+      (account) => account.name === "liquidity_pool",
+    ),
+    "pool-treasury withdraw must thread LiquidityPool for curator authority",
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.withdraw_pool_oracle_fee_spl.some(
+      (account) => account.name === "oracle_profile",
+    ),
+    "pool-oracle-fee withdraw must thread OracleProfile for oracle authority",
   );
 
   assert(!instructionNames.includes("create_pool"));

--- a/tests/protocol_contract.test.ts
+++ b/tests/protocol_contract.test.ts
@@ -136,6 +136,24 @@ test("canonical contract exposes the health-capital-markets surface", () => {
     "pool-oracle-fee withdraw must thread OracleProfile for oracle authority",
   );
 
+  // Phase 1.7 PR3 — withdraw ix args matrix. All 6 ix share WithdrawArgs { amount: u64 }.
+  for (const name of [
+    "withdraw_protocol_fee_sol",
+    "withdraw_protocol_fee_spl",
+    "withdraw_pool_treasury_sol",
+    "withdraw_pool_treasury_spl",
+    "withdraw_pool_oracle_fee_sol",
+    "withdraw_pool_oracle_fee_spl",
+  ] as const) {
+    const args = PROTOCOL_INSTRUCTION_ARGS[name];
+    assert(args, `expected args for ${name}`);
+    assert.equal(
+      args.length,
+      1,
+      `${name} should take exactly one args struct (WithdrawArgs)`,
+    );
+  }
+
   assert(!instructionNames.includes("create_pool"));
   assert(!instructionNames.includes("set_pool_status"));
   assert(!serializedAccounts.includes("pool_type"));

--- a/tests/protocol_contract.test.ts
+++ b/tests/protocol_contract.test.ts
@@ -42,6 +42,11 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert(instructionNames.includes("close_outcome_schema"));
   assert(instructionNames.includes("attest_claim_case"));
 
+  // Phase 1.6 — fee-vault init instructions
+  assert(instructionNames.includes("init_protocol_fee_vault"));
+  assert(instructionNames.includes("init_pool_treasury_vault"));
+  assert(instructionNames.includes("init_pool_oracle_fee_vault"));
+
   assert(accountNames.includes("ReserveDomain"));
   assert(accountNames.includes("HealthPlan"));
   assert(accountNames.includes("PolicySeries"));
@@ -58,6 +63,43 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert(accountNames.includes("OutcomeSchema"));
   assert(accountNames.includes("SchemaDependencyLedger"));
   assert(accountNames.includes("ClaimAttestation"));
+
+  // Phase 1.6 — fee-vault account types (declared on-chain, exposed via IDL)
+  assert(accountNames.includes("ProtocolFeeVault"));
+  assert(accountNames.includes("PoolTreasuryVault"));
+  assert(accountNames.includes("PoolOracleFeeVault"));
+
+  // Phase 1.6 — optional fee accounts on the inflow handlers we wired accrual into
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.record_premium_payment.some(
+      (account) => account.name === "protocol_fee_vault",
+    ),
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.deposit_into_capital_class.some(
+      (account) => account.name === "pool_treasury_vault",
+    ),
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.process_redemption_queue.some(
+      (account) => account.name === "pool_treasury_vault",
+    ),
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.settle_claim_case.some(
+      (account) => account.name === "protocol_fee_vault",
+    ),
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.settle_claim_case.some(
+      (account) => account.name === "pool_oracle_fee_vault",
+    ),
+  );
+  assert(
+    PROTOCOL_INSTRUCTION_ACCOUNTS.settle_claim_case.some(
+      (account) => account.name === "pool_oracle_policy",
+    ),
+  );
 
   assert(!instructionNames.includes("create_pool"));
   assert(!instructionNames.includes("set_pool_status"));

--- a/tests/protocol_pdas.test.ts
+++ b/tests/protocol_pdas.test.ts
@@ -24,7 +24,12 @@ const {
   deriveProtocolGovernancePda,
   deriveReserveDomainPda,
   deriveSchemaDependencyLedgerPda,
+  deriveProtocolFeeVaultPda,
+  derivePoolTreasuryVaultPda,
+  derivePoolOracleFeeVaultPda,
   MEMBERSHIP_PROOF_MODE_INVITE_PERMIT,
+  NATIVE_SOL_MINT,
+  NATIVE_SOL_MINT_KEY,
   ZERO_PUBKEY,
 } = protocolModule as typeof import("../frontend/lib/protocol.ts");
 
@@ -115,6 +120,88 @@ test("claim attestation builders reject unsupported decisions before chain submi
       }),
     /claim attestation decision must be one of 0/,
   );
+});
+
+test("Phase 1.7 fee-vault PDA derivers are deterministic and rail-aware", () => {
+  const [openDomain] = DEVNET_PROTOCOL_FIXTURE_STATE.reserveDomains;
+  const pool = DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!;
+  const oracleAddress = DEFAULT_HEALTH_PLAN_ADDRESS;
+  const splMint = pool.depositAssetMint;
+
+  // Sanity: all 9 derivers (3 vaults × {SOL, SPL, distinct-seed-input}) return
+  // valid base58 PDA addresses.
+  const protocolFeeSpl = deriveProtocolFeeVaultPda({
+    reserveDomain: openDomain.address,
+    assetMint: splMint,
+  });
+  const protocolFeeSol = deriveProtocolFeeVaultPda({
+    reserveDomain: openDomain.address,
+    assetMint: NATIVE_SOL_MINT_KEY,
+  });
+  const poolTreasurySpl = derivePoolTreasuryVaultPda({
+    liquidityPool: pool.address,
+    assetMint: splMint,
+  });
+  const poolTreasurySol = derivePoolTreasuryVaultPda({
+    liquidityPool: pool.address,
+    assetMint: NATIVE_SOL_MINT_KEY,
+  });
+  const poolOracleSpl = derivePoolOracleFeeVaultPda({
+    liquidityPool: pool.address,
+    oracle: oracleAddress,
+    assetMint: splMint,
+  });
+  const poolOracleSol = derivePoolOracleFeeVaultPda({
+    liquidityPool: pool.address,
+    oracle: oracleAddress,
+    assetMint: NATIVE_SOL_MINT_KEY,
+  });
+
+  for (const pda of [
+    protocolFeeSpl,
+    protocolFeeSol,
+    poolTreasurySpl,
+    poolTreasurySol,
+    poolOracleSpl,
+    poolOracleSol,
+  ]) {
+    assert.match(pda.toBase58(), /^[1-9A-HJ-NP-Za-km-z]{32,44}$/);
+  }
+
+  // SOL and SPL rails of the same vault scope MUST produce different PDAs —
+  // otherwise the rail-mismatch guard wouldn't be necessary on-chain.
+  assert.notEqual(protocolFeeSpl.toBase58(), protocolFeeSol.toBase58());
+  assert.notEqual(poolTreasurySpl.toBase58(), poolTreasurySol.toBase58());
+  assert.notEqual(poolOracleSpl.toBase58(), poolOracleSol.toBase58());
+
+  // Different rails (protocol/treasury/oracle) MUST produce different PDAs
+  // for the same (scope, mint) — they use different seed prefixes.
+  assert.notEqual(protocolFeeSpl.toBase58(), poolTreasurySpl.toBase58());
+  assert.notEqual(poolTreasurySpl.toBase58(), poolOracleSpl.toBase58());
+
+  // Determinism: re-deriving with the same inputs returns the same PDA.
+  assert.equal(
+    deriveProtocolFeeVaultPda({
+      reserveDomain: openDomain.address,
+      assetMint: splMint,
+    }).toBase58(),
+    protocolFeeSpl.toBase58(),
+  );
+
+  // NATIVE_SOL_MINT string and NATIVE_SOL_MINT_KEY (PublicKey) produce the
+  // same PDA — both forms are accepted via toPublicKey coercion.
+  assert.equal(
+    deriveProtocolFeeVaultPda({
+      reserveDomain: openDomain.address,
+      assetMint: NATIVE_SOL_MINT,
+    }).toBase58(),
+    protocolFeeSol.toBase58(),
+  );
+
+  // ZERO_PUBKEY (the panel's UI sentinel) is NOT the same as NATIVE_SOL_MINT
+  // and would derive a different PDA — confirm the listers are responsible
+  // for translating UI sentinel to on-chain mint, not the derivers.
+  assert.notEqual(ZERO_PUBKEY, NATIVE_SOL_MINT);
 });
 
 test("member enrollment builder marks invite authority as a signer", () => {

--- a/tests/protocol_withdraw_builders.test.ts
+++ b/tests/protocol_withdraw_builders.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Phase 1.7 — Fee-vault withdrawal builder tests.
+//
+// Validates that each of the 6 buildWithdraw*Tx builders produces a transaction
+// whose instruction (a) targets the protocol program, (b) carries the correct
+// 8-byte instruction discriminator, (c) has the right signer flag on the
+// authority key, (d) has the rail-scope account at the right ordinal, and
+// (e) BN-encodes the amount arg.
+//
+// Account ordering MUST match the on-chain `#[derive(Accounts)]` structs —
+// any drift surfaces here as an ordinal-pubkey mismatch.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PublicKey } from "@solana/web3.js";
+import contractModule from "../frontend/lib/generated/protocol-contract.ts";
+import protocolModule from "../frontend/lib/protocol.ts";
+import fixturesModule from "../frontend/lib/devnet-fixtures.ts";
+
+const { PROTOCOL_INSTRUCTION_DISCRIMINATORS } = contractModule as typeof import(
+  "../frontend/lib/generated/protocol-contract.ts"
+);
+const {
+  buildWithdrawProtocolFeeSplTx,
+  buildWithdrawProtocolFeeSolTx,
+  buildWithdrawPoolTreasurySplTx,
+  buildWithdrawPoolTreasurySolTx,
+  buildWithdrawPoolOracleFeeSplTx,
+  buildWithdrawPoolOracleFeeSolTx,
+  deriveProtocolGovernancePda,
+  deriveProtocolFeeVaultPda,
+  derivePoolTreasuryVaultPda,
+  derivePoolOracleFeeVaultPda,
+  deriveDomainAssetVaultPda,
+  deriveDomainAssetVaultTokenAccountPda,
+  deriveOracleProfilePda,
+  getProgramId,
+  NATIVE_SOL_MINT_KEY,
+} = protocolModule as typeof import("../frontend/lib/protocol.ts");
+
+const { DEVNET_PROTOCOL_FIXTURE_STATE, DEFAULT_LIQUIDITY_POOL_ADDRESS } =
+  fixturesModule as typeof import("../frontend/lib/devnet-fixtures.ts");
+
+const RECENT_BLOCKHASH = "11111111111111111111111111111111";
+const AUTHORITY = new PublicKey("So11111111111111111111111111111111111111112");
+const SPL_MINT = new PublicKey(DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!.depositAssetMint);
+const POOL = new PublicKey(DEFAULT_LIQUIDITY_POOL_ADDRESS);
+const RESERVE_DOMAIN = new PublicKey(DEVNET_PROTOCOL_FIXTURE_STATE.reserveDomains[0]!.address);
+const RECIPIENT_ATA = new PublicKey("BVfgRQQk1WDTo6QPwhfRR5MKfQ58oV44L94qhEHjk1tg");
+const RECIPIENT_SYS = new PublicKey("Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B");
+const ORACLE = new PublicKey("oxhocTdPyENqy9RS13iaq2upoNAovMJHu9PMaBxrK8h");
+
+function discriminatorForName(name: string): Uint8Array {
+  const disc = (PROTOCOL_INSTRUCTION_DISCRIMINATORS as Record<string, Uint8Array>)[name];
+  assert.ok(disc, `expected discriminator for ${name}`);
+  return disc;
+}
+
+function assertProtocolIxShape(
+  tx: { feePayer?: PublicKey; instructions: ReadonlyArray<{ programId: PublicKey; data: Buffer | Uint8Array; keys: ReadonlyArray<{ pubkey: PublicKey; isSigner: boolean; isWritable: boolean }> }> },
+  expectedName: string,
+  expectedAuthority: PublicKey,
+): { keys: ReadonlyArray<{ pubkey: PublicKey; isSigner: boolean; isWritable: boolean }>; data: Buffer | Uint8Array } {
+  assert.equal(tx.instructions.length, 1, `${expectedName} should produce exactly one instruction`);
+  const ix = tx.instructions[0]!;
+  assert.equal(
+    ix.programId.toBase58(),
+    getProgramId().toBase58(),
+    `${expectedName} instruction must target the protocol program`,
+  );
+  const expectedDisc = discriminatorForName(expectedName);
+  const actualDiscPrefix = Array.from(ix.data.subarray(0, 8));
+  assert.deepEqual(
+    actualDiscPrefix,
+    Array.from(expectedDisc),
+    `${expectedName} discriminator prefix mismatch`,
+  );
+  assert.equal(
+    ix.keys[0]!.pubkey.toBase58(),
+    expectedAuthority.toBase58(),
+    `${expectedName} authority must be the first account`,
+  );
+  assert.equal(
+    ix.keys[0]!.isSigner,
+    true,
+    `${expectedName} authority must be flagged as signer`,
+  );
+  return ix;
+}
+
+test("buildWithdrawProtocolFeeSplTx: programId, discriminator, authority, vault PDAs", () => {
+  const tx = buildWithdrawProtocolFeeSplTx({
+    governanceAuthority: AUTHORITY,
+    reserveDomainAddress: RESERVE_DOMAIN,
+    paymentMint: SPL_MINT,
+    recipientTokenAccount: RECIPIENT_ATA,
+    amount: 1_000_000n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_protocol_fee_spl", AUTHORITY);
+  // Account order per on-chain struct: authority, governance, reserve_domain,
+  // protocol_fee_vault, domain_asset_vault, asset_mint, vault_token_account,
+  // recipient_token_account, token_program.
+  assert.equal(ix.keys[1]!.pubkey.toBase58(), deriveProtocolGovernancePda().toBase58());
+  assert.equal(ix.keys[2]!.pubkey.toBase58(), RESERVE_DOMAIN.toBase58());
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    deriveProtocolFeeVaultPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[4]!.pubkey.toBase58(),
+    deriveDomainAssetVaultPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
+  );
+  assert.equal(ix.keys[5]!.pubkey.toBase58(), SPL_MINT.toBase58());
+  assert.equal(
+    ix.keys[6]!.pubkey.toBase58(),
+    deriveDomainAssetVaultTokenAccountPda({
+      reserveDomain: RESERVE_DOMAIN,
+      assetMint: SPL_MINT,
+    }).toBase58(),
+  );
+  assert.equal(ix.keys[7]!.pubkey.toBase58(), RECIPIENT_ATA.toBase58());
+});
+
+test("buildWithdrawProtocolFeeSolTx: SOL rail uses NATIVE_SOL_MINT in vault seed", () => {
+  const tx = buildWithdrawProtocolFeeSolTx({
+    governanceAuthority: AUTHORITY,
+    reserveDomainAddress: RESERVE_DOMAIN,
+    recipientSystemAccount: RECIPIENT_SYS,
+    amount: 5_000_000n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_protocol_fee_sol", AUTHORITY);
+  // Account order: authority, governance, reserve_domain, protocol_fee_vault,
+  // recipient, system_program.
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    deriveProtocolFeeVaultPda({
+      reserveDomain: RESERVE_DOMAIN,
+      assetMint: NATIVE_SOL_MINT_KEY,
+    }).toBase58(),
+    "SOL rail must derive the fee-vault PDA against NATIVE_SOL_MINT, not the recipient or any SPL mint",
+  );
+  assert.equal(ix.keys[4]!.pubkey.toBase58(), RECIPIENT_SYS.toBase58());
+  // SOL rail does NOT thread DomainAssetVault — the vault PDA holds lamports
+  // directly. The struct only has 6 accounts vs 9 for the SPL variant.
+  assert.equal(ix.keys.length, 6);
+});
+
+test("buildWithdrawPoolTreasurySplTx: pool-scoped vault PDA, asset_mint check", () => {
+  const tx = buildWithdrawPoolTreasurySplTx({
+    oracle: AUTHORITY,
+    poolAddress: POOL,
+    reserveDomainAddress: RESERVE_DOMAIN,
+    paymentMint: SPL_MINT,
+    recipientTokenAccount: RECIPIENT_ATA,
+    amount: 250_000n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_pool_treasury_spl", AUTHORITY);
+  // Account order: authority, governance, liquidity_pool, pool_treasury_vault,
+  // domain_asset_vault, asset_mint, vault_token_account, recipient, token_program.
+  assert.equal(ix.keys[2]!.pubkey.toBase58(), POOL.toBase58());
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    derivePoolTreasuryVaultPda({ liquidityPool: POOL, assetMint: SPL_MINT }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[4]!.pubkey.toBase58(),
+    deriveDomainAssetVaultPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
+  );
+});
+
+test("buildWithdrawPoolTreasurySolTx: minimal SOL rail accounts", () => {
+  const tx = buildWithdrawPoolTreasurySolTx({
+    oracle: AUTHORITY,
+    poolAddress: POOL,
+    recipientSystemAccount: RECIPIENT_SYS,
+    amount: 42n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_pool_treasury_sol", AUTHORITY);
+  // Account order: authority, governance, liquidity_pool, pool_treasury_vault,
+  // recipient, system_program.
+  assert.equal(ix.keys[2]!.pubkey.toBase58(), POOL.toBase58());
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    derivePoolTreasuryVaultPda({
+      liquidityPool: POOL,
+      assetMint: NATIVE_SOL_MINT_KEY,
+    }).toBase58(),
+  );
+  assert.equal(ix.keys[4]!.pubkey.toBase58(), RECIPIENT_SYS.toBase58());
+  assert.equal(ix.keys.length, 6);
+});
+
+test("buildWithdrawPoolOracleFeeSplTx: oracle_profile + per-oracle vault PDA", () => {
+  const tx = buildWithdrawPoolOracleFeeSplTx({
+    oracle: ORACLE,
+    poolAddress: POOL,
+    reserveDomainAddress: RESERVE_DOMAIN,
+    paymentMint: SPL_MINT,
+    recipientTokenAccount: RECIPIENT_ATA,
+    amount: 999n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_pool_oracle_fee_spl", ORACLE);
+  // Account order: authority, governance, liquidity_pool, oracle_profile,
+  // pool_oracle_fee_vault, domain_asset_vault, asset_mint, vault_token_account,
+  // recipient, token_program.
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    deriveOracleProfilePda({ oracle: ORACLE }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[4]!.pubkey.toBase58(),
+    derivePoolOracleFeeVaultPda({
+      liquidityPool: POOL,
+      oracle: ORACLE,
+      assetMint: SPL_MINT,
+    }).toBase58(),
+  );
+});
+
+test("buildWithdrawPoolOracleFeeSolTx: oracleAddress override decouples signer from vault key", () => {
+  const tx = buildWithdrawPoolOracleFeeSolTx({
+    oracle: AUTHORITY,
+    oracleAddress: ORACLE,
+    poolAddress: POOL,
+    recipientSystemAccount: RECIPIENT_SYS,
+    amount: 1n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = assertProtocolIxShape(tx, "withdraw_pool_oracle_fee_sol", AUTHORITY);
+  // Vault is keyed by ORACLE (the registered oracle), not AUTHORITY (the
+  // admin/governance signer). This validates the admin-signing path works.
+  assert.equal(
+    ix.keys[3]!.pubkey.toBase58(),
+    deriveOracleProfilePda({ oracle: ORACLE }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[4]!.pubkey.toBase58(),
+    derivePoolOracleFeeVaultPda({
+      liquidityPool: POOL,
+      oracle: ORACLE,
+      assetMint: NATIVE_SOL_MINT_KEY,
+    }).toBase58(),
+  );
+});
+
+test("buildWithdrawPoolOracleFeeSolTx: omitting oracleAddress defaults to signer (common path)", () => {
+  // The pool-treasury-panel calls without oracleAddress, treating
+  // `oracle: publicKey` as both the signer AND the vault's oracle wallet.
+  const tx = buildWithdrawPoolOracleFeeSolTx({
+    oracle: ORACLE,
+    poolAddress: POOL,
+    recipientSystemAccount: RECIPIENT_SYS,
+    amount: 1n,
+    recentBlockhash: RECENT_BLOCKHASH,
+  });
+  const ix = tx.instructions[0]!;
+  assert.equal(
+    ix.keys[4]!.pubkey.toBase58(),
+    derivePoolOracleFeeVaultPda({
+      liquidityPool: POOL,
+      oracle: ORACLE,
+      assetMint: NATIVE_SOL_MINT_KEY,
+    }).toBase58(),
+  );
+});

--- a/tests/security/no_money_out_path.test.ts
+++ b/tests/security/no_money_out_path.test.ts
@@ -45,18 +45,30 @@ function extractInstructionBody(name: string): string {
   return programSource.slice(startIdx, i);
 }
 
-test("[PT-01] IDL exposes no withdraw / sweep / fee-collection instruction", () => {
+test("[PT-01 defense regression] IDL exposes the 6 expected fee-vault withdrawal instructions", () => {
+  // Phase 1.7 (PR2) shipped 6 withdraw_*_fee_* instructions, fully closing
+  // PT-01 on the protocol-fee / pool-treasury / pool-oracle rails. This
+  // assertion was flipped from VULN_CONFIRMED to a defense regression: if
+  // any of the six are removed, the original "no money-out path" finding
+  // would re-emerge for that rail.
   const drainPatterns = /^(withdraw|sweep|collect_fee|reclaim|payout)/i;
   const matches = idl.instructions
     .map((ix) => ix.name)
-    .filter((name) => drainPatterns.test(name));
+    .filter((name) => drainPatterns.test(name))
+    .sort();
 
-  // PASSES when there is no withdrawal instruction (vulnerability present).
-  // FAILS once the team adds one — at that point, flip to a defense test.
+  const expected = [
+    "withdraw_pool_oracle_fee_sol",
+    "withdraw_pool_oracle_fee_spl",
+    "withdraw_pool_treasury_sol",
+    "withdraw_pool_treasury_spl",
+    "withdraw_protocol_fee_sol",
+    "withdraw_protocol_fee_spl",
+  ];
   assert.deepEqual(
     matches,
-    [],
-    "Expected no on-chain withdrawal instruction; finding PT-01 would be remediated if any exists",
+    expected,
+    "[PT-01 defense] expected exactly the 6 Phase 1.7 fee-vault withdraw instructions; removal or addition would change the protocol's outflow surface and warrants security review.",
   );
 });
 

--- a/tests/security/treasury_panel_imports_unresolved.test.ts
+++ b/tests/security/treasury_panel_imports_unresolved.test.ts
@@ -9,16 +9,19 @@
 // withdraw instruction (see no_money_out_path.test.ts), so even if the builders
 // existed they would have no on-chain instruction to call.
 //
-// PR3 status (2026-04-29): both the on-chain IDL and the frontend builders
-// have shipped. The 6 `buildWithdraw*Tx` exports in `frontend/lib/protocol.ts`
-// resolve every panel import. The remaining VULN piece is the tsconfig
-// exclusion of `components/**/*` from typecheck (PT-13) — that closes in
-// PR4 alongside the panel re-mount.
+// PR4 status (2026-04-29): full PT-03 closure. The on-chain IDL (PR2),
+// frontend builder exports (PR3), and panel typecheck enrollment (PR4)
+// have all shipped. All three originally-VULN-CONFIRMED checks in this
+// file are now defense regressions:
+//   - IDL ix presence (PR2-flipped)
+//   - Builder exports (PR3-flipped)
+//   - tsconfig include of pool-treasury-panel.tsx (this commit)
 //
-// Two of this file's three "vulnerability-confirming" tests have been
-// flipped to defense regressions (IDL ix presence in PR2; builder exports
-// in PR3). The remaining VULN_CONFIRMED test (test 4 below) flips when
-// PR4 removes `components/**/*` from tsconfig.exclude.
+// The broad `components/**/*` exclude that originally hid the dead
+// imports has been removed; pool-treasury-panel.tsx is now in the
+// explicit include list. Other dead components in the directory are
+// quarantined separately (tracked as a follow-up cleanup task) but the
+// panel-specific gap that PT-03 originally documented is closed.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -100,7 +103,13 @@ test("[PT-03 defense regression] IDL exposes the 6 withdraw instructions PR2 shi
   }
 });
 
-test("[PT-03] frontend/tsconfig.json excludes components/ from typecheck — explains why dead imports ship unflagged", () => {
+test("[PT-03 defense regression] frontend/tsconfig.json typechecks pool-treasury-panel.tsx", () => {
+  // Phase 1.7 PR4 removed the broad `components/**/*` exclusion that
+  // shielded dead imports from build-time detection, AND added
+  // `components/pool-treasury-panel.tsx` to the explicit include list.
+  // This regression test pins both halves of the closure: if the broad
+  // exclude returns or the panel's explicit include is dropped, the
+  // dead-import vulnerability re-emerges.
   const tsconfig = JSON.parse(
     readFileSync(new URL("../../frontend/tsconfig.json", import.meta.url), "utf8"),
   ) as {
@@ -110,22 +119,17 @@ test("[PT-03] frontend/tsconfig.json excludes components/ from typecheck — exp
 
   assert.ok(
     Array.isArray(tsconfig.exclude),
-    "tsconfig.json must have an exclude array for this finding to apply",
+    "tsconfig.json must have an exclude array",
   );
   assert.ok(
-    tsconfig.exclude!.includes("components/**/*"),
-    "[PT-03 root cause] tsconfig.json excludes components/**/* from typecheck — why the dead imports in pool-treasury-panel.tsx are not caught at build time",
+    !tsconfig.exclude!.includes("components/**/*"),
+    "[PT-03 defense] tsconfig.json must NOT re-add a broad components/**/* exclusion (would re-shield the panel from typecheck).",
   );
 
-  // Sanity: confirm components/ is also not pulled back in via include.
   const include = tsconfig.include ?? [];
-  const componentsInclude = include.filter((pattern) =>
-    /components/.test(pattern),
-  );
-  assert.deepEqual(
-    componentsInclude,
-    [],
-    "[PT-03 root cause] tsconfig include must not silently re-enable components/",
+  assert.ok(
+    include.includes("components/pool-treasury-panel.tsx"),
+    "[PT-03 defense] tsconfig.json must explicitly include components/pool-treasury-panel.tsx so its imports are typechecked. If it is removed, the dead-import vulnerability returns.",
   );
 
   // Higher-order finding: lib/ coverage is tiny — only 4 specific files.

--- a/tests/security/treasury_panel_imports_unresolved.test.ts
+++ b/tests/security/treasury_panel_imports_unresolved.test.ts
@@ -9,19 +9,16 @@
 // withdraw instruction (see no_money_out_path.test.ts), so even if the builders
 // existed they would have no on-chain instruction to call.
 //
-// PR1.7 status (2026-04-28): the on-chain side has shipped — the IDL now
-// exposes 6 `withdraw_*_fee_*` instructions. The frontend builders and the
-// tsconfig exclusion are still missing/active, so the dead-import vulnerability
-// remains until PR3 (frontend builders) + PR4 (panel re-enable + tsconfig fix)
-// land. The IDL-side check below was flipped from VULN_CONFIRMED to a defense
-// regression: it now PASSES when the 6 instructions exist on-chain, FAILS if
-// any get removed.
+// PR3 status (2026-04-29): both the on-chain IDL and the frontend builders
+// have shipped. The 6 `buildWithdraw*Tx` exports in `frontend/lib/protocol.ts`
+// resolve every panel import. The remaining VULN piece is the tsconfig
+// exclusion of `components/**/*` from typecheck (PT-13) — that closes in
+// PR4 alongside the panel re-mount.
 //
-// This file removes itself when:
-//   - PR3 ships the 6 buildWithdraw*Tx builders → test 2 below should be
-//     flipped or removed.
-//   - PR4 removes `components/**/*` from tsconfig.exclude → test 4 below
-//     should be flipped or removed.
+// Two of this file's three "vulnerability-confirming" tests have been
+// flipped to defense regressions (IDL ix presence in PR2; builder exports
+// in PR3). The remaining VULN_CONFIRMED test (test 4 below) flips when
+// PR4 removes `components/**/*` from tsconfig.exclude.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -54,11 +51,13 @@ test("[PT-03] pool-treasury-panel imports the documented dead builder names", ()
   }
 });
 
-test("[PT-03] None of the dead builder names is exported by frontend/lib/protocol.ts", () => {
+test("[PT-03 defense regression] All six builder names are exported by frontend/lib/protocol.ts", () => {
+  // Phase 1.7 PR3 shipped the six builders; the panel imports now resolve.
+  // This assertion was flipped from VULN_CONFIRMED to a defense regression:
+  // if any builder export is removed or renamed, the panel reverts to the
+  // dead-import state and PT-03 partially regresses.
   const unresolved: string[] = [];
   for (const name of expectedDeadImports) {
-    // Look for any export form: `export function NAME`, `export const NAME`,
-    // `export async function NAME`, `export { NAME }`, or `export { ..., NAME, ... }`.
     const exportPatterns = [
       new RegExp(String.raw`^export\s+(?:async\s+)?function\s+${name}\b`, "m"),
       new RegExp(String.raw`^export\s+const\s+${name}\b`, "m"),
@@ -68,11 +67,10 @@ test("[PT-03] None of the dead builder names is exported by frontend/lib/protoco
     if (!isExported) unresolved.push(name);
   }
 
-  // PASSES when all six imports are unresolved (vulnerability present).
   assert.deepEqual(
     unresolved,
-    expectedDeadImports,
-    `Expected all six dead imports to remain unresolved; finding PT-03 would be remediated if any resolves. Currently unresolved: ${JSON.stringify(unresolved, null, 2)}`,
+    [],
+    `[PT-03 defense] All six panel-imported builders must remain exported. Currently missing: ${JSON.stringify(unresolved, null, 2)}`,
   );
 });
 

--- a/tests/security/treasury_panel_imports_unresolved.test.ts
+++ b/tests/security/treasury_panel_imports_unresolved.test.ts
@@ -1,18 +1,27 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Pre-mainnet pen-test PoC — finding PT-2026-04-27-03.
+// Pre-mainnet pen-test PoC — finding PT-2026-04-27-03 (partially remediated).
 // Severity: HIGH (build integrity).
 //
-// Hypothesis: `frontend/components/pool-treasury-panel.tsx:14-19` imports six
-// `buildWithdraw*Tx` builders from `@/lib/protocol`, but none of those names
-// is exported by `frontend/lib/protocol.ts`. The IDL also has no withdraw
-// instruction (see no_money_out_path.test.ts), so even if the builders existed
-// they would have no on-chain instruction to call.
+// Original hypothesis: `frontend/components/pool-treasury-panel.tsx:14-19`
+// imports six `buildWithdraw*Tx` builders from `@/lib/protocol`, but none of
+// those names is exported by `frontend/lib/protocol.ts`. The IDL also had no
+// withdraw instruction (see no_money_out_path.test.ts), so even if the builders
+// existed they would have no on-chain instruction to call.
 //
-// This test PASSES when the imports are unresolved (vulnerability present).
-// When the team either (a) deletes the dead UI or (b) ships the corresponding
-// program instructions and frontend builders, this test should fail and be
-// removed or flipped.
+// PR1.7 status (2026-04-28): the on-chain side has shipped — the IDL now
+// exposes 6 `withdraw_*_fee_*` instructions. The frontend builders and the
+// tsconfig exclusion are still missing/active, so the dead-import vulnerability
+// remains until PR3 (frontend builders) + PR4 (panel re-enable + tsconfig fix)
+// land. The IDL-side check below was flipped from VULN_CONFIRMED to a defense
+// regression: it now PASSES when the 6 instructions exist on-chain, FAILS if
+// any get removed.
+//
+// This file removes itself when:
+//   - PR3 ships the 6 buildWithdraw*Tx builders → test 2 below should be
+//     flipped or removed.
+//   - PR4 removes `components/**/*` from tsconfig.exclude → test 4 below
+//     should be flipped or removed.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -67,25 +76,28 @@ test("[PT-03] None of the dead builder names is exported by frontend/lib/protoco
   );
 });
 
-test("[PT-03] No corresponding withdrawal instruction exists in the IDL either", () => {
+test("[PT-03 defense regression] IDL exposes the 6 withdraw instructions PR2 shipped", () => {
+  // Phase 1.7 (PR2) landed the on-chain withdraw instructions, closing
+  // half of PT-03. This test flipped from VULN_CONFIRMED to a defense
+  // regression: if any of the six are removed, the dead-builder problem
+  // would re-emerge as soon as the frontend builders ship in PR3.
   const idl = JSON.parse(
     readFileSync(new URL("../../idl/omegax_protocol.json", import.meta.url), "utf8"),
   ) as { instructions: Array<{ name: string }> };
   const names = idl.instructions.map((i) => i.name.toLowerCase());
 
-  // The frontend would need at least these on-chain handlers for the dead
-  // imports to actually do something useful. Confirm they are all absent.
-  const expectedMissingInstructions = [
-    /withdraw.*pool.*oracle.*fee/,
-    /withdraw.*pool.*treasury/,
-    /withdraw.*protocol.*fee/,
+  const expectedInstructions = [
+    "withdraw_protocol_fee_sol",
+    "withdraw_protocol_fee_spl",
+    "withdraw_pool_treasury_sol",
+    "withdraw_pool_treasury_spl",
+    "withdraw_pool_oracle_fee_sol",
+    "withdraw_pool_oracle_fee_spl",
   ];
-  for (const rx of expectedMissingInstructions) {
-    const matches = names.filter((n) => rx.test(n));
-    assert.deepEqual(
-      matches,
-      [],
-      `Expected no IDL instruction matching ${rx.source}; finding PT-02/PT-03 would change. Found: ${JSON.stringify(matches)}`,
+  for (const expected of expectedInstructions) {
+    assert.ok(
+      names.includes(expected),
+      `[PT-03 defense] IDL must expose ${expected}; if removed the dead-builder vulnerability re-emerges once PR3 lands.`,
     );
   }
 });


### PR DESCRIPTION
## Summary

Pre-mainnet pen-test Phase 1.6/1.7 — fee accumulation + withdrawal infrastructure across the on-chain program, the IDL/contract surface, the frontend builders, and the operator UI. Closes PT-03 and PT-13 in full and reinforces PT-01 with a dedicated fee-rail withdrawal surface.

Executed as a four-PR ladder, squashed into 19 commits on this single branch:

- **PR1 — Phase 1.6 init + accrual** (9 commits): NATIVE_SOL_MINT sentinel, 8 new error variants, 3 events, 3 governance-only `init_*_fee_vault` instructions, 2 accrual helpers, accrual hooks wired into 4 inflow handlers (`record_premium_payment`, `deposit_into_capital_class`, `process_redemption_queue`, `settle_claim_case`), 7 Rust unit tests, IDL/contract regen, Node test extensions, rustfmt cleanup.
- **PR2 — Phase 1.7 on-chain withdraws** (4 commits): 6 `withdraw_*_fee_*` instructions (SOL+SPL × 3 rails), per-rail authority gating (`require_governance` / `require_curator_control` / `require_oracle_profile_control`), `WithdrawArgs`, `require_fee_vault_balance` + `transfer_lamports_from_fee_vault` helpers, 5 Rust unit tests, IDL/contract regen, PT-01 + PT-03 IDL assertions flipped to defense regression.
- **PR3 — Phase 1.7 frontend** (3 commits): 6 `buildWithdraw*Tx` builders, 3 `list*` summary functions, 3 PDA derivers, summary types matching the panel imports verbatim, snapshot decoders for the new account types, PT-03 builder-export assertion flipped to defense regression, 7 new builder tests + extended PDA + contract assertions.
- **PR4 — Phase 1.7 panel mount + tsconfig** (3 commits): `pool-treasury-panel.tsx` mounted as a new `treasury` tab on `capital-workbench.tsx` with synthetic minimal `WalletCapabilities` derivation, per-rail authority correction in `ui-capabilities.ts`, broad `components/**/*` tsconfig exclusion removed (PT-13 closure) with explicit-include list for live components, last PT-03 PoC assertion flipped to defense regression, pen-test report verdict moved from NOT-READY to READY-WITH-FIXES.

Tracker: [omegax-protocol: Pre-mainnet pen-test remediation — Phase 1 (on-chain) complete](https://www.notion.so/350e7028cbb981a79bffdfd1dd4638e7).

## Verification gate (post-PR4, all green)

| Check | Result |
|---|---|
| `npm run rust:test` | 51 / 51 pass (39 pre-existing + 7 Phase 1.6 + 5 Phase 1.7) |
| `npm run test:node` | 162 / 162 pass |
| `npm run rust:fmt:check` | clean |
| `npm run protocol:contract:check` | in sync (`sha256: f095fb3ee9dd…`) |
| `npm run idl:freshness:check` | matches program source |
| `npm run public:hygiene:check` | no publish blockers |
| `npm --prefix frontend run build` | exit 0 |

## Pen-test PoC progression

All three originally-VULN_CONFIRMED tests in `tests/security/treasury_panel_imports_unresolved.test.ts` flipped to defense regressions across PR2, PR3, and PR4. `tests/security/no_money_out_path.test.ts` `PT-01` test similarly flipped — now pins exactly the 6 expected withdraw ix names.

Pen-test report (`docs/security/pre-mainnet-pen-test-2026-04-27.md`) executive verdict updated: **NOT-READY → READY-WITH-FIXES**. Remaining mainnet-readiness work is the multisig recommendation doc for governance authority (operator-runbook, not a code finding).

## Backward compatibility

The four accrual hooks make their fee-vault accounts `Option<Box<Account<…>>>` so callers without initialized fee infrastructure (devnet bootstraps, all current test fixtures) see bit-identical behavior. SOL withdrawal plumbing ships correct-but-empty until SOL inflows land in a follow-up.

## Test plan

- [ ] Inspect the 9 instruction signatures + account structs (`grep "pub fn (init|withdraw)_(protocol|pool)_(fee|treasury)" programs/omegax_protocol/src/lib.rs`)
- [ ] Verify the 4 inflow handlers preserve their existing semantics when the optional fee-vault accounts are `None` (`npm run rust:test` — 39/39 pre-existing tests untouched)
- [ ] Confirm the 6 frontend builders match panel call-site signatures (`tests/protocol_withdraw_builders.test.ts`)
- [ ] Verify the panel mounts and renders the treasury tab (`npm --prefix frontend run dev` → connect any wallet → navigate to `/capital?tab=treasury`)
- [ ] Run the full e2e localnet matrix on a follow-up CI run (the `localnet-e2e` workflow path-filter will trigger automatically on merge)
- [ ] Sanity-check the pen-test report verdict update reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)