### PR TITLE
Require pool treasury vault when entry fees are enabled

### DIFF
--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -11835,6 +11835,11 @@
     },
     {
       "code": 6067,
+      "name": "FeeVaultRequiredForConfiguredFee",
+      "msg": "Configured class entry fee requires the matching pool treasury fee vault account"
+    },
+    {
+      "code": 6068,
       "name": "FeeVaultBpsMisconfigured",
       "msg": "Fee vault basis-points configuration is out of range"
     }

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-192d35a886c013dbaa52584952cad7fcaf11dd65d0584ae6e50ef288f44785aa
+7c80365bdb37ae33d1adaf3968f303233da5e4856f01b2adef5ae05ead733d28
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1988,6 +1988,10 @@ pub mod omegax_protocol {
             );
             fee_share_from_bps(amount, class_fee_bps)?
         } else {
+            require!(
+                class_fee_bps == 0,
+                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
+            );
             0
         };
         let net_amount = checked_sub(amount, entry_fee)?;
@@ -5968,6 +5972,8 @@ pub enum OmegaXProtocolError {
     FeeVaultRentExemptionBreach,
     #[msg("Fee vault rail and asset mint disagree (SOL vault used on SPL path or vice versa)")]
     FeeVaultRailMismatch,
+    #[msg("Configured class entry fee requires the matching pool treasury fee vault account")]
+    FeeVaultRequiredForConfiguredFee,
     #[msg("Fee vault basis-points configuration is out of range")]
     FeeVaultBpsMisconfigured,
 }

--- a/tests/security/fee_vault_required_regression.test.ts
+++ b/tests/security/fee_vault_required_regression.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regression: a configured pool entry fee must fail closed
+// when the caller omits the matching pool_treasury_vault account.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const programSource = readFileSync(
+  new URL("../../programs/omegax_protocol/src/lib.rs", import.meta.url),
+  "utf8",
+);
+
+function extractInstructionBody(name: string): string {
+  const startIdx = programSource.indexOf(`pub fn ${name}(`);
+  assert.notEqual(startIdx, -1, `instruction ${name} should exist in program source`);
+
+  let i = programSource.indexOf("{", startIdx);
+  assert.notEqual(i, -1, `instruction ${name} should have a body`);
+
+  let depth = 1;
+  i += 1;
+  for (; i < programSource.length && depth > 0; i += 1) {
+    if (programSource[i] === "{") depth += 1;
+    else if (programSource[i] === "}") depth -= 1;
+  }
+
+  return programSource.slice(startIdx, i);
+}
+
+test("[CSO-2026-04-29] deposit entry fees require the pool treasury vault when fee_bps is nonzero", () => {
+  const body = extractInstructionBody("deposit_into_capital_class");
+  const missingVaultBranch = /let\s+entry_fee\s*=\s*if\s+let\s+Some\(vault\)[\s\S]+?\}\s+else\s+\{([\s\S]+?)\};/.exec(body);
+
+  assert.ok(missingVaultBranch, "deposit_into_capital_class must keep an explicit missing-vault branch");
+  assert.match(
+    missingVaultBranch[1],
+    /class_fee_bps\s*==\s*0/,
+    "missing pool_treasury_vault must only be allowed when class_fee_bps is zero",
+  );
+  assert.match(
+    missingVaultBranch[1],
+    /FeeVaultRequiredForConfiguredFee/,
+    "missing pool_treasury_vault with nonzero entry fee must return the dedicated fee-vault error",
+  );
+});


### PR DESCRIPTION
### Motivation
- Prevent a caller-controlled optional account from allowing depositors to bypass configured entry fees by making `pool_treasury_vault` mandatory whenever `capital_class.fee_bps > 0` so protocol accounting and treasury accrual cannot be skirted.

### Description
- Add a runtime check in `deposit_into_capital_class` (`programs/omegax_protocol/src/lib.rs`) that requires `class_fee_bps == 0` when `pool_treasury_vault` is absent, returning a clear protocol error otherwise.
- Introduce a new error variant `FeeVaultRequiredForConfiguredFee` on `OmegaXProtocolError` to provide an explicit, auditable failure reason when a configured entry fee is missing its matching vault.

### Testing
- Ran `cargo test -p omegax_protocol --lib -- --nocapture` and the test suite completed successfully with `51 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1917fbb74832f92bc3509e0a8f0ee)