### PR TITLE
Harden claim settlement fees and linked-obligation outflows

### DIFF
--- a/frontend/components/plan-operator-drawer.tsx
+++ b/frontend/components/plan-operator-drawer.tsx
@@ -74,6 +74,9 @@ import {
   type LiquidityPoolSnapshot,
   type MemberPositionSnapshot,
   type ObligationSnapshot,
+  type PoolOracleFeeVaultSnapshot,
+  type PoolOraclePolicySnapshot,
+  type ProtocolFeeVaultSnapshot,
   type PolicySeriesSnapshot,
   type ReserveDomainSnapshot,
 } from "@/lib/protocol";
@@ -104,6 +107,9 @@ type PlanOperatorDrawerProps = {
   classes: CapitalClassSnapshot[];
   pools: LiquidityPoolSnapshot[];
   domainAssetVaults: DomainAssetVaultSnapshot[];
+  protocolFeeVaults: ProtocolFeeVaultSnapshot[];
+  poolOracleFeeVaults: PoolOracleFeeVaultSnapshot[];
+  poolOraclePolicies: PoolOraclePolicySnapshot[];
 };
 
 const SECTIONS: Array<{ id: PlanOperatorSection; label: string; blurb: string }> = [
@@ -265,6 +271,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
   const [settleClaimAmount, setSettleClaimAmount] = useState("0");
   const [settleObligationAmount, setSettleObligationAmount] = useState("0");
   const [settleObligationStatus, setSettleObligationStatus] = useState(String(OBLIGATION_STATUS_CLAIMABLE_PAYABLE));
+  const [recipientTokenAccount, setRecipientTokenAccount] = useState("");
   const [impairmentAmount, setImpairmentAmount] = useState("0");
   const [impairmentReason, setImpairmentReason] = useState("");
 
@@ -408,6 +415,10 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
     () => props.obligations.find((obligation) => obligation.address === selectedObligationAddress) ?? null,
     [props.obligations, selectedObligationAddress],
   );
+  const selectedObligationClaim = useMemo(
+    () => props.claimCases.find((claim) => claim.address === selectedObligation?.claimCase) ?? null,
+    [props.claimCases, selectedObligation?.claimCase],
+  );
   const selectedMemberForClaim = useMemo(
     () => props.members.find((member) => member.address === selectedMemberAddress) ?? null,
     [props.members, selectedMemberAddress],
@@ -459,6 +470,25 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
   const obligationFlowFundingLine = selectedObligationFundingLine;
   const settleClaimFundingLine = selectedClaimFundingLine;
   const impairmentFundingLine = selectedObligationFundingLine ?? selectedFundingLineForClaimResolved;
+  const settlementAssetMint = settleClaimFundingLine?.assetMint ?? selectedObligation?.assetMint ?? null;
+  const selectedSettlementVault = useMemo(
+    () =>
+      props.domainAssetVaults.find(
+        (vault) =>
+          vault.reserveDomain === props.plan?.reserveDomain &&
+          vault.assetMint === settlementAssetMint,
+      ) ?? null,
+    [props.domainAssetVaults, props.plan?.reserveDomain, settlementAssetMint],
+  );
+  const selectedSettlementProtocolFeeVault = useMemo(
+    () =>
+      props.protocolFeeVaults.find(
+        (vault) =>
+          vault.reserveDomain === props.plan?.reserveDomain &&
+          vault.assetMint === settlementAssetMint,
+      ) ?? null,
+    [props.protocolFeeVaults, props.plan?.reserveDomain, settlementAssetMint],
+  );
   const allocationFundingLineAddress =
     section === "funding"
       ? selectedFundingLine?.address
@@ -476,6 +506,20 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
   const selectedPool = useMemo(
     () => props.pools.find((pool) => pool.address === selectedAllocation?.liquidityPool) ?? null,
     [props.pools, selectedAllocation?.liquidityPool],
+  );
+  const selectedPoolOraclePolicy = useMemo(
+    () => props.poolOraclePolicies.find((policy) => policy.liquidityPool === selectedPool?.address) ?? null,
+    [props.poolOraclePolicies, selectedPool?.address],
+  );
+  const selectedPoolOracleFeeVault = useMemo(
+    () =>
+      props.poolOracleFeeVaults.find(
+        (vault) =>
+          vault.liquidityPool === selectedPool?.address &&
+          vault.oracle === selectedClaim?.adjudicator &&
+          vault.assetMint === settlementAssetMint,
+      ) ?? null,
+    [props.poolOracleFeeVaults, selectedPool?.address, selectedClaim?.adjudicator, settlementAssetMint],
   );
   const selectedFundingVault = useMemo(
     () =>
@@ -1023,6 +1067,12 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                         <option value={String(OBLIGATION_STATUS_CANCELED)}>Canceled</option>
                       </SelectField>
                     </div>
+                    <TextField
+                      label="Recipient token account"
+                      value={recipientTokenAccount}
+                      onChange={setRecipientTokenAccount}
+                      placeholder="Member or delegate ATA"
+                    />
                     <div className="operator-drawer-actions">
                       <button
                         type="button"
@@ -1091,10 +1141,13 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                       <button
                         type="button"
                         className="plans-secondary-cta"
-                        disabled={
+	                        disabled={
                           !canAct ||
                           !selectedClaim ||
                           !settleClaimFundingLine ||
+                          !selectedClaim.memberPosition ||
+                          !selectedSettlementVault?.vaultTokenAccount ||
+                          !recipientTokenAccount.trim() ||
                           busyOn("Settle claim")
                         }
                         onClick={() =>
@@ -1114,6 +1167,12 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                               capitalClassAddress: selectedObligation?.capitalClass ?? null,
                               allocationPositionAddress: selectedObligation?.allocationPosition ?? null,
                               poolAssetMint: selectedPool?.depositAssetMint ?? null,
+                              protocolFeeVaultAddress: selectedSettlementProtocolFeeVault?.address ?? null,
+                              poolOracleFeeVaultAddress: selectedPoolOracleFeeVault?.address ?? null,
+                              poolOraclePolicyAddress: selectedPoolOraclePolicy?.address ?? null,
+                              memberPositionAddress: selectedClaim!.memberPosition,
+                              vaultTokenAccountAddress: selectedSettlementVault!.vaultTokenAccount,
+                              recipientTokenAccountAddress: recipientTokenAccount.trim(),
                             });
                           })
                         }
@@ -1123,10 +1182,19 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                       <button
                         type="button"
                         className="plans-primary-cta"
-                        disabled={
+	                        disabled={
                           !canAct ||
                           !selectedObligation ||
                           !obligationFlowFundingLine ||
+                          (
+                            selectedObligation.claimCase &&
+                            (Number.parseInt(settleObligationStatus, 10) || OBLIGATION_STATUS_CLAIMABLE_PAYABLE) === OBLIGATION_STATUS_SETTLED &&
+                            (
+                              !selectedObligationClaim?.memberPosition ||
+                              !selectedSettlementVault?.vaultTokenAccount ||
+                              !recipientTokenAccount.trim()
+                            )
+                          ) ||
                           busyOn("Settle obligation")
                         }
                         onClick={() =>
@@ -1151,6 +1219,9 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                               capitalClassAddress: selectedObligation!.capitalClass ?? null,
                               allocationPositionAddress: selectedObligation!.allocationPosition ?? null,
                               poolAssetMint: selectedPool?.depositAssetMint ?? null,
+                              memberPositionAddress: selectedObligationClaim?.memberPosition ?? null,
+                              vaultTokenAccountAddress: selectedSettlementVault?.vaultTokenAccount ?? null,
+                              recipientTokenAccountAddress: recipientTokenAccount.trim() || null,
                             });
                           })
                         }

--- a/frontend/components/plans-workbench.tsx
+++ b/frontend/components/plans-workbench.tsx
@@ -1331,6 +1331,9 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
           classes={snapshot.capitalClasses}
           pools={snapshot.liquidityPools}
           domainAssetVaults={snapshot.domainAssetVaults}
+          protocolFeeVaults={snapshot.protocolFeeVaults}
+          poolOracleFeeVaults={snapshot.poolOracleFeeVaults}
+          poolOraclePolicies={snapshot.poolOraclePolicies}
         />
       ) : null}
     </div>

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -334,6 +334,7 @@ export type ClaimCaseSnapshot = {
   fundingLine: string;
   memberPosition: string;
   claimant: string;
+  adjudicator?: string | null;
   claimId: string;
   intakeStatus: number;
   approvedAmount: BigNumberish;
@@ -2165,6 +2166,7 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           fundingLine: asAddress(decodedField(decoded, "fundingLine")),
           memberPosition: asAddress(decodedField(decoded, "memberPosition")),
           claimant: asAddress(decodedField(decoded, "claimant")),
+          adjudicator: asOptionalAddress(decodedField(decoded, "adjudicator")),
           claimId: stringFromAnchorValue(decodedField(decoded, "claimId")),
           intakeStatus: Number(decodedField(decoded, "intakeStatus") ?? 0),
           approvedAmount: bigintFromAnchorValue(decodedField(decoded, "approvedAmount")),
@@ -4409,10 +4411,37 @@ function buildObligationFlowTx(params: {
   capitalClassAddress?: PublicKeyish | null;
   allocationPositionAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
+  memberPositionAddress?: PublicKeyish | null;
+  vaultTokenAccountAddress?: PublicKeyish | null;
+  recipientTokenAccountAddress?: PublicKeyish | null;
+  tokenProgramId?: PublicKeyish | null;
   args: Record<string, unknown>;
   includeVault?: boolean;
 }): Transaction {
   const authority = toPublicKey(params.authority);
+  const includeSettlementOutflow = Boolean(
+    params.memberPositionAddress
+      && params.vaultTokenAccountAddress
+      && params.recipientTokenAccountAddress,
+  );
+  const settlementOutflowAccounts: ProtocolInstructionAccountInput[] =
+    params.instructionName === "settle_obligation"
+      ? includeSettlementOutflow
+        ? [
+          { pubkey: params.memberPositionAddress },
+          { pubkey: params.assetMint },
+          { pubkey: params.vaultTokenAccountAddress, isWritable: true },
+          { pubkey: params.recipientTokenAccountAddress, isWritable: true },
+          { pubkey: toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID) },
+        ]
+        : [
+          optionalProtocolAccount(undefined),
+          optionalProtocolAccount(undefined),
+          optionalProtocolAccount(undefined),
+          optionalProtocolAccount(undefined),
+          optionalProtocolAccount(undefined),
+        ]
+      : [];
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4457,6 +4486,7 @@ function buildObligationFlowTx(params: {
       optionalAllocationLedgerAccount(params.allocationPositionAddress, params.assetMint),
       { pubkey: params.obligationAddress, isWritable: true },
       optionalProtocolAccount(params.claimCaseAddress, true),
+      ...settlementOutflowAccounts,
     ],
   });
 }
@@ -4521,6 +4551,10 @@ export function buildSettleObligationTx(params: {
   capitalClassAddress?: PublicKeyish | null;
   allocationPositionAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
+  memberPositionAddress?: PublicKeyish | null;
+  vaultTokenAccountAddress?: PublicKeyish | null;
+  recipientTokenAccountAddress?: PublicKeyish | null;
+  tokenProgramId?: PublicKeyish | null;
 }): Transaction {
   return buildObligationFlowTx({
     ...params,
@@ -4548,8 +4582,16 @@ export function buildSettleClaimCaseTx(params: {
   capitalClassAddress?: PublicKeyish | null;
   allocationPositionAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
+  protocolFeeVaultAddress?: PublicKeyish | null;
+  poolOracleFeeVaultAddress?: PublicKeyish | null;
+  poolOraclePolicyAddress?: PublicKeyish | null;
+  memberPositionAddress?: PublicKeyish | null;
+  vaultTokenAccountAddress?: PublicKeyish | null;
+  recipientTokenAccountAddress?: PublicKeyish | null;
+  tokenProgramId?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
+  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4594,6 +4636,14 @@ export function buildSettleClaimCaseTx(params: {
       optionalAllocationLedgerAccount(params.allocationPositionAddress, params.assetMint),
       { pubkey: params.claimCaseAddress, isWritable: true },
       optionalProtocolAccount(params.obligationAddress, true),
+      optionalProtocolAccount(params.protocolFeeVaultAddress, true),
+      optionalProtocolAccount(params.poolOracleFeeVaultAddress, true),
+      optionalProtocolAccount(params.poolOraclePolicyAddress),
+      optionalProtocolAccount(params.memberPositionAddress),
+      { pubkey: params.assetMint },
+      optionalProtocolAccount(params.vaultTokenAccountAddress, true),
+      optionalProtocolAccount(params.recipientTokenAccountAddress, true),
+      { pubkey: params.memberPositionAddress && params.vaultTokenAccountAddress && params.recipientTokenAccountAddress ? tokenProgramId : getProgramId() },
     ],
   });
 }

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -11842,6 +11842,11 @@
       "code": 6068,
       "name": "FeeVaultBpsMisconfigured",
       "msg": "Fee vault basis-points configuration is out of range"
+    },
+    {
+      "code": 6069,
+      "name": "SettlementOutflowAccountsRequired",
+      "msg": "Linked claim settlement requires the member, mint, vault token, recipient token, and token program accounts"
     }
   ],
   "types": [

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-7c80365bdb37ae33d1adaf3968f303233da5e4856f01b2adef5ae05ead733d28
+871890b7a6c4960ae608f5322a4cb1ff6233c1cd20c64a06edcb3b1911bd6653
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1226,6 +1226,14 @@ pub mod omegax_protocol {
                     amount <= remaining_claim_amount(claim_case),
                     OmegaXProtocolError::AmountExceedsApprovedClaim
                 );
+                require!(
+                    ctx.accounts.member_position.is_some()
+                        && ctx.accounts.asset_mint.is_some()
+                        && ctx.accounts.vault_token_account.is_some()
+                        && ctx.accounts.recipient_token_account.is_some()
+                        && ctx.accounts.token_program.is_some(),
+                    OmegaXProtocolError::SettlementOutflowAccountsRequired
+                );
             }
         }
 
@@ -1285,15 +1293,11 @@ pub mod omegax_protocol {
                 )?;
                 obligation.status = OBLIGATION_STATUS_SETTLED;
 
-                // PT-2026-04-27-01/02 fix: SPL outflow CPI for linked-claim
-                // settlement. When a claim_case is linked AND all five outflow
-                // accounts are supplied, transfer the SPL out of the
-                // PDA-owned vault to the resolved recipient. When any are
-                // absent (e.g. direct sponsor recoveries that pre-date this
-                // surface), fall back to accounting-only — operators using
-                // those flows must adapt to a future direct-recipient path.
+                // Linked-claim settlement must include the SPL outflow accounts.
+                // Without them, the obligation would be marked settled while
+                // the vault balance never leaves custody.
                 if let Some(claim_case_ref) = ctx.accounts.claim_case.as_deref() {
-                    if let (
+                    let (
                         Some(member_pos),
                         Some(mint),
                         Some(vault_ta),
@@ -1305,28 +1309,30 @@ pub mod omegax_protocol {
                         ctx.accounts.vault_token_account.as_ref(),
                         ctx.accounts.recipient_token_account.as_ref(),
                         ctx.accounts.token_program.as_ref(),
-                    ) {
-                        require_keys_eq!(
-                            member_pos.key(),
-                            claim_case_ref.member_position,
-                            OmegaXProtocolError::Unauthorized
-                        );
-                        let resolved_recipient =
-                            resolve_claim_settlement_recipient(claim_case_ref, member_pos);
-                        require_keys_eq!(
-                            recipient_ta.owner,
-                            resolved_recipient,
-                            OmegaXProtocolError::Unauthorized
-                        );
-                        transfer_from_domain_vault(
-                            amount,
-                            &ctx.accounts.domain_asset_vault,
-                            vault_ta,
-                            recipient_ta,
-                            mint,
-                            token_prog,
-                        )?;
-                    }
+                    )
+                    else {
+                        return Err(OmegaXProtocolError::SettlementOutflowAccountsRequired.into());
+                    };
+                    require_keys_eq!(
+                        member_pos.key(),
+                        claim_case_ref.member_position,
+                        OmegaXProtocolError::Unauthorized
+                    );
+                    let resolved_recipient =
+                        resolve_claim_settlement_recipient(claim_case_ref, member_pos);
+                    require_keys_eq!(
+                        recipient_ta.owner,
+                        resolved_recipient,
+                        OmegaXProtocolError::Unauthorized
+                    );
+                    transfer_from_domain_vault(
+                        amount,
+                        &ctx.accounts.domain_asset_vault,
+                        vault_ta,
+                        recipient_ta,
+                        mint,
+                        token_prog,
+                    )?;
                 }
             }
             OBLIGATION_STATUS_CANCELED => {
@@ -1661,6 +1667,10 @@ pub mod omegax_protocol {
             );
             fee_share_from_bps(amount, protocol_fee_bps)?
         } else {
+            require!(
+                protocol_fee_bps == 0,
+                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
+            );
             0
         };
 
@@ -1691,10 +1701,12 @@ pub mod omegax_protocol {
                 );
                 fee_share_from_bps(amount, policy.oracle_fee_bps)?
             }
-            (None, Some(_)) => {
-                // Policy provided without vault is a configuration error;
-                // refuse to silently bypass oracle fees.
-                return Err(OmegaXProtocolError::FeeVaultBpsMisconfigured.into());
+            (None, Some(policy)) => {
+                require!(
+                    policy.oracle_fee_bps == 0,
+                    OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
+                );
+                0
             }
             (None, None) => 0,
             (Some(_), None) => {
@@ -3627,14 +3639,9 @@ pub struct SettleObligation<'info> {
     pub obligation: Box<Account<'info, Obligation>>,
     #[account(mut, seeds = [SEED_CLAIM_CASE, health_plan.key().as_ref(), claim_case.claim_id.as_bytes()], bump = claim_case.bump)]
     pub claim_case: Option<Box<Account<'info, ClaimCase>>>,
-    // PT-2026-04-27-01/02 fix: optional outflow accounts. When all five are
-    // provided AND a linked claim_case is present AND next_status is SETTLED,
-    // the handler resolves recipient = claim_case.delegate_recipient if
-    // non-zero else member.wallet, asserts recipient_token_account.owner ==
-    // resolved, and transfers SPL via the domain_asset_vault PDA. When any
-    // are absent (e.g. direct sponsor recoveries with no linked claim), the
-    // handler falls back to accounting-only behavior to preserve existing
-    // operator flows.
+    // Optional for non-claim obligation transitions, but required when a
+    // linked claim is being marked SETTLED so accounting cannot move without
+    // the matching SPL outflow.
     pub member_position: Option<Box<Account<'info, MemberPosition>>>,
     pub asset_mint: Option<InterfaceAccount<'info, Mint>>,
     #[account(mut)]
@@ -5986,6 +5993,8 @@ pub enum OmegaXProtocolError {
     FeeVaultRequiredForConfiguredFee,
     #[msg("Fee vault basis-points configuration is out of range")]
     FeeVaultBpsMisconfigured,
+    #[msg("Linked claim settlement requires the member, mint, vault token, recipient token, and token program accounts")]
+    SettlementOutflowAccountsRequired,
 }
 
 fn require_id(value: &str) -> Result<()> {

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -1675,6 +1675,11 @@ pub mod omegax_protocol {
         ) {
             (Some(vault), Some(policy)) => {
                 require_keys_eq!(
+                    vault.oracle,
+                    ctx.accounts.claim_case.adjudicator,
+                    OmegaXProtocolError::Unauthorized
+                );
+                require_keys_eq!(
                     vault.asset_mint,
                     asset_mint_key,
                     OmegaXProtocolError::FeeVaultMismatch
@@ -1686,7 +1691,12 @@ pub mod omegax_protocol {
                 );
                 fee_share_from_bps(amount, policy.oracle_fee_bps)?
             }
-            (None, _) => 0,
+            (None, Some(_)) => {
+                // Policy provided without vault is a configuration error;
+                // refuse to silently bypass oracle fees.
+                return Err(OmegaXProtocolError::FeeVaultBpsMisconfigured.into());
+            }
+            (None, None) => 0,
             (Some(_), None) => {
                 // Vault provided without policy is a configuration error;
                 // refuse to silently zero the bps.

--- a/tests/security/settlement_fee_guards_regression.test.ts
+++ b/tests/security/settlement_fee_guards_regression.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regressions for claim settlement:
+// - linked obligations cannot be marked settled without an SPL outflow
+// - configured settlement fee bps cannot be bypassed by omitting fee vaults
+// - public builders must keep Anchor optional-account placeholders in order
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import fixturesModule from "../../frontend/lib/devnet-fixtures.ts";
+import protocolModule from "../../frontend/lib/protocol.ts";
+
+const programSource = readFileSync(
+  new URL("../../programs/omegax_protocol/src/lib.rs", import.meta.url),
+  "utf8",
+);
+
+const {
+  DEVNET_PROTOCOL_FIXTURE_STATE,
+} = fixturesModule as typeof import("../../frontend/lib/devnet-fixtures.ts");
+
+const {
+  OBLIGATION_STATUS_SETTLED,
+  buildSettleClaimCaseTx,
+  buildSettleObligationTx,
+  getProgramId,
+  listProtocolInstructionAccounts,
+} = protocolModule as typeof import("../../frontend/lib/protocol.ts");
+
+function extractInstructionBody(name: string): string {
+  const startIdx = programSource.indexOf(`pub fn ${name}(`);
+  assert.notEqual(startIdx, -1, `instruction ${name} should exist in program source`);
+
+  let i = programSource.indexOf("{", startIdx);
+  assert.notEqual(i, -1, `instruction ${name} should have a body`);
+
+  let depth = 1;
+  i += 1;
+  for (; i < programSource.length && depth > 0; i += 1) {
+    if (programSource[i] === "{") depth += 1;
+    else if (programSource[i] === "}") depth -= 1;
+  }
+
+  return programSource.slice(startIdx, i);
+}
+
+function assertAccountCount(name: Parameters<typeof listProtocolInstructionAccounts>[0], actual: number) {
+  assert.equal(
+    actual,
+    listProtocolInstructionAccounts(name).length,
+    `${name} builder must emit one key for every Anchor account, including optional placeholders`,
+  );
+}
+
+test("[CSO-2026-04-29] linked obligation settlement requires SPL outflow accounts", () => {
+  const body = extractInstructionBody("settle_obligation");
+
+  assert.match(body, /SettlementOutflowAccountsRequired/);
+  assert.match(body, /member_position\.is_some\(\)/);
+  assert.match(body, /vault_token_account\.is_some\(\)/);
+  assert.match(body, /recipient_token_account\.is_some\(\)/);
+  assert.match(body, /token_program\.is_some\(\)/);
+});
+
+test("[CSO-2026-04-29] claim settlement fee vault omission is allowed only for zero bps", () => {
+  const body = extractInstructionBody("settle_claim_case");
+
+  assert.match(body, /protocol_fee_bps\s*==\s*0/);
+  assert.match(body, /policy\.oracle_fee_bps\s*==\s*0/);
+  assert.match(body, /vault\.oracle[\s\S]+ctx\.accounts\.claim_case\.adjudicator/);
+});
+
+test("[CSO-2026-04-29] settlement builders preserve fee and outflow account slots", () => {
+  const claim = DEVNET_PROTOCOL_FIXTURE_STATE.claimCases.find((row) => row.linkedObligation)
+    ?? DEVNET_PROTOCOL_FIXTURE_STATE.claimCases[0]!;
+  const obligation = DEVNET_PROTOCOL_FIXTURE_STATE.obligations.find((row) => row.claimCase === claim.address)
+    ?? DEVNET_PROTOCOL_FIXTURE_STATE.obligations[0]!;
+  const fundingLine = DEVNET_PROTOCOL_FIXTURE_STATE.fundingLines.find((row) => row.address === claim.fundingLine)!;
+  const vault = DEVNET_PROTOCOL_FIXTURE_STATE.domainAssetVaults.find(
+    (row) => row.reserveDomain === claim.reserveDomain && row.assetMint === fundingLine.assetMint,
+  )!;
+  const vaultTokenAccount = vault.address;
+  const recipientTokenAccount = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[1]!.address;
+  const recentBlockhash = "11111111111111111111111111111111";
+  const programId = getProgramId().toBase58();
+
+  const settleClaim = buildSettleClaimCaseTx({
+    authority: DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address,
+    healthPlanAddress: claim.healthPlan,
+    reserveDomainAddress: claim.reserveDomain,
+    fundingLineAddress: claim.fundingLine,
+    assetMint: fundingLine.assetMint,
+    claimCaseAddress: claim.address,
+    recentBlockhash,
+    amount: 1n,
+    policySeriesAddress: claim.policySeries ?? null,
+    obligationAddress: obligation.address,
+    capitalClassAddress: obligation.capitalClass ?? null,
+    allocationPositionAddress: obligation.allocationPosition ?? null,
+    poolAssetMint: fundingLine.assetMint,
+    memberPositionAddress: claim.memberPosition,
+    vaultTokenAccountAddress: vaultTokenAccount,
+    recipientTokenAccountAddress: recipientTokenAccount,
+  });
+  assertAccountCount("settle_claim_case", settleClaim.instructions[0]!.keys.length);
+  assert.equal(settleClaim.instructions[0]!.keys[14]!.pubkey.toBase58(), programId);
+  assert.equal(settleClaim.instructions[0]!.keys[17]!.pubkey.toBase58(), claim.memberPosition);
+  assert.equal(settleClaim.instructions[0]!.keys[19]!.pubkey.toBase58(), vaultTokenAccount);
+  assert.equal(settleClaim.instructions[0]!.keys[20]!.pubkey.toBase58(), recipientTokenAccount);
+
+  const settleObligation = buildSettleObligationTx({
+    authority: DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address,
+    healthPlanAddress: obligation.healthPlan,
+    reserveDomainAddress: obligation.reserveDomain,
+    fundingLineAddress: obligation.fundingLine,
+    assetMint: obligation.assetMint,
+    obligationAddress: obligation.address,
+    recentBlockhash,
+    nextStatus: OBLIGATION_STATUS_SETTLED,
+    amount: 1n,
+    claimCaseAddress: claim.address,
+    policySeriesAddress: obligation.policySeries ?? null,
+    capitalClassAddress: obligation.capitalClass ?? null,
+    allocationPositionAddress: obligation.allocationPosition ?? null,
+    poolAssetMint: fundingLine.assetMint,
+    memberPositionAddress: claim.memberPosition,
+    vaultTokenAccountAddress: vaultTokenAccount,
+    recipientTokenAccountAddress: recipientTokenAccount,
+  });
+  assertAccountCount("settle_obligation", settleObligation.instructions[0]!.keys.length);
+  assert.equal(settleObligation.instructions[0]!.keys[14]!.pubkey.toBase58(), claim.memberPosition);
+  assert.equal(settleObligation.instructions[0]!.keys[16]!.pubkey.toBase58(), vaultTokenAccount);
+  assert.equal(settleObligation.instructions[0]!.keys[17]!.pubkey.toBase58(), recipientTokenAccount);
+});


### PR DESCRIPTION
### Motivation
- Close the claim-settlement fee-bypass path where callers could omit optional fee vault accounts and silently zero configured fee accrual.
- Bind oracle fee accrual to the actual claim adjudicator so a caller cannot divert oracle fee accounting to an arbitrary vault.
- Close the linked-obligation settlement gap where a claim-linked obligation could be marked settled without the SPL outflow accounts needed to transfer funds.

### Description
- `settle_claim_case` now requires the protocol fee vault whenever `protocol_fee_bps > 0` and only allows an omitted oracle fee vault when the supplied policy has `oracle_fee_bps == 0`.
- The supplied pool oracle fee vault must match `claim_case.adjudicator`, the settlement asset mint, and the supplied pool oracle policy.
- `settle_obligation` now requires member, mint, vault token, recipient token, and token program accounts before a linked claim can transition to `SETTLED`.
- Public builders now preserve the generated Anchor account slots for claim settlement and linked obligation settlement, including optional placeholders, and the plan operator drawer passes the available fee/outflow accounts.
- Added CSO regression coverage for the fee omission, oracle binding, linked-obligation outflow requirement, and builder account ordering.

### Testing
- `npm run verify:public`
