### PR TITLE
Fix missing pool rail guard in oracle fee vault initialization

### DIFF
--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-7c80365bdb37ae33d1adaf3968f303233da5e4856f01b2adef5ae05ead733d28
+9330d160160ce38991fb55c5745c590af2f3e2c41de1603c791e95acf316603f
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -446,6 +446,12 @@ pub mod omegax_protocol {
             ctx.accounts.oracle_profile.claimed,
             OmegaXProtocolError::OracleProfileUnclaimed
         );
+        // Either SOL rail or matching the pool's SPL deposit mint.
+        require!(
+            args.asset_mint == NATIVE_SOL_MINT
+                || args.asset_mint == ctx.accounts.liquidity_pool.deposit_asset_mint,
+            OmegaXProtocolError::AssetMintMismatch
+        );
         if args.asset_mint != NATIVE_SOL_MINT {
             require!(
                 ctx.accounts.domain_asset_vault.is_some(),

--- a/tests/security/pool_oracle_fee_vault_rail_regression.test.ts
+++ b/tests/security/pool_oracle_fee_vault_rail_regression.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regression: pool-oracle fee vaults must not be initialized
+// against arbitrary SPL mints. They accrue against the same pool rail that
+// backs claim settlement, plus the explicit SOL rail.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const programSource = readFileSync(
+  new URL("../../programs/omegax_protocol/src/lib.rs", import.meta.url),
+  "utf8",
+);
+
+function extractInstructionBody(name: string): string {
+  const startIdx = programSource.indexOf(`pub fn ${name}(`);
+  assert.notEqual(startIdx, -1, `instruction ${name} should exist in program source`);
+
+  let i = programSource.indexOf("{", startIdx);
+  assert.notEqual(i, -1, `instruction ${name} should have a body`);
+
+  let depth = 1;
+  i += 1;
+  for (; i < programSource.length && depth > 0; i += 1) {
+    if (programSource[i] === "{") depth += 1;
+    else if (programSource[i] === "}") depth -= 1;
+  }
+
+  return programSource.slice(startIdx, i);
+}
+
+test("[CSO-2026-04-29] pool oracle fee vault init is pinned to SOL or the pool deposit mint", () => {
+  const body = extractInstructionBody("init_pool_oracle_fee_vault");
+
+  assert.match(
+    body,
+    /args\.asset_mint\s*==\s*NATIVE_SOL_MINT[\s\S]+args\.asset_mint\s*==\s*ctx\.accounts\.liquidity_pool\.deposit_asset_mint/,
+    "init_pool_oracle_fee_vault must reject arbitrary SPL fee rails outside the pool deposit mint",
+  );
+  assert.match(
+    body,
+    /OmegaXProtocolError::AssetMintMismatch/,
+    "oracle fee vault rail mismatch must fail with the asset-mint mismatch error",
+  );
+});


### PR DESCRIPTION
### Motivation
- Prevent initialization of a `PoolOracleFeeVault` for an asset mint that is unrelated to the pool rail by enforcing the same asset-rail invariant used by the pool-treasury initializer.

### Description
- Add a guard in `init_pool_oracle_fee_vault` requiring `args.asset_mint == NATIVE_SOL_MINT || args.asset_mint == ctx.accounts.liquidity_pool.deposit_asset_mint`, preserving the existing non-SOL `DomainAssetVault` presence check and behavior.

### Testing
- Ran `cargo test -p omegax_protocol --lib` and all unit tests passed (51 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a60eba30832f8fff323738909cd2)