### PR TITLE
Harden localnet E2E workflow supply-chain execution points

### DIFF
--- a/.github/workflows/localnet-e2e.yml
+++ b/.github/workflows/localnet-e2e.yml
@@ -73,7 +73,7 @@ jobs:
             build-essential
 
       - name: Cache cargo registry, git, and target
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: |
             ~/.cargo/registry
@@ -85,21 +85,24 @@ jobs:
 
       - name: Cache Solana CLI install
         id: solana-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.local/share/solana
           key: solana-stable-${{ runner.os }}-v1
 
       - name: Install Solana CLI
         if: steps.solana-cache.outputs.cache-hit != 'true'
-        run: sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+        run: |
+          curl -sSfL https://release.anza.xyz/stable/install -o /tmp/solana-install.sh
+          echo '4c69258d317fdd3cf65193053ea2c2f8c29f24a08161afb787b192262c72d070  /tmp/solana-install.sh' | sha256sum -c -
+          sh /tmp/solana-install.sh
 
       - name: Add Solana CLI to PATH
         run: echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
 
       - name: Cache Anchor CLI binary
         id: anchor-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.cargo/bin/anchor
           key: anchor-cli-${{ env.ANCHOR_VERSION }}-${{ runner.os }}
@@ -130,7 +133,7 @@ jobs:
 
       - name: Upload artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: localnet-e2e-${{ github.run_id }}
           path: artifacts/


### PR DESCRIPTION
### Motivation

- Remediate CI supply-chain risk by removing mutable third-party execution points in the `localnet-e2e` workflow so upstream tag or script compromise cannot execute arbitrary code in CI.

### Description

- Pin `actions/cache` and `actions/upload-artifact` references in `.github/workflows/localnet-e2e.yml` to immutable commit SHAs instead of the mutable `@v4` tag.
- Replace the direct `sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"` pattern with a download to `/tmp/solana-install.sh`, a SHA-256 checksum verification using `sha256sum -c`, and then execute the verified script.
- The change is confined to `.github/workflows/localnet-e2e.yml` and the commit includes a DCO sign-off (`git commit -s`).

### Testing

- Ran repository/file discovery checks with `rg` and `sed` to locate the workflow and confirm the original risky lines and the updated content, which succeeded.
- Verified upstream action refs with `git ls-remote` to obtain stable SHAs and inserted those SHAs into the workflow, which succeeded.
- Fetched the remote installer and computed its SHA with `curl` and `sha256sum` to produce the expected digest used in the workflow, which succeeded.
- Confirmed the final changes with `git diff` and committed the patch with `git commit -s`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a611a318832f8435daac0da00585)