### PR TITLE
Harden mainnet bootstrap guard for custom RPC domains

### DIFF
--- a/scripts/support/genesis_live_bootstrap_config.ts
+++ b/scripts/support/genesis_live_bootstrap_config.ts
@@ -224,16 +224,31 @@ function parsePubkey(value: string, label: string): string {
 }
 
 /**
- * Returns true when the resolved RPC URL points at a Solana mainnet endpoint.
- * Conservative: matches anything containing `mainnet`. Operators running an
- * isolated rehearsal against a private mainnet-beta-like cluster can bypass
- * via OMEGAX_LIVE_CLUSTER_OVERRIDE=devnet.
+ * Returns true when the resolved RPC URL should be treated as Solana mainnet.
+ * Conservative: only explicit non-mainnet markers (devnet/testnet/localnet)
+ * disable the guard; anything else is treated as mainnet to avoid custom-
+ * domain bypasses.
  *
  * See docs/security/mainnet-privileged-role-controls.md §4 for the policy
  * this guard enforces.
  */
 function isMainnetCluster(rpcUrl: string): boolean {
-  return rpcUrl.toLowerCase().includes("mainnet");
+  const normalized = rpcUrl.trim().toLowerCase();
+  if (!normalized) return true;
+
+  // Explicit non-mainnet markers disable the guard for rehearsals/localnet.
+  if (
+    normalized.includes("devnet")
+    || normalized.includes("testnet")
+    || normalized.includes("localhost")
+    || normalized.includes("127.0.0.1")
+  ) {
+    return false;
+  }
+
+  // Mainnet endpoints can be hosted behind custom domains without the
+  // literal "mainnet" in the URL; default to mainnet unless clearly non-mainnet.
+  return true;
 }
 
 function optionalPubkey(

--- a/tests/genesis_live_bootstrap_config.test.ts
+++ b/tests/genesis_live_bootstrap_config.test.ts
@@ -135,6 +135,19 @@ test("Mainnet bootstrap blocked when OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS is un
   );
 });
 
+test("Mainnet guard still blocks custom-domain RPC URLs when distinct-keys flag is unset", () => {
+  assert.throws(
+    () => loadGenesisLiveBootstrapConfig({
+      governanceAuthority: GOVERNANCE,
+      env: {
+        ...baseMainnetEnv(),
+        SOLANA_RPC_URL: "https://rpc.omegax.health/solana",
+      },
+    }),
+    /Mainnet bootstrap blocked.*OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 is required/,
+  );
+});
+
 test("Mainnet bootstrap blocked when role wallets default to governance signer", () => {
   // Distinct-keys flag is set but no per-role wallets; every operational role
   // would silently default to governanceAuthority.


### PR DESCRIPTION
### Motivation
- The previous mainnet classification used `rpcUrl.includes("mainnet")`, which allowed real mainnet RPCs served from custom domains to bypass the mainnet custody guard and permit privileged roles to default to the governance signer.
- The intent is to enforce a fail-closed rule for mainnet bootstraps so missing per-role wallets or the distinct-keys flag cannot silently collapse custody on live mainnet clusters.

### Description
- Reworked `isMainnetCluster` in `scripts/support/genesis_live_bootstrap_config.ts` to treat unknown/custom RPC hostnames as mainnet by default and only disable the guard for explicit non-mainnet markers (`devnet`, `testnet`, `localhost`, `127.0.0.1`).
- Updated the inline documentation for the mainnet guard to reflect the fail-closed policy.
- Added a regression test in `tests/genesis_live_bootstrap_config.test.ts` that asserts a custom-domain RPC URL without the literal `mainnet` is still blocked when `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS` is unset.
- Changes were committed with DCO sign-off and a focused PR created for review.

### Testing
- Ran the targeted test file with `node --import tsx --test tests/genesis_live_bootstrap_config.test.ts` and all tests passed (`10/10`).
- The regression test verifies that a custom-domain RPC URL triggers the mainnet guard as intended and the existing break-glass and cluster-override behaviors remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a610ceb4832f83118fde13043fa1)