### PR TITLE
Harden fee accrual rails and redemption outflows

### DIFF
--- a/frontend/components/capital-operator-drawer.tsx
+++ b/frontend/components/capital-operator-drawer.tsx
@@ -26,10 +26,12 @@ import {
   hashStringTo32Hex,
   type AllocationPositionSnapshot,
   type CapitalClassSnapshot,
+  type DomainAssetVaultSnapshot,
   type FundingLineSnapshot,
   type HealthPlanSnapshot,
   type LiquidityPoolSnapshot,
   type LPPositionSnapshot,
+  type PoolTreasuryVaultSnapshot,
   type ReserveDomainSnapshot,
 } from "@/lib/protocol";
 import { cn } from "@/lib/cn";
@@ -54,6 +56,8 @@ type CapitalOperatorDrawerProps = {
   allocations: AllocationPositionSnapshot[];
   plans: HealthPlanSnapshot[];
   fundingLines: FundingLineSnapshot[];
+  domainAssetVaults: DomainAssetVaultSnapshot[];
+  poolTreasuryVaults: PoolTreasuryVaultSnapshot[];
 };
 
 const SECTIONS: Array<{ id: CapitalOperatorSection; label: string; blurb: string }> = [
@@ -134,6 +138,7 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
   // Queue
   const [lpOwner, setLpOwner] = useState("");
   const [queueShares, setQueueShares] = useState("0");
+  const [redemptionRecipientTokenAccount, setRedemptionRecipientTokenAccount] = useState("");
   const [lpCredentialed, setLpCredentialed] = useState(true);
   const [lpReason, setLpReason] = useState("");
 
@@ -173,6 +178,25 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
     () => filteredFundingLines.find((line) => line.address === fundingLineAddress) ?? null,
     [filteredFundingLines, fundingLineAddress],
   );
+  const selectedPoolAssetVault = useMemo(
+    () =>
+      props.domainAssetVaults.find(
+        (vault) =>
+          vault.reserveDomain === props.selectedPool?.reserveDomain &&
+          vault.assetMint === props.selectedPool?.depositAssetMint,
+      ) ?? null,
+    [props.domainAssetVaults, props.selectedPool?.depositAssetMint, props.selectedPool?.reserveDomain],
+  );
+  const selectedPoolTreasuryVault = useMemo(
+    () =>
+      props.poolTreasuryVaults.find(
+        (vault) =>
+          vault.liquidityPool === props.selectedPool?.address &&
+          vault.assetMint === props.selectedPool?.depositAssetMint,
+      ) ?? null,
+    [props.poolTreasuryVaults, props.selectedPool?.address, props.selectedPool?.depositAssetMint],
+  );
+  const selectedClassRequiresFeeVault = (props.selectedClass?.feeBps ?? 0) > 0;
 
   async function run(label: string, factory: () => Promise<Transaction>) {
     if (!publicKey || !sendTransaction) return;
@@ -691,11 +715,16 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                       value={lpOwner}
                       onChange={setLpOwner}
                     />
-                    <div className="plans-wizard-row">
+	                    <div className="plans-wizard-row">
                       <TextField
                         label="Shares"
                         value={queueShares}
                         onChange={setQueueShares}
+                      />
+                      <TextField
+                        label="Recipient token account"
+                        value={redemptionRecipientTokenAccount}
+                        onChange={setRedemptionRecipientTokenAccount}
                       />
                     </div>
                     <p className="operator-drawer-hint">
@@ -705,7 +734,14 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                       <button
                         type="button"
                         className="plans-primary-cta"
-                        disabled={!canAct || !lpOwner || busyOn("Process redemption queue")}
+                        disabled={
+                          !canAct ||
+                          !lpOwner ||
+                          !selectedPoolAssetVault?.vaultTokenAccount ||
+                          (selectedClassRequiresFeeVault && !selectedPoolTreasuryVault) ||
+                          !redemptionRecipientTokenAccount.trim() ||
+                          busyOn("Process redemption queue")
+                        }
                         onClick={() =>
                           run("Process redemption queue", async () => {
                             const { blockhash } = await connection.getLatestBlockhash("confirmed");
@@ -718,6 +754,9 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                               lpOwnerAddress: lpOwner,
                               recentBlockhash: blockhash,
                               shares: parseBigIntInput(queueShares),
+                              poolTreasuryVaultAddress: selectedPoolTreasuryVault?.address ?? null,
+                              vaultTokenAccountAddress: selectedPoolAssetVault!.vaultTokenAccount,
+                              recipientTokenAccountAddress: redemptionRecipientTokenAccount.trim(),
                             });
                           })
                         }

--- a/frontend/components/capital-workbench.tsx
+++ b/frontend/components/capital-workbench.tsx
@@ -1145,6 +1145,8 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
           allocations={poolAllocations}
           plans={snapshot.healthPlans}
           fundingLines={snapshot.fundingLines}
+          domainAssetVaults={snapshot.domainAssetVaults}
+          poolTreasuryVaults={snapshot.poolTreasuryVaults}
         />
       ) : null}
     </div>

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -399,6 +399,7 @@ export type CapitalClassSnapshot = {
   displayName: string;
   priority: number;
   restrictionMode: number;
+  feeBps?: number;
   totalShares: BigNumberish;
   navAssets: BigNumberish;
   allocatedAssets?: BigNumberish;
@@ -2240,6 +2241,7 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           displayName: stringFromAnchorValue(decodedField(decoded, "displayName")),
           priority: Number(decodedField(decoded, "priority") ?? 0),
           restrictionMode: Number(decodedField(decoded, "restrictionMode") ?? 0),
+          feeBps: Number(decodedField(decoded, "feeBps") ?? decodedField(decoded, "fee_bps") ?? 0),
           totalShares: bigintFromAnchorValue(decodedField(decoded, "totalShares")),
           navAssets: bigintFromAnchorValue(decodedField(decoded, "navAssets")),
           allocatedAssets: bigintFromAnchorValue(decodedField(decoded, "allocatedAssets")),
@@ -4125,6 +4127,7 @@ export function buildRecordPremiumPaymentTx(params: {
   policySeriesAddress?: PublicKeyish | null;
   capitalClassAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
+  protocolFeeVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
   const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
@@ -4167,6 +4170,7 @@ export function buildRecordPremiumPaymentTx(params: {
         isWritable: true,
       },
       optionalSeriesReserveLedgerAccount(params.policySeriesAddress, params.assetMint),
+      optionalProtocolAccount(params.protocolFeeVaultAddress, true),
       { pubkey: params.sourceTokenAccountAddress, isWritable: true },
       { pubkey: params.assetMint },
       { pubkey: params.vaultTokenAccountAddress, isWritable: true },
@@ -4752,6 +4756,7 @@ export function buildDepositIntoCapitalClassTx(params: {
   recentBlockhash: string;
   amount: bigint;
   shares: bigint;
+  poolTreasuryVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const owner = toPublicKey(params.owner);
   const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
@@ -4794,6 +4799,7 @@ export function buildDepositIntoCapitalClassTx(params: {
         isWritable: true,
       },
       { pubkey: lpPosition, isWritable: true },
+      optionalProtocolAccount(params.poolTreasuryVaultAddress, true),
       { pubkey: params.sourceTokenAccountAddress, isWritable: true },
       { pubkey: params.poolDepositAssetMint },
       { pubkey: params.vaultTokenAccountAddress, isWritable: true },
@@ -4895,8 +4901,13 @@ export function buildProcessRedemptionQueueTx(params: {
   recentBlockhash: string;
   shares: bigint;
   assetAmount?: bigint;
+  poolTreasuryVaultAddress?: PublicKeyish | null;
+  vaultTokenAccountAddress: PublicKeyish;
+  recipientTokenAccountAddress: PublicKeyish;
+  tokenProgramId?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
+  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
   const lpPosition = deriveLpPositionPda({
     capitalClass: params.capitalClassAddress,
     owner: params.lpOwnerAddress,
@@ -4935,6 +4946,11 @@ export function buildProcessRedemptionQueueTx(params: {
         isWritable: true,
       },
       { pubkey: lpPosition, isWritable: true },
+      optionalProtocolAccount(params.poolTreasuryVaultAddress, true),
+      { pubkey: params.poolDepositAssetMint },
+      { pubkey: params.vaultTokenAccountAddress, isWritable: true },
+      { pubkey: params.recipientTokenAccountAddress, isWritable: true },
+      { pubkey: tokenProgramId },
     ],
   });
 }

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -3275,7 +3275,7 @@
           "docs": [
             "Phase 1.6 — optional pool-treasury vault for entry-fee accrual.",
             "When supplied, must match (liquidity_pool, deposit_asset_mint).",
-            "Validated at runtime; absent means entry-fee accrual is skipped (backward compat)."
+            "Required when capital_class.fee_bps is nonzero."
           ],
           "writable": true,
           "optional": true
@@ -5539,7 +5539,7 @@
           "docs": [
             "Phase 1.6 — optional pool-treasury vault for exit-fee accrual.",
             "When supplied, must match (liquidity_pool, deposit_asset_mint).",
-            "Validated at runtime; absent means exit-fee accrual is skipped (backward compat)."
+            "Required when capital_class.fee_bps is nonzero."
           ],
           "writable": true,
           "optional": true
@@ -5858,9 +5858,9 @@
         {
           "name": "protocol_fee_vault",
           "docs": [
-            "Phase 1.6 — optional protocol fee vault for accrual at premium time.",
-            "When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).",
-            "Validated at runtime; absent means premium accrual is skipped (backward compat)."
+            "Protocol fee vault for premium-time fee accrual. Required when",
+            "protocol_governance.protocol_fee_bps is nonzero.",
+            "Must match (health_plan.reserve_domain, funding_line.asset_mint)."
           ],
           "writable": true,
           "optional": true

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-9330d160160ce38991fb55c5745c590af2f3e2c41de1603c791e95acf316603f
+fa0559fb905c173f65729da8fc9d863115c25aa55cc14f65093e72ea43c6c284
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -970,32 +970,29 @@ pub mod omegax_protocol {
         // The full premium amount is booked into the vault; the fee is an
         // internal claim that decrements `accrued_fees - withdrawn_fees`
         // headroom. No user-facing payout reduction here (premiums are not
-        // refundable). Accrual is skipped silently when `protocol_fee_vault`
-        // is None to preserve backward compatibility for callers that have
-        // not yet initialized the fee infrastructure.
-        if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
-            require_keys_eq!(
-                vault.reserve_domain,
-                health_plan_reserve_domain,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            require_keys_eq!(
-                vault.asset_mint,
-                funding_line_asset_mint,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
-            if fee > 0 {
-                let vault_key = vault.key();
-                let vault_mint = vault.asset_mint;
-                let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
-                emit!(FeeAccruedEvent {
-                    vault: vault_key,
-                    asset_mint: vault_mint,
-                    amount: fee,
-                    accrued_total,
-                });
-            }
+        // refundable).
+        let vault = &mut ctx.accounts.protocol_fee_vault;
+        require_keys_eq!(
+            vault.reserve_domain,
+            health_plan_reserve_domain,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        require_keys_eq!(
+            vault.asset_mint,
+            funding_line_asset_mint,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
+        if fee > 0 {
+            let vault_key = vault.key();
+            let vault_mint = vault.asset_mint;
+            let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
+            emit!(FeeAccruedEvent {
+                vault: vault_key,
+                asset_mint: vault_mint,
+                amount: fee,
+                accrued_total,
+            });
         }
 
         emit!(FundingFlowRecordedEvent {
@@ -3508,11 +3505,10 @@ pub struct RecordPremiumPayment<'info> {
     pub plan_reserve_ledger: Box<Account<'info, PlanReserveLedger>>,
     #[account(mut)]
     pub series_reserve_ledger: Option<Box<Account<'info, SeriesReserveLedger>>>,
-    /// Phase 1.6 — optional protocol fee vault for accrual at premium time.
-    /// When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).
-    /// Validated at runtime; absent means premium accrual is skipped (backward compat).
+    /// Protocol fee vault for mandatory premium-time fee accrual.
+    /// Must match (health_plan.reserve_domain, funding_line.asset_mint).
     #[account(mut)]
-    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
+    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -977,28 +977,34 @@ pub mod omegax_protocol {
         // internal claim that decrements `accrued_fees - withdrawn_fees`
         // headroom. No user-facing payout reduction here (premiums are not
         // refundable).
-        let vault = &mut ctx.accounts.protocol_fee_vault;
-        require_keys_eq!(
-            vault.reserve_domain,
-            health_plan_reserve_domain,
-            OmegaXProtocolError::FeeVaultMismatch
-        );
-        require_keys_eq!(
-            vault.asset_mint,
-            funding_line_asset_mint,
-            OmegaXProtocolError::FeeVaultMismatch
-        );
-        let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
-        if fee > 0 {
-            let vault_key = vault.key();
-            let vault_mint = vault.asset_mint;
-            let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
-            emit!(FeeAccruedEvent {
-                vault: vault_key,
-                asset_mint: vault_mint,
-                amount: fee,
-                accrued_total,
-            });
+        if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
+            require_keys_eq!(
+                vault.reserve_domain,
+                health_plan_reserve_domain,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            require_keys_eq!(
+                vault.asset_mint,
+                funding_line_asset_mint,
+                OmegaXProtocolError::FeeVaultMismatch
+            );
+            let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
+            if fee > 0 {
+                let vault_key = vault.key();
+                let vault_mint = vault.asset_mint;
+                let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
+                emit!(FeeAccruedEvent {
+                    vault: vault_key,
+                    asset_mint: vault_mint,
+                    amount: fee,
+                    accrued_total,
+                });
+            }
+        } else {
+            require!(
+                protocol_fee_bps == 0,
+                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
+            );
         }
 
         emit!(FundingFlowRecordedEvent {
@@ -2032,8 +2038,8 @@ pub mod omegax_protocol {
 
         // Accrue the entry fee to the pool-treasury vault. SPL tokens already
         // sit in the DomainAssetVault from the transfer above; this only updates
-        // the rail's claim counter. Skipped silently when entry_fee == 0 (either
-        // pool_treasury_vault is None or capital_class.fee_bps == 0).
+        // the rail's claim counter. Missing vaults are only allowed when
+        // capital_class.fee_bps == 0.
         if entry_fee > 0 {
             if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
                 let vault_key = vault.key();
@@ -2164,6 +2170,10 @@ pub mod omegax_protocol {
             );
             fee_share_from_bps(asset_amount, class_fee_bps)?
         } else {
+            require!(
+                class_fee_bps == 0,
+                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
+            );
             0
         };
         let net_to_lp = checked_sub(asset_amount, exit_fee)?;
@@ -2243,7 +2253,7 @@ pub mod omegax_protocol {
 
         // Accrue the exit fee to the pool-treasury vault. SPL tokens are still
         // physically in the vault_token_account; only the rail's claim counter
-        // changes. Skipped silently when exit_fee == 0.
+        // changes. Missing vaults are only allowed when class_fee_bps == 0.
         if exit_fee > 0 {
             if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
                 let vault_key = vault.key();
@@ -3515,10 +3525,11 @@ pub struct RecordPremiumPayment<'info> {
     pub plan_reserve_ledger: Box<Account<'info, PlanReserveLedger>>,
     #[account(mut)]
     pub series_reserve_ledger: Option<Box<Account<'info, SeriesReserveLedger>>>,
-    /// Protocol fee vault for mandatory premium-time fee accrual.
+    /// Protocol fee vault for premium-time fee accrual. Required when
+    /// protocol_governance.protocol_fee_bps is nonzero.
     /// Must match (health_plan.reserve_domain, funding_line.asset_mint).
     #[account(mut)]
-    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
+    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,
@@ -3963,7 +3974,7 @@ pub struct DepositIntoCapitalClass<'info> {
     pub lp_position: Box<Account<'info, LPPosition>>,
     /// Phase 1.6 — optional pool-treasury vault for entry-fee accrual.
     /// When supplied, must match (liquidity_pool, deposit_asset_mint).
-    /// Validated at runtime; absent means entry-fee accrual is skipped (backward compat).
+    /// Required when capital_class.fee_bps is nonzero.
     #[account(mut)]
     pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
     #[account(mut)]
@@ -4011,7 +4022,7 @@ pub struct ProcessRedemptionQueue<'info> {
     pub lp_position: Box<Account<'info, LPPosition>>,
     /// Phase 1.6 — optional pool-treasury vault for exit-fee accrual.
     /// When supplied, must match (liquidity_pool, deposit_asset_mint).
-    /// Validated at runtime; absent means exit-fee accrual is skipped (backward compat).
+    /// Required when capital_class.fee_bps is nonzero.
     #[account(mut)]
     pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
     // PT-2026-04-27-01/02 fix: outflow CPI accounts. Recipient must be the LP

--- a/tests/security/fee_accrual_guards_regression.test.ts
+++ b/tests/security/fee_accrual_guards_regression.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regressions for fee accrual:
+// configured premium and LP exit fees must fail closed when callers omit the
+// matching fee-vault account, and builders must preserve optional-account slots.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import fixturesModule from "../../frontend/lib/devnet-fixtures.ts";
+import protocolModule from "../../frontend/lib/protocol.ts";
+
+const programSource = readFileSync(
+  new URL("../../programs/omegax_protocol/src/lib.rs", import.meta.url),
+  "utf8",
+);
+
+const { DEVNET_PROTOCOL_FIXTURE_STATE } =
+  fixturesModule as typeof import("../../frontend/lib/devnet-fixtures.ts");
+
+const {
+  buildDepositIntoCapitalClassTx,
+  buildProcessRedemptionQueueTx,
+  buildRecordPremiumPaymentTx,
+  getProgramId,
+  listProtocolInstructionAccounts,
+} = protocolModule as typeof import("../../frontend/lib/protocol.ts");
+
+function extractInstructionBody(name: string): string {
+  const startIdx = programSource.indexOf(`pub fn ${name}(`);
+  assert.notEqual(startIdx, -1, `instruction ${name} should exist in program source`);
+
+  let i = programSource.indexOf("{", startIdx);
+  assert.notEqual(i, -1, `instruction ${name} should have a body`);
+
+  let depth = 1;
+  i += 1;
+  for (; i < programSource.length && depth > 0; i += 1) {
+    if (programSource[i] === "{") depth += 1;
+    else if (programSource[i] === "}") depth -= 1;
+  }
+
+  return programSource.slice(startIdx, i);
+}
+
+function assertAccountCount(name: Parameters<typeof listProtocolInstructionAccounts>[0], actual: number) {
+  assert.equal(
+    actual,
+    listProtocolInstructionAccounts(name).length,
+    `${name} builder must emit one key for every Anchor account, including optional placeholders`,
+  );
+}
+
+test("[CSO-2026-04-29] configured premium and LP exit fees require fee vault accounts", () => {
+  const premiumBody = extractInstructionBody("record_premium_payment");
+  const redemptionBody = extractInstructionBody("process_redemption_queue");
+
+  assert.match(premiumBody, /protocol_fee_bps\s*==\s*0/);
+  assert.match(premiumBody, /FeeVaultRequiredForConfiguredFee/);
+  assert.match(redemptionBody, /class_fee_bps\s*==\s*0/);
+  assert.match(redemptionBody, /FeeVaultRequiredForConfiguredFee/);
+});
+
+test("[CSO-2026-04-29] fee-accrual builders preserve optional fee-vault slots", () => {
+  const programId = getProgramId().toBase58();
+  const recentBlockhash = "11111111111111111111111111111111";
+  const authority = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address;
+  const recipient = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[1]!.address;
+  const plan = DEVNET_PROTOCOL_FIXTURE_STATE.healthPlans[0]!;
+  const fundingLine = DEVNET_PROTOCOL_FIXTURE_STATE.fundingLines.find((line) => line.healthPlan === plan.address)
+    ?? DEVNET_PROTOCOL_FIXTURE_STATE.fundingLines[0]!;
+  const pool = DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!;
+  const capitalClass = DEVNET_PROTOCOL_FIXTURE_STATE.capitalClasses.find((entry) => entry.liquidityPool === pool.address)
+    ?? DEVNET_PROTOCOL_FIXTURE_STATE.capitalClasses[0]!;
+  const lpPosition = DEVNET_PROTOCOL_FIXTURE_STATE.lpPositions.find((entry) => entry.capitalClass === capitalClass.address)
+    ?? DEVNET_PROTOCOL_FIXTURE_STATE.lpPositions[0]!;
+
+  const recordPremium = buildRecordPremiumPaymentTx({
+    authority,
+    healthPlanAddress: plan.address,
+    reserveDomainAddress: plan.reserveDomain,
+    fundingLineAddress: fundingLine.address,
+    assetMint: fundingLine.assetMint,
+    sourceTokenAccountAddress: authority,
+    vaultTokenAccountAddress: recipient,
+    recentBlockhash,
+    amount: 1n,
+    policySeriesAddress: fundingLine.policySeries ?? null,
+  });
+  assertAccountCount("record_premium_payment", recordPremium.instructions[0]!.keys.length);
+  assert.equal(recordPremium.instructions[0]!.keys[9]!.pubkey.toBase58(), programId);
+
+  const recordPremiumWithVault = buildRecordPremiumPaymentTx({
+    authority,
+    healthPlanAddress: plan.address,
+    reserveDomainAddress: plan.reserveDomain,
+    fundingLineAddress: fundingLine.address,
+    assetMint: fundingLine.assetMint,
+    sourceTokenAccountAddress: authority,
+    vaultTokenAccountAddress: recipient,
+    recentBlockhash,
+    amount: 1n,
+    policySeriesAddress: fundingLine.policySeries ?? null,
+    protocolFeeVaultAddress: recipient,
+  });
+  assert.equal(recordPremiumWithVault.instructions[0]!.keys[9]!.pubkey.toBase58(), recipient);
+
+  const deposit = buildDepositIntoCapitalClassTx({
+    owner: authority,
+    reserveDomainAddress: pool.reserveDomain,
+    poolAddress: pool.address,
+    poolDepositAssetMint: pool.depositAssetMint,
+    capitalClassAddress: capitalClass.address,
+    sourceTokenAccountAddress: authority,
+    vaultTokenAccountAddress: recipient,
+    recentBlockhash,
+    amount: 1n,
+    shares: 1n,
+  });
+  assertAccountCount("deposit_into_capital_class", deposit.instructions[0]!.keys.length);
+  assert.equal(deposit.instructions[0]!.keys[8]!.pubkey.toBase58(), programId);
+
+  const redemption = buildProcessRedemptionQueueTx({
+    authority,
+    reserveDomainAddress: pool.reserveDomain,
+    poolAddress: pool.address,
+    poolDepositAssetMint: pool.depositAssetMint,
+    capitalClassAddress: capitalClass.address,
+    lpOwnerAddress: lpPosition.owner,
+    recentBlockhash,
+    shares: 1n,
+    vaultTokenAccountAddress: pool.address,
+    recipientTokenAccountAddress: recipient,
+  });
+  assertAccountCount("process_redemption_queue", redemption.instructions[0]!.keys.length);
+  assert.equal(redemption.instructions[0]!.keys[8]!.pubkey.toBase58(), programId);
+  assert.equal(redemption.instructions[0]!.keys[10]!.pubkey.toBase58(), pool.address);
+  assert.equal(redemption.instructions[0]!.keys[11]!.pubkey.toBase58(), recipient);
+});


### PR DESCRIPTION
## Summary
- keeps fee-vault accounts optional at the IDL boundary but fails closed when premium, entry, or exit fees are configured
- adds builder/UI account slots for premium protocol fees, capital-class treasury fees, and redemption SPL outflows
- adds CSO regression coverage for omitted fee-vault and outflow account edge cases

## Validation
- node --import tsx --test tests/security/fee_accrual_guards_regression.test.ts
- node --import tsx --test tests/security/settlement_fee_guards_regression.test.ts
- npm run idl:freshness:check
- npm run protocol:contract:check
- npm --prefix frontend run build
- npm run test:node
- npm run verify:public