### PR TITLE
[codex] Harden pre-mainnet protocol fund flows

### DIFF
--- a/docs/security/codex-challenge-2026-04-29.md
+++ b/docs/security/codex-challenge-2026-04-29.md
@@ -1,0 +1,473 @@
+# OmegaX Protocol — Codex Adversarial Challenge
+
+- **Date:** 2026-04-29
+- **Reviewer:** OpenAI Codex (gpt-5.5, codex-cli 0.125.0, `model_reasoning_effort="high"`)
+- **Driver:** Claude Code via `/gstack-codex challenge`
+- **Scope:** Holistic safety-property audit of `programs/omegax_protocol/src/lib.rs` (~9000 LOC) and `programs/omegax_protocol/src/core_accounts.rs`. Frontend (`frontend/lib/protocol.ts`) in scope only as it affects on-chain instruction construction.
+- **Mode:** Defensive pre-mainnet hardening review, framed as 10 safety properties to verify.
+- **Companion to:** [`docs/security/pre-mainnet-pen-test-2026-04-27.md`](pre-mainnet-pen-test-2026-04-27.md) (PT-01 .. PT-13 already remediated; this run is fresh ground).
+- **Codex run cost:** 1,038,311 tokens, ~4 minutes wall clock.
+
+---
+
+## Verdict
+
+**Codex verdict:** `MUST-FIX-BEFORE-MAINNET`
+**Totals:** P0 = 1, P1 = 4, P2 = 3, P3 = 0
+
+**Claude verification:** All 10 findings cross-checked against actual source. **Every "DOES_NOT_HOLD" / "PARTIAL" claim is grounded in real code at the cited file:line.** No false positives. One severity downgrade noted (PROPERTY-1 is defense-in-depth, runtime checks already catch the issue at handler time).
+
+The team should treat this report as a **must-fix gate before mainnet**, with PROPERTY-9 (deposit shares math) as the single highest-priority item. PT-08 in the prior pen-test was withdrawn because impairment doesn't mutate NAV — but Codex found a **different, larger NAV first-mover bug** in the deposit-shares math itself that the prior review did not surface.
+
+### Severity legend
+
+- **P0** — direct fund-loss path (existing LPs lose value to a dust attacker)
+- **P1** — fee leakage, mis-routing, or defense-in-depth gap that compounds with other compromise
+- **P2** — DoS, griefing, or operational risk
+- **P3** — informational
+
+---
+
+## Summary table
+
+| # | Property | Codex status | Severity | Verified | Fix priority |
+|---|----------|--------------|----------|----------|--------------|
+| 1 | Fee-vault account binding integrity | DOES_NOT_HOLD | P1 | ✅ true (defense-in-depth gap; runtime checks DO catch wrong vaults at handler time) | High |
+| 2 | Withdraw-rail account isolation (recipient owner) | PARTIAL | P1 | ✅ true | High |
+| 3 | Oracle fee accrual binding (vault ↔ adjudicator) | DOES_NOT_HOLD | P1 | ✅ true | High |
+| 4 | PDA seed canonicality + init re-init protection | HOLDS | — | ✅ confirmed | — |
+| 5 | Curator authority scope | PARTIAL | P2 | ✅ true | Medium |
+| 6 | Token program / mint extension safety | DOES_NOT_HOLD | P1 | ✅ true | **Critical** (Token-2022) |
+| 7 | SOL-rail lamport accounting | HOLDS | — | ✅ confirmed | — |
+| 8 | Settlement recipient routing under `delegate_recipient` | PARTIAL | P2 | ✅ true | Medium |
+| 9 | **Capital-class deposit shares math** | **DOES_NOT_HOLD** | **P0** | ✅ true (NAV first-mover via deposit pricing) | **Critical** |
+| 10 | Authority rotation (no two-step accept) | DOES_NOT_HOLD | P2 | ✅ true | Medium |
+
+---
+
+## Findings
+
+### FINDING-1 — Optional fee-vault accounts lack canonical PDA seed bindings
+
+- **Severity:** P1 (defense-in-depth gap)
+- **Status:** DOES_NOT_HOLD per Codex; verified at handler-runtime level the attack is blocked, but Anchor account-resolution is loose.
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:3514`](../../programs/omegax_protocol/src/lib.rs#L3514) — `RecordPremiumPayment.protocol_fee_vault: Option<...>` with only `#[account(mut)]`
+  - [`programs/omegax_protocol/src/lib.rs:3813`](../../programs/omegax_protocol/src/lib.rs#L3813) — `SettleClaimCase.protocol_fee_vault` (same pattern)
+  - [`programs/omegax_protocol/src/lib.rs:3822`](../../programs/omegax_protocol/src/lib.rs#L3822) — `SettleClaimCase.pool_oracle_fee_vault` (same pattern)
+  - [`programs/omegax_protocol/src/lib.rs:3827`](../../programs/omegax_protocol/src/lib.rs#L3827) — `SettleClaimCase.pool_oracle_policy` (same pattern)
+- **Pre-conditions:** A privileged operator (claims_operator, sponsor_operator, plan_admin) supplies a fee-vault account during a flow.
+- **Verification:** Runtime checks DO exist:
+  - `record_premium_payment` checks `protocol_fee_vault.reserve_domain == health_plan.reserve_domain` at lines 977–986
+  - `deposit_into_capital_class` checks `pool_treasury_vault.liquidity_pool == pool.key()` and `vault.asset_mint == pool_deposit_mint` at lines 1979–1988
+  - `settle_claim_case` runs the same `vault.liquidity_pool == policy.liquidity_pool` and asset-mint checks at lines 1672–1689
+  - So the immediate attack ("substitute attacker-controlled vault") IS blocked at runtime, but ONLY for the parent reference + asset mint. There is no Anchor seed binding asserting the supplied vault is the **canonical** PDA for that (parent, mint).
+- **Impact:** Defense-in-depth. If a future code change drops one of the runtime checks, or if a new caller path forgets to validate, the vault could silently route to a wrong destination. With seeds in the `#[derive(Accounts)]`, Anchor would refuse the wrong account at instruction-decode time.
+- **Recommended fix:** Add explicit seeds + bumps to every optional fee-vault account:
+  ```rust
+  #[account(
+      mut,
+      seeds = [SEED_PROTOCOL_FEE_VAULT, health_plan.reserve_domain.as_ref(), funding_line.asset_mint.as_ref()],
+      bump = protocol_fee_vault.bump,
+      constraint = protocol_fee_vault.reserve_domain == health_plan.reserve_domain @ OmegaXProtocolError::FeeVaultMismatch,
+  )]
+  pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
+  ```
+  Apply to all four optional vault account fields. Anchor handles `Option<...>` with seeds correctly when present.
+
+---
+
+### FINDING-2 — SPL withdraw recipient_token_account has no owner constraint
+
+- **Severity:** P1 (defense-in-depth; matters under privileged-key compromise)
+- **Status:** PARTIAL
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:4073`](../../programs/omegax_protocol/src/lib.rs#L4073) — `WithdrawProtocolFeeSpl.recipient_token_account`
+  - [`programs/omegax_protocol/src/lib.rs:4131`](../../programs/omegax_protocol/src/lib.rs#L4131) — `WithdrawPoolTreasurySpl.recipient_token_account`
+  - [`programs/omegax_protocol/src/lib.rs:4198`](../../programs/omegax_protocol/src/lib.rs#L4198) — `WithdrawPoolOracleFeeSpl.recipient_token_account`
+- **Pre-conditions:** A privileged signer (governance, curator, oracle, or oracle_profile.admin) calls a withdraw instruction.
+- **Concrete evidence:** Each `recipient_token_account` is declared as:
+  ```rust
+  #[account(mut)]
+  pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
+  ```
+  with no `constraint = recipient_token_account.owner == ...`. The transfer helper `transfer_from_domain_vault` only checks the mint matches and rejects self-transfers (lib.rs:6899–6923).
+- **Impact:** A privileged-key compromise (governance keypair, pool curator, oracle admin) drains accrued fees to ANY ATA of the correct mint — including the attacker's. A typo by a benign operator could send fees to a wrong wallet. Does not enable an unprivileged attack, but eliminates an important defense-in-depth check.
+- **Recommended fix:** Either:
+  1. Pin to a configured fee-recipient pubkey stored on the vault state (preferred — no operator typo risk):
+     ```rust
+     #[account(
+         mut,
+         constraint = recipient_token_account.owner == protocol_fee_vault.configured_recipient
+             @ OmegaXProtocolError::Unauthorized,
+     )]
+     pub recipient_token_account: InterfaceAccount<'info, TokenAccount>,
+     ```
+     and add `pub configured_recipient: Pubkey,` to each vault state struct; require governance to set it via a separate `set_fee_recipient` ix (event-emitted, audit-logged).
+  2. As a minimum, require `recipient_token_account.owner == authority.key()` so fees can only be withdrawn to the signer's own ATA — collapses the threat model to "the privileged signer's own keypair."
+
+---
+
+### FINDING-3 — Oracle fee vault not bound to the adjudicator on settlement
+
+- **Severity:** P1 (fee mis-routing across oracles in the same pool)
+- **Status:** DOES_NOT_HOLD
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:1672-1689`](../../programs/omegax_protocol/src/lib.rs#L1672) — settle_claim_case oracle_fee accrual
+  - [`programs/omegax_protocol/src/lib.rs:5022`](../../programs/omegax_protocol/src/lib.rs#L5022) — `PoolOraclePolicy` struct
+  - [`programs/omegax_protocol/src/lib.rs:3822`](../../programs/omegax_protocol/src/lib.rs#L3822) — optional `pool_oracle_fee_vault` account
+- **Pre-conditions:** Multiple oracles can serve the same `(liquidity_pool, asset_mint)`. A claims_operator settles a claim and supplies a `pool_oracle_fee_vault` belonging to oracle B, while the actual adjudicator on the claim is oracle A.
+- **Concrete evidence:** `PoolOraclePolicy` (line 5022) stores only `liquidity_pool`, quorum, schema flag, `oracle_fee_bps`, delegate flag, challenge window, ts, bump. **It does NOT carry `oracle: Pubkey` or `asset_mint: Pubkey`.** The settlement check at lines 1672–1689 verifies:
+  - `vault.asset_mint == funding_line.asset_mint` ✅
+  - `vault.liquidity_pool == policy.liquidity_pool` ✅
+  - **No check that `vault.oracle == claim_case.adjudicator`** ❌
+- **Impact:** In a pool with N oracles, an operator can credit oracle B's fee vault for adjudication work performed by oracle A, redirecting the revshare. With the per-call magnitude bounded by `oracle_fee_bps` × claim amount, the cumulative drain is significant for a high-volume pool.
+- **Recommended fix:** Two changes, both required:
+  1. In `settle_claim_case` body, add:
+     ```rust
+     require_keys_eq!(
+         vault.oracle,
+         claim_case.adjudicator,
+         OmegaXProtocolError::OracleProfileMismatch
+     );
+     ```
+  2. In `SettleClaimCase` accounts struct (line 3822), bind seeds:
+     ```rust
+     #[account(
+         mut,
+         seeds = [
+             SEED_POOL_ORACLE_FEE_VAULT,
+             liquidity_pool.key().as_ref(),
+             claim_case.adjudicator.as_ref(),
+             funding_line.asset_mint.as_ref(),
+         ],
+         bump = pool_oracle_fee_vault.bump,
+     )]
+     pub pool_oracle_fee_vault: Option<Box<Account<'info, PoolOracleFeeVault>>>,
+     ```
+  Anchor account-resolution will then refuse a wrong-oracle vault before the body runs.
+
+---
+
+### FINDING-4 — VECTOR HOLDS
+
+PROPERTY-4 holds. Init handlers (`init_protocol_fee_vault` line 340, `init_pool_treasury_vault` line 380, `init_pool_oracle_fee_vault` line 425) use canonical seeds and Anchor `init` constraint rejects re-init. Authority gating: governance for protocol rail, curator for pool rails. No squatting path found.
+
+---
+
+### FINDING-5 — Curator unilateral discretion on redemption queue and treasury
+
+- **Severity:** P2 (operational risk; LP payout routing IS protected)
+- **Status:** PARTIAL
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:2122`](../../programs/omegax_protocol/src/lib.rs#L2122) — `process_redemption_queue` `require_curator_control`
+  - [`programs/omegax_protocol/src/lib.rs:2223-2226`](../../programs/omegax_protocol/src/lib.rs#L2223) — recipient owner pinned to `lp_position.owner` ✅
+  - [`programs/omegax_protocol/src/lib.rs:2345-2349`](../../programs/omegax_protocol/src/lib.rs#L2345) — `withdraw_pool_treasury_*` `require_curator_control`
+- **Pre-conditions:** Pool curator is single-keyed (no multisig at protocol level).
+- **Concrete evidence:** Redemption recipient IS pinned to `lp_position.owner` — curator cannot redirect LP payouts (good, codex confirms). But curator alone decides:
+  - Order in which queued redemptions are processed (no FIFO invariant on-chain)
+  - Timing (no minimum wait between request and process)
+  - Whether to process at all (no governance pressure)
+  - All `withdraw_pool_treasury_spl/sol` recipient routing (combined with FINDING-2's missing recipient owner constraint, a curator key compromise drains the treasury rail to attacker-controlled ATAs)
+- **Impact:** Curator-key compromise drains pool treasury fees and can grief LPs by reordering or stalling redemptions. Not a direct LP-fund-loss vector (recipient is pinned).
+- **Recommended fix:**
+  1. Add a configured `treasury_recipient` field on `LiquidityPool` and constrain `withdraw_pool_treasury_*` to that recipient (combine with FINDING-2 fix).
+  2. Add a FIFO ordering invariant + minimum processing delay on `process_redemption_queue` (already documented as PT-08-adjacent in the prior pen-test).
+  3. Multisig is operational, not code — covered in `docs/security/mainnet-privileged-role-controls.md`.
+
+---
+
+### FINDING-6 — Token-2022 accepted without extension safety checks (CRITICAL for asset choice)
+
+- **Severity:** P1 (CRITICAL if the team plans to accept Token-2022 mints)
+- **Status:** DOES_NOT_HOLD
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:6`](../../programs/omegax_protocol/src/lib.rs#L6) — `use anchor_spl::token_interface::{...};`
+  - [`programs/omegax_protocol/Cargo.toml`](../../programs/omegax_protocol/Cargo.toml) — `anchor-spl = "0.32.1"`
+  - All `vault_token_account: InterfaceAccount<'info, TokenAccount>` and `asset_mint: InterfaceAccount<'info, Mint>` fields throughout
+- **Pre-conditions:** Any operator initializes a `domain_asset_vault` with a Token-2022 mint that has the transfer-fee or transfer-hook extension enabled.
+- **Concrete evidence:** The program imports `token_interface` (the Token-2022-compatible interface), declares all token accounts and mints as `InterfaceAccount<...>`, and uses `Interface<TokenInterface>` for the token program. There is **no constraint excluding Token-2022 mints**, no `asset_mint.to_account_info().owner == &anchor_spl::token::ID` check, and no inspection of mint extensions.
+- **Concrete impact paths:**
+  - **Transfer-fee extension:** `transfer_to_domain_vault` deducts `args.amount` from source but the vault receives `amount - transfer_fee`. The protocol then books `total_assets += amount` — **NAV is overstated** by exactly the transfer fee on every deposit.
+  - **Transfer-hook extension:** A hook program runs on every transfer. A malicious hook can re-enter the OmegaX program through any other instruction (Solana CPI is single-call but the hook is called BEFORE return), arbitrarily mutating state if the hook author calls the program back. CEI (checks-effects-interactions) is not enforced — `deposit_into_capital_class` does the SPL transfer (line 1957) BEFORE state mutation (line 2008+), and `withdraw_*_fee_*` does the transfer (line 2287) BEFORE bumping `withdrawn_fees` (line 2288).
+  - **Confidential-transfer extension:** Amount is cryptographically hidden. `transfer_checked` may not even surface the real amount.
+- **Recommended fix (pick one):**
+  1. **For mainnet launch (recommended):** restrict to classic SPL Token only. Add to every relevant accounts struct:
+     ```rust
+     #[account(
+         constraint = asset_mint.to_account_info().owner == &anchor_spl::token::ID
+             @ OmegaXProtocolError::Token2022NotSupported,
+     )]
+     pub asset_mint: InterfaceAccount<'info, Mint>,
+     #[account(
+         constraint = token_program.key() == anchor_spl::token::ID
+             @ OmegaXProtocolError::Token2022NotSupported,
+     )]
+     pub token_program: Interface<'info, TokenInterface>,
+     ```
+  2. **If Token-2022 must be supported:** explicitly inspect mint extensions, reject `TransferHook`, `TransferFeeConfig`, `ConfidentialTransferMint`, `PermanentDelegate`, `MintCloseAuthority`. Reorder all fund-flow handlers to mutate state BEFORE CPI (CEI pattern). Add a reentrancy guard on the program PDA.
+
+  Option 1 is the right call for the v1 launch. Token-2022 is a much larger surface than the Phase 1.6/1.7 work just consolidated.
+
+---
+
+### FINDING-7 — VECTOR HOLDS
+
+PROPERTY-7 holds. `require_fee_vault_balance` correctly uses checked `withdrawn + requested <= accrued` (no underflow), and `transfer_lamports_from_fee_vault` preserves rent-exempt minimum AFTER the transfer. SOL vaults cannot be drained below rent-exemption.
+
+---
+
+### FINDING-8 — `delegate_recipient` can change between approval and settlement
+
+- **Severity:** P2 (member-controlled action; "self-harm" or social-engineering vector)
+- **Status:** PARTIAL
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:1512-1524`](../../programs/omegax_protocol/src/lib.rs#L1512) — `authorize_claim_recipient` handler (no status gate)
+  - [`programs/omegax_protocol/src/lib.rs:3698-3721`](../../programs/omegax_protocol/src/lib.rs#L3698) — `AuthorizeClaimRecipient` accounts (member-only ✅)
+- **Pre-conditions:** Member's keypair signs `authorize_claim_recipient` after the claim is adjudicated/approved but before `settle_claim_case` runs.
+- **Concrete evidence:** The handler body is:
+  ```rust
+  let claim_case = &mut ctx.accounts.claim_case;
+  claim_case.delegate_recipient = args.delegate_recipient;
+  claim_case.updated_at = Clock::get()?.unix_timestamp;
+  Ok(())
+  ```
+  No `require!(claim_case.intake_status < CLAIM_INTAKE_APPROVED ...)` gate. No paid-amount check. Member can mutate the recipient arbitrarily late in the lifecycle.
+- **Impact:** Approval/audit was performed assuming member's wallet was the recipient; member can redirect to a third-party wallet right before settlement. May violate KYC/AML or reviewer-trust assumptions. Not a fund-loss vector for OmegaX (member-authorized) but breaks the audit chain.
+- **Recommended fix:**
+  ```rust
+  pub fn authorize_claim_recipient(...) -> Result<()> {
+      require_protocol_not_paused(...)?;
+      let claim_case = &ctx.accounts.claim_case;
+      require!(
+          claim_case.intake_status < CLAIM_INTAKE_APPROVED,
+          OmegaXProtocolError::ClaimRecipientLocked
+      );
+      require!(
+          claim_case.paid_amount == 0,
+          OmegaXProtocolError::ClaimRecipientLocked
+      );
+      // ... mutate ...
+  }
+  ```
+  Or snapshot `settlement_recipient` onto the claim_case at adjudication time so settlement uses the snapshotted value, ignoring later `delegate_recipient` changes.
+
+---
+
+### FINDING-9 — `deposit_into_capital_class` shares math is wrong (NAV first-mover via dust deposit)
+
+- **Severity: P0 — direct fund loss to existing LPs**
+- **Status:** DOES_NOT_HOLD
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:1947-2052`](../../programs/omegax_protocol/src/lib.rs#L1947) — `deposit_into_capital_class` handler
+  - [`programs/omegax_protocol/src/lib.rs:1995-2001`](../../programs/omegax_protocol/src/lib.rs#L1995) — the broken shares calculation
+  - [`programs/omegax_protocol/src/lib.rs:2008-2015`](../../programs/omegax_protocol/src/lib.rs#L2008) — `nav_assets` and `total_shares` updated naively
+- **Pre-conditions:** A capital class with `restriction_mode == OPEN`, `min_lockup_seconds == 0` (or already elapsed), and an existing NAV ratio ≠ 1:1 (i.e., the pool has accumulated returns OR taken impairments OR has accrued fees that affect nav_assets).
+- **The bug:** Lines 1995–2001 read:
+  ```rust
+  let shares = if args.shares == 0 {
+      net_amount  // ← uses 1:1 ratio with deposit, ignoring existing nav_assets / total_shares
+  } else {
+      args.shares  // ← honors caller-supplied shares verbatim, no validation
+  };
+  ```
+  Both branches are wrong:
+  - **Default branch (args.shares == 0):** mints `net_amount` shares regardless of whether existing share price is 0.5x, 2x, or 10x of 1:1. This is the textbook NAV first-mover attack.
+  - **Caller-supplied branch (args.shares != 0):** honors any number the caller passes. Caller can set `args.shares = 1` for a `args.amount = 1_000_000` deposit (severely undermint and donate to LPs) OR `args.shares = 1_000_000_000` for a `args.amount = 1` deposit (severely overmint and steal from LPs).
+- **Exploit (concrete steps):**
+  1. Pool has existing `nav_assets = 10_000`, `total_shares = 1_000` (share price = 10).
+  2. Attacker (any signer if class is OPEN) calls `deposit_into_capital_class` with `args.amount = 1`, `args.shares = 0`.
+  3. Handler computes `net_amount = 1`, `shares = 1` (default branch). Mints attacker 1 share.
+  4. Pool state: `nav_assets = 10_001`, `total_shares = 1_001`. New share price = 9.99.
+  5. Attacker calls `request_redemption` (or waits for lockup if any), then `process_redemption_queue` is called by curator/governance.
+  6. Attacker's 1 share redeems at NAV: `(1 / 1_001) × 10_001 ≈ 9.99` units.
+  7. **Profit: ~8.99 units stolen from existing LPs per dust deposit.** Repeat at scale.
+  
+  The `args.shares != 0` branch is even worse — attacker passes `args.shares = u64::MAX / 2` for `args.amount = 1`, mints astronomical shares, then redeems for the entire pool minus 1 unit on the next available redemption.
+- **Why the prior pen-test missed this:** PT-08 was scoped to "NAV first-mover via impairment timing," and impairment was confirmed not to mutate `nav_assets`. But the bug isn't impairment-related — it's in the **deposit** math itself, which uses a 1:1 ratio whenever the caller doesn't supply shares (and trusts the caller when they do). Any source of NAV ≠ shares (accumulated returns, fee carve-outs that subtract from `nav_assets` differently than `total_shares`) creates the attack window.
+- **Recommended fix:** Replace lines 1995–2001 with the correct AMM-style mint formula:
+  ```rust
+  // Phase 1.6 fee carve-out: net_amount is post-entry-fee
+  let class = &ctx.accounts.capital_class;
+  let shares = if class.total_shares == 0 || class.nav_assets == 0 {
+      // Bootstrap: first deposit sets the 1:1 baseline
+      net_amount
+  } else {
+      // Subsequent deposits: mint pro-rata at current NAV
+      // shares = (net_amount * total_shares) / nav_assets
+      u64::try_from(
+          (net_amount as u128)
+              .checked_mul(class.total_shares as u128)
+              .ok_or(OmegaXProtocolError::ArithmeticOverflow)?
+              .checked_div(class.nav_assets as u128)
+              .ok_or(OmegaXProtocolError::ArithmeticOverflow)?
+      ).map_err(|_| OmegaXProtocolError::ArithmeticOverflow)?
+  };
+  // Stop honoring caller-supplied args.shares for OPEN classes.
+  // Allow it ONLY for restricted/wrapper classes where the caller is a credentialed subscription manager.
+  ```
+  Additionally — **add a settlement-delay or epoch-snapshot** so that even with correct math, a deposit cannot atomically deposit→redeem in the same epoch (defends against any future rounding-error variant).
+
+---
+
+### FINDING-10 — Single-step `rotate_protocol_governance_authority` (bricking risk)
+
+- **Severity:** P2 (operational; not exploitable without governance signature)
+- **Status:** DOES_NOT_HOLD
+- **Files:**
+  - [`programs/omegax_protocol/src/lib.rs:193-209`](../../programs/omegax_protocol/src/lib.rs#L193) — handler
+  - [`programs/omegax_protocol/src/lib.rs:6010-6022`](../../programs/omegax_protocol/src/lib.rs#L6010) — state mutation
+- **Pre-conditions:** Current governance signs a rotation transaction.
+- **Concrete evidence:** Rotation immediately writes `governance.governance_authority = new_governance_authority`. Only zero-pubkey is rejected. There is no pending authority field, no separate accept step, no timeout / cancel path, and no recovery mechanism in the account state.
+- **Impact:** A single bad rotation (typo, dead key, misconfigured multisig, lost device) permanently bricks every governance-gated operation: protocol pause, fee withdrawals, authority changes, schema updates. The protocol becomes inoperable; only a redeploy with state migration (impossible for a live program with funds custody) recovers it.
+- **Recommended fix:** Two-step rotation:
+  ```rust
+  // Step 1: current authority proposes
+  pub fn propose_governance_authority(ctx, new_authority: Pubkey) -> Result<()> {
+      require_governance(...);
+      let g = &mut ctx.accounts.protocol_governance;
+      g.pending_governance_authority = new_authority;
+      g.pending_proposed_at = Clock::get()?.unix_timestamp;
+      Ok(())
+  }
+  // Step 2: new authority accepts (must sign)
+  pub fn accept_governance_authority(ctx) -> Result<()> {
+      let g = &mut ctx.accounts.protocol_governance;
+      require_keys_eq!(ctx.accounts.new_authority.key(), g.pending_governance_authority, ...);
+      // Optional: enforce minimum delay between propose and accept
+      g.governance_authority = g.pending_governance_authority;
+      g.pending_governance_authority = Pubkey::default();
+      Ok(())
+  }
+  // Step 3: current authority can cancel before accept
+  pub fn cancel_governance_authority_proposal(ctx) -> Result<()> { ... }
+  ```
+
+---
+
+## Recommended fix order (priority-ranked)
+
+1. **FINDING-9 (P0):** Fix `deposit_into_capital_class` shares math. This is the single largest exploitable bug. Add a Rust unit test that asserts `shares = (net_amount * total_shares) / nav_assets` for all `(nav_assets, total_shares)` ≠ `(0, 0)`, AND a localnet e2e that runs the dust-deposit attack and confirms it now fails (or yields zero profit).
+2. **FINDING-6 (P1, CRITICAL for asset choice):** Lock to classic SPL Token for v1 launch. Add the mint-owner constraint; defer Token-2022 support to a separately-audited Phase 2.
+3. **FINDING-3 (P1):** Bind `pool_oracle_fee_vault` to `claim_case.adjudicator` via both `require_keys_eq!` and Anchor seeds.
+4. **FINDING-2 (P1):** Add recipient-owner constraint on all 3 SPL withdraw rails (pin to a configured fee-recipient field on each vault state).
+5. **FINDING-1 (P1):** Tighten Anchor seeds on every optional fee-vault account (defense-in-depth).
+6. **FINDING-8 (P2):** Add status gate to `authorize_claim_recipient`.
+7. **FINDING-10 (P2):** Two-step governance rotation.
+8. **FINDING-5 (P2):** FIFO + delay invariant on `process_redemption_queue`; configured treasury recipient on `withdraw_pool_treasury_*`.
+
+Findings 4 and 7 are clean — no action required.
+
+---
+
+## Verbatim Codex output
+
+The complete, unedited Codex JSONL stream lives in this conversation's task output. Below is the parsed `agent_message` block (the report Codex produced) preserved verbatim, line-for-line, for audit:
+
+```
+### PROPERTY-1: Fee-vault account binding integrity
+- **Status:** DOES_NOT_HOLD
+- **Severity (if not HOLDS):** P1 (fee leakage / mis-routing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:3514-3515, 3813-3827, 3961-3962, 4009-4010
+- **Pre-conditions:** A caller supplies optional fee-vault accounts during premium/deposit/settlement/redemption flows.
+- **Concrete evidence:** The optional `protocol_fee_vault`, `pool_treasury_vault`, `pool_oracle_fee_vault`, and `pool_oracle_policy` fields are only `#[account(mut)]` / plain optional accounts in the `#[derive(Accounts)]` structs. Runtime checks exist at lines 976-986, 1651-1687, 1978-1988, and 2147-2158, but the account resolver does not enforce canonical PDA seeds for these optional vaults.
+- **Impact:** Wrong-domain/mint is mostly rejected in handlers, but canonical account binding is not enforced at account-resolution time. Oracle-fee routing is especially exposed because the supplied oracle fee vault is not bound to the adjudicator.
+- **Recommended fix:** Add seeds/constraints directly on optional accounts, e.g. `seeds = [SEED_PROTOCOL_FEE_VAULT, health_plan.reserve_domain.as_ref(), funding_line.asset_mint.as_ref()]`; `seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), liquidity_pool.deposit_asset_mint.as_ref()]`; and for oracle fees bind `SEED_POOL_ORACLE_FEE_VAULT` to the expected oracle plus mint.
+
+### PROPERTY-2: Withdraw-rail account isolation
+- **Status:** PARTIAL
+- **Severity (if not HOLDS):** P1 (fee leakage / mis-routing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:4073-4075, 4131-4133, 4198-4200, 2277-2284, 2356-2363, 2435-2442
+- **Pre-conditions:** Governance, pool curator, oracle wallet/admin, or a compromised privileged signer calls a withdraw instruction.
+- **Concrete evidence:** SPL withdraw recipient token accounts are mutable `InterfaceAccount<TokenAccount>` with no owner constraint. `transfer_from_domain_vault` checks mint and self-transfer only at lines 6899-6923. Balance safety holds via `require_fee_vault_balance` using checked `withdrawn + requested <= accrued` at lines 6833-6840. Cross-rail confusion is mostly blocked by distinct account types, PDA seeds, and SOL/SPL rail constraints at lines 4050-4056, 4108-4114, 4174-4181.
+- **Impact:** A privileged or mistaken caller can send accrued fees to any token account of the correct mint.
+- **Recommended fix:** Add recipient-owner constraints, e.g. `constraint = recipient_token_account.owner == authority.key() @ OmegaXProtocolError::Unauthorized`, or add configured fee recipient fields per vault and require `recipient_token_account.owner == vault.configured_recipient`.
+
+### PROPERTY-3: Oracle fee accrual binding
+- **Status:** DOES_NOT_HOLD
+- **Severity (if not HOLDS):** P1 (fee leakage / mis-routing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:1672-1687, 3815-3827, 5022-5031
+- **Pre-conditions:** Claim settlement supplies both `pool_oracle_fee_vault` and `pool_oracle_policy`.
+- **Concrete evidence:** Settlement checks only `vault.asset_mint == funding_line.asset_mint` and `vault.liquidity_pool == policy.liquidity_pool`. `PoolOraclePolicy` stores only `liquidity_pool` and fee settings, not oracle or asset. There is no `vault.oracle == claim_case.adjudicator` check.
+- **Impact:** A valid fee vault for another oracle on the same pool/asset can receive the adjudicator fee.
+- **Recommended fix:** Add `require_keys_eq!(vault.oracle, ctx.accounts.claim_case.adjudicator, OmegaXProtocolError::OracleProfileMismatch);` and constrain the optional account with seeds including that expected oracle.
+
+### PROPERTY-4: PDA seed canonicality + init re-init protection
+PROPERTY-4: HOLDS — defense is governance-only handlers plus canonical `init` PDA seeds for protocol, pool treasury, and pool oracle fee vaults at programs/omegax_protocol/src/lib.rs:344-366, 384-410, 429-462, 3206-3213, 3237-3244, 3283-3290.
+
+### PROPERTY-5: Curator authority scope
+- **Status:** PARTIAL
+- **Severity (if not HOLDS):** P2 (DoS / griefing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:2122-2126, 2223-2226, 2345-2349, 6579-6588
+- **Pre-conditions:** Pool curator or governance signs redemption processing or pool-treasury withdrawal.
+- **Concrete evidence:** Redemption recipient is pinned to `lp_position.owner` at lines 2223-2226, so curator cannot redirect LP payouts. However `require_curator_control` is only curator-or-governance, and there is no processing timelock, multisig, FIFO queue invariant, or destination owner constraint for treasury withdrawals.
+- **Impact:** LP payout routing is protected, but curator discretion over redemption timing/order and pool-treasury withdrawals remains broad.
+- **Recommended fix:** Add queue ordering/timelock or multisig policy for `process_redemption_queue`, and constrain pool-treasury recipient ownership or configured treasury recipient.
+
+### PROPERTY-6: Token program / mint extension safety
+- **Status:** DOES_NOT_HOLD
+- **Severity (if not HOLDS):** P1 (fee leakage / mis-routing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:6, 3518-3521, 3837-3848, 3965-3968, 4023-4024, 6784-6788, 6941-6945
+- **Pre-conditions:** A Token-2022 mint or token account is used for an asset rail.
+- **Concrete evidence:** The program uses `anchor_spl::token_interface` with `InterfaceAccount<Mint>`, `InterfaceAccount<TokenAccount>`, and `Interface<TokenInterface>`, so both SPL Token and Token-2022 are accepted. There is no mint owner constraint excluding Token-2022 or extension inspection. Several flows perform CPI before final accounting, including deposits at 1957-1965 before state updates and fee withdrawals at 2277-2287 before `withdrawn_fees` is updated.
+- **Impact:** Token-2022 transfer fees/hooks can break exact accounting assumptions or create reentrancy-sensitive windows.
+- **Recommended fix:** For mainnet launch, either require classic SPL Token with `constraint = asset_mint.to_account_info().owner == &anchor_spl::token::ID` and `constraint = token_program.key() == anchor_spl::token::ID`, or explicitly inspect and forbid unsafe Token-2022 extensions and move all state updates before CPI with a reentrancy guard.
+
+### PROPERTY-7: SOL-rail lamport accounting
+PROPERTY-7: HOLDS — defense is checked `withdrawn + requested <= accrued` at programs/omegax_protocol/src/lib.rs:6833-6840 plus post-transfer rent preservation in `transfer_lamports_from_fee_vault` at lines 6861-6869.
+
+### PROPERTY-8: Settlement recipient routing under delegate_recipient
+- **Status:** PARTIAL
+- **Severity (if not HOLDS):** P2 (DoS / griefing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:1512-1522, 3698-3720, 6480-6488
+- **Pre-conditions:** Member signs `authorize_claim_recipient` after claim approval but before settlement.
+- **Concrete evidence:** Only the member can set the delegate because `member_position.wallet == authority.key()` and `claim_case.member_position == member_position.key()`. But the handler has no status gate, paid-amount gate, or approval-time recipient snapshot, so it can run between approval and settlement.
+- **Impact:** Payout recipient can change after approval, which may violate approval/review assumptions.
+- **Recommended fix:** Add `require!(claim_case.intake_status < CLAIM_INTAKE_APPROVED && claim_case.paid_amount == 0, OmegaXProtocolError::ClaimRecipientLocked);` or snapshot/freeze `settlement_recipient` during adjudication.
+
+### PROPERTY-9: Capital-class deposit access boundary
+- **Status:** DOES_NOT_HOLD
+- **Severity (if not HOLDS):** P0 (fund-loss path)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:1947-2015, 2083-2087, 2064-2067
+- **Pre-conditions:** Capital class is `OPEN`, `min_lockup_seconds == 0` or already elapsed, and redemption can be processed by curator/governance.
+- **Concrete evidence:** Deposits have no signer-role gate, open access is allowed at lines 2008-2011, and caller-supplied `args.shares` is honored verbatim at lines 1995-2000. Redemption value is later computed pro-rata from `capital_class.total_shares` and `nav_assets` at lines 2083-2087. There is no NAV snapshot or deposit-to-redeem delay beyond optional lockup.
+- **Impact:** A dust depositor can mint mispriced shares, then redeem against existing NAV if the pool is open and lockup is zero/short.
+- **Recommended fix:** Ignore caller-supplied shares for open deposits and compute `shares = amount * total_shares / nav_assets` when supply exists; enforce nonzero settlement delay/snapshot epochs before redemption eligibility.
+
+### PROPERTY-10: Authority rotation
+- **Status:** DOES_NOT_HOLD
+- **Severity (if not HOLDS):** P2 (DoS / griefing)
+- **File:line(s):** programs/omegax_protocol/src/lib.rs:217-229, 3097-3100, 6010-6022
+- **Pre-conditions:** Current governance signs rotation to a typo, dead key, or inaccessible key.
+- **Concrete evidence:** Rotation immediately writes `governance.governance_authority = new_governance_authority`; only zero pubkey is rejected. There is no pending authority, accept step, timeout, cancel, or recovery path in the account.
+- **Impact:** A bad rotation can brick governance-controlled protocol operations.
+- **Recommended fix:** Replace direct rotation with two-step `pending_governance_authority` + `accept_protocol_governance_authority`; allow current authority to cancel before acceptance and consider a time-limited emergency recovery policy.
+
+- **VERDICT:** MUST-FIX-BEFORE-MAINNET
+- **TOTALS:** P0=1 P1=4 P2=3 P3=0
+```
+
+---
+
+## How this report was generated
+
+```bash
+# v0.125.0 codex CLI; defensive-audit framing (offensive framing was filtered by OpenAI safety)
+codex exec - \
+  -C /Users/dr_sabijan/Documents/GitHub/omegax-protocol \
+  -s read-only \
+  -c 'model_reasoning_effort="high"' \
+  --json \
+  < /tmp/codex-prompt.txt
+```
+
+Prompt source: this conversation's `gstack-codex` skill invocation, reframed as a defensive pre-mainnet audit of 10 named safety properties. Each finding includes file:line evidence and a concrete remediation sketch.
+
+**Tokens:** 1,038,311. **Wall clock:** ~4 min. **Exit:** 0.
+
+## Cross-reference
+
+- Prior pen-test (PT-01..PT-13): [`pre-mainnet-pen-test-2026-04-27.md`](pre-mainnet-pen-test-2026-04-27.md)
+- Privileged-role custody matrix: [`mainnet-privileged-role-controls.md`](mainnet-privileged-role-controls.md)
+- Phase 1.6 fee-rail accrual: PR #23 (merged commits `9cee4ef`, `6634f79`, `956d0f1`, `8bf2849`, `7171866`, `42dba41`)
+- Phase 1.7 fee-rail withdrawals + frontend: PR #23 (final) + commit `c026348`, `576819a`

--- a/docs/security/codex-challenge-2026-04-29.md
+++ b/docs/security/codex-challenge-2026-04-29.md
@@ -10,6 +10,16 @@
 
 ---
 
+## Remediation Update — 2026-04-29
+
+The pre-mainnet hardening patch following this report remediated the three confirmed fund-flow blockers:
+
+- **FINDING-9:** `deposit_into_capital_class` no longer honors caller-supplied shares. The existing `shares` wire field is now interpreted as `min_shares_out`; actual issued shares are derived from current `total_shares / nav_assets`, with 1:1 bootstrap only for an empty class.
+- **FINDING-6:** v1 custody rails now require the classic SPL Token program and reject Token-2022 mint/program ownership at vault creation and transfer helper boundaries.
+- **Fee-withdraw recipient risk:** protocol, pool-treasury, and pool-oracle fee vaults now store `fee_recipient`; SOL withdrawals must pay that address directly, and SPL withdrawals must pay a token account owned by that address.
+
+Validation for the remediation: `npm run anchor:idl`, `npm run protocol:contract`, `npm run rust:test`, `npm run test:node`, `npm run verify:public`, and `npm run test:e2e:localnet`.
+
 ## Verdict
 
 **Codex verdict:** `MUST-FIX-BEFORE-MAINNET`

--- a/frontend/components/pool-treasury-panel.tsx
+++ b/frontend/components/pool-treasury-panel.tsx
@@ -120,6 +120,25 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
     () => oracleFeeVaults.find((row) => row.address === selectedOracleFeeVaultAddress) ?? null,
     [oracleFeeVaults, selectedOracleFeeVaultAddress],
   );
+
+  useEffect(() => {
+    if (selectedReserve?.paymentMint === ZERO_PUBKEY) {
+      setTreasuryRecipient(selectedReserve.feeRecipient);
+    }
+  }, [selectedReserve?.address, selectedReserve?.feeRecipient, selectedReserve?.paymentMint]);
+
+  useEffect(() => {
+    if (selectedProtocolFeeVault?.paymentMint === ZERO_PUBKEY) {
+      setProtocolFeeRecipient(selectedProtocolFeeVault.feeRecipient);
+    }
+  }, [selectedProtocolFeeVault?.address, selectedProtocolFeeVault?.feeRecipient, selectedProtocolFeeVault?.paymentMint]);
+
+  useEffect(() => {
+    if (selectedOracleFeeVault?.paymentMint === ZERO_PUBKEY) {
+      setOracleFeeRecipient(selectedOracleFeeVault.feeRecipient);
+    }
+  }, [selectedOracleFeeVault?.address, selectedOracleFeeVault?.feeRecipient, selectedOracleFeeVault?.paymentMint]);
+
   const poolTreasuryGuard = useMemo(() => {
     if (!capabilities.canWithdrawPoolTreasury) {
       return "Pool treasury withdrawals require an active oracle signer with treasury-withdraw permissions on this pool.";
@@ -130,8 +149,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
     if (!selectedReserve) {
       return "Select a reserve before submitting a withdrawal.";
     }
+    if (selectedReserve.paymentMint === ZERO_PUBKEY && treasuryRecipient.trim() !== selectedReserve.feeRecipient) {
+      return "SOL withdrawals must use the configured pool treasury fee recipient.";
+    }
     return null;
-  }, [capabilities.canWithdrawPoolTreasury, publicKey, selectedReserve, sendTransaction]);
+  }, [capabilities.canWithdrawPoolTreasury, publicKey, selectedReserve, sendTransaction, treasuryRecipient]);
   const protocolFeeGuard = useMemo(() => {
     if (!capabilities.canWithdrawProtocolFees) {
       return "Protocol fee withdrawals require the governance authority or protocol admin wallet.";
@@ -142,8 +164,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
     if (!selectedProtocolFeeVault) {
       return "Select a protocol fee vault before submitting a withdrawal.";
     }
+    if (selectedProtocolFeeVault.paymentMint === ZERO_PUBKEY && protocolFeeRecipient.trim() !== selectedProtocolFeeVault.feeRecipient) {
+      return "SOL withdrawals must use the configured protocol fee recipient.";
+    }
     return null;
-  }, [capabilities.canWithdrawProtocolFees, publicKey, selectedProtocolFeeVault, sendTransaction]);
+  }, [capabilities.canWithdrawProtocolFees, protocolFeeRecipient, publicKey, selectedProtocolFeeVault, sendTransaction]);
   const oracleFeeGuard = useMemo(() => {
     if (!capabilities.canWithdrawOracleFees) {
       return "Oracle fee withdrawals require the matching active oracle signer with fee-withdraw permissions.";
@@ -154,8 +179,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
     if (!selectedOracleFeeVault) {
       return "Select an oracle fee vault before submitting a withdrawal.";
     }
+    if (selectedOracleFeeVault.paymentMint === ZERO_PUBKEY && oracleFeeRecipient.trim() !== selectedOracleFeeVault.feeRecipient) {
+      return "SOL withdrawals must use the configured oracle fee recipient.";
+    }
     return null;
-  }, [capabilities.canWithdrawOracleFees, publicKey, selectedOracleFeeVault, sendTransaction]);
+  }, [capabilities.canWithdrawOracleFees, oracleFeeRecipient, publicKey, selectedOracleFeeVault, sendTransaction]);
 
   async function onWithdrawPoolTreasury() {
     if (!publicKey || !sendTransaction || !selectedReserve) return;
@@ -362,6 +390,7 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
                 <div className="space-y-2 text-sm text-[var(--muted-foreground)]">
                   <p>Reserve account: <span className="break-all font-mono">{selectedReserve.address}</span></p>
                   <p>Payment mint: <span className="break-all font-mono">{selectedReserve.paymentMint === ZERO_PUBKEY ? "SOL" : selectedReserve.paymentMint}</span></p>
+                  <p>Fee recipient: <span className="break-all font-mono">{selectedReserve.feeRecipient}</span></p>
                 </div>
               </ProtocolDetailDisclosure>
             </article>
@@ -378,11 +407,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
                 {selectedReserve.paymentMint === ZERO_PUBKEY ? (
                   <label className="space-y-1">
                     <span className="metric-label">Recipient system account</span>
-                    <input className="field-input" value={treasuryRecipient} onChange={(event) => setTreasuryRecipient(event.target.value)} />
+                    <input className="field-input" value={treasuryRecipient} onChange={(event) => setTreasuryRecipient(event.target.value)} disabled />
                   </label>
                 ) : (
                   <label className="space-y-1">
-                    <span className="metric-label">Recipient token account</span>
+                    <span className="metric-label">Recipient token account owned by {shortAddress(selectedReserve.feeRecipient)}</span>
                     <input className="field-input" value={treasuryRecipientTokenAccount} onChange={(event) => setTreasuryRecipientTokenAccount(event.target.value)} />
                   </label>
                 )}
@@ -431,6 +460,7 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
                 <div className="space-y-2 text-sm text-[var(--muted-foreground)]">
                   <p>Vault account: <span className="break-all font-mono">{selectedProtocolFeeVault.address}</span></p>
                   <p>Payment mint: <span className="break-all font-mono">{selectedProtocolFeeVault.paymentMint === ZERO_PUBKEY ? "SOL" : selectedProtocolFeeVault.paymentMint}</span></p>
+                  <p>Fee recipient: <span className="break-all font-mono">{selectedProtocolFeeVault.feeRecipient}</span></p>
                 </div>
               </ProtocolDetailDisclosure>
             </article>
@@ -447,11 +477,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
                 {selectedProtocolFeeVault.paymentMint === ZERO_PUBKEY ? (
                   <label className="space-y-1">
                     <span className="metric-label">Recipient system account</span>
-                    <input className="field-input" value={protocolFeeRecipient} onChange={(event) => setProtocolFeeRecipient(event.target.value)} />
+                    <input className="field-input" value={protocolFeeRecipient} onChange={(event) => setProtocolFeeRecipient(event.target.value)} disabled />
                   </label>
                 ) : (
                   <label className="space-y-1">
-                    <span className="metric-label">Recipient token account</span>
+                    <span className="metric-label">Recipient token account owned by {shortAddress(selectedProtocolFeeVault.feeRecipient)}</span>
                     <input className="field-input" value={protocolFeeRecipientTokenAccount} onChange={(event) => setProtocolFeeRecipientTokenAccount(event.target.value)} />
                   </label>
                 )}
@@ -498,12 +528,14 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
               <ul className="operator-summary-list">
                 <li>Oracle: {shortAddress(selectedOracleFeeVault.oracle)}</li>
                 <li>Payment mint: {selectedOracleFeeVault.paymentMint === ZERO_PUBKEY ? "SOL" : shortAddress(selectedOracleFeeVault.paymentMint)}</li>
+                <li>Fee recipient: {shortAddress(selectedOracleFeeVault.feeRecipient)}</li>
               </ul>
               <ProtocolDetailDisclosure title="Vault addresses" summary="Full oracle fee vault details stay collapsed unless you are auditing the rail.">
                 <div className="space-y-2 text-sm text-[var(--muted-foreground)]">
                   <p>Vault account: <span className="break-all font-mono">{selectedOracleFeeVault.address}</span></p>
                   <p>Oracle: <span className="break-all font-mono">{selectedOracleFeeVault.oracle}</span></p>
                   <p>Pool: <span className="break-all font-mono">{selectedOracleFeeVault.pool}</span></p>
+                  <p>Fee recipient: <span className="break-all font-mono">{selectedOracleFeeVault.feeRecipient}</span></p>
                 </div>
               </ProtocolDetailDisclosure>
             </article>
@@ -520,11 +552,11 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
                 {selectedOracleFeeVault.paymentMint === ZERO_PUBKEY ? (
                   <label className="space-y-1">
                     <span className="metric-label">Recipient system account</span>
-                    <input className="field-input" value={oracleFeeRecipient} onChange={(event) => setOracleFeeRecipient(event.target.value)} />
+                    <input className="field-input" value={oracleFeeRecipient} onChange={(event) => setOracleFeeRecipient(event.target.value)} disabled />
                   </label>
                 ) : (
                   <label className="space-y-1">
-                    <span className="metric-label">Recipient token account</span>
+                    <span className="metric-label">Recipient token account owned by {shortAddress(selectedOracleFeeVault.feeRecipient)}</span>
                     <input className="field-input" value={oracleFeeRecipientTokenAccount} onChange={(event) => setOracleFeeRecipientTokenAccount(event.target.value)} />
                   </label>
                 )}

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -42,6 +42,14 @@ export const NATIVE_SOL_MINT = "So11111111111111111111111111111111111111112";
 export const NATIVE_SOL_MINT_KEY = new PublicKey(NATIVE_SOL_MINT);
 export const MAX_ID_SEED_BYTES = 32;
 
+export function classicTokenProgramId(tokenProgramId?: PublicKeyish | null): PublicKey {
+  const candidate = toPublicKey(tokenProgramId ?? TOKEN_PROGRAM_ID);
+  if (!candidate.equals(TOKEN_PROGRAM_ID)) {
+    throw new Error("OmegaX Protocol v1 supports only the classic SPL Token program.");
+  }
+  return candidate;
+}
+
 export const SEED_PROTOCOL_GOVERNANCE = "protocol_governance";
 export const SEED_RESERVE_DOMAIN = "reserve_domain";
 export const SEED_DOMAIN_ASSET_VAULT = "domain_asset_vault";
@@ -237,6 +245,7 @@ export type ProtocolFeeVaultSnapshot = {
   address: string;
   reserveDomain: string;
   assetMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   bump: number;
@@ -246,6 +255,7 @@ export type PoolTreasuryVaultSnapshot = {
   address: string;
   liquidityPool: string;
   assetMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   bump: number;
@@ -256,6 +266,7 @@ export type PoolOracleFeeVaultSnapshot = {
   liquidityPool: string;
   oracle: string;
   assetMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   bump: number;
@@ -705,6 +716,7 @@ export type ProtocolFeeVaultSummary = {
   reserveDomain: string;
   /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
   paymentMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   availableFees: bigint;
@@ -718,6 +730,7 @@ export type PoolTreasuryReserveSummary = {
   reserveDomain: string;
   /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
   paymentMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   availableFees: bigint;
@@ -745,6 +758,7 @@ export type PoolOracleFeeVaultSummary = {
   oracle: string;
   /** ZERO_PUBKEY for SOL rails, the real SPL mint otherwise. */
   paymentMint: string;
+  feeRecipient: string;
   accruedFees: bigint;
   withdrawnFees: bigint;
   availableFees: bigint;
@@ -2046,6 +2060,7 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           address,
           reserveDomain: asAddress(decodedField(decoded, "reserveDomain")),
           assetMint: asAddress(decodedField(decoded, "assetMint")),
+          feeRecipient: asAddress(decodedField(decoded, "feeRecipient")),
           accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
           withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
           bump: Number(decodedField(decoded, "bump") ?? 0),
@@ -2056,6 +2071,7 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           address,
           liquidityPool: asAddress(decodedField(decoded, "liquidityPool")),
           assetMint: asAddress(decodedField(decoded, "assetMint")),
+          feeRecipient: asAddress(decodedField(decoded, "feeRecipient")),
           accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
           withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
           bump: Number(decodedField(decoded, "bump") ?? 0),
@@ -2067,6 +2083,7 @@ export async function loadProtocolConsoleSnapshot(connection: Connection): Promi
           liquidityPool: asAddress(decodedField(decoded, "liquidityPool")),
           oracle: asAddress(decodedField(decoded, "oracle")),
           assetMint: asAddress(decodedField(decoded, "assetMint")),
+          feeRecipient: asAddress(decodedField(decoded, "feeRecipient")),
           accruedFees: bigintFromAnchorValue(decodedField(decoded, "accruedFees")),
           withdrawnFees: bigintFromAnchorValue(decodedField(decoded, "withdrawnFees")),
           bump: Number(decodedField(decoded, "bump") ?? 0),
@@ -2896,6 +2913,7 @@ export async function listProtocolFeeVaults(params: {
       address: vault.address,
       reserveDomain: vault.reserveDomain,
       paymentMint: paymentMintForUi(vault.assetMint),
+      feeRecipient: vault.feeRecipient,
       accruedFees: vault.accruedFees,
       withdrawnFees: vault.withdrawnFees,
       availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
@@ -2919,6 +2937,7 @@ export async function listPoolTreasuryReserves(params: {
       pool: vault.liquidityPool,
       reserveDomain: poolByAddress.get(vault.liquidityPool)?.reserveDomain ?? ZERO_PUBKEY,
       paymentMint: paymentMintForUi(vault.assetMint),
+      feeRecipient: vault.feeRecipient,
       accruedFees: vault.accruedFees,
       withdrawnFees: vault.withdrawnFees,
       availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
@@ -2952,6 +2971,7 @@ export async function listPoolOracleFeeVaults(params: {
       reserveDomain: poolByAddress.get(vault.liquidityPool)?.reserveDomain ?? ZERO_PUBKEY,
       oracle: vault.oracle,
       paymentMint: paymentMintForUi(vault.assetMint),
+      feeRecipient: vault.feeRecipient,
       accruedFees: vault.accruedFees,
       withdrawnFees: vault.withdrawnFees,
       availableFees: feeVaultAvailable(vault.accruedFees, vault.withdrawnFees),
@@ -3338,7 +3358,7 @@ export function buildCreateDomainAssetVaultTx(params: {
 }): Transaction {
   const authority = toPublicKey(params.authority);
   const assetMint = toPublicKey(params.assetMint);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -3435,7 +3455,7 @@ export function buildWithdrawProtocolFeeSplTx(params: {
   const authority = toPublicKey(params.governanceAuthority);
   const reserveDomain = toPublicKey(params.reserveDomainAddress);
   const assetMint = toPublicKey(params.paymentMint);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -3516,7 +3536,7 @@ export function buildWithdrawPoolTreasurySplTx(params: {
   const pool = toPublicKey(params.poolAddress);
   const reserveDomain = toPublicKey(params.reserveDomainAddress);
   const assetMint = toPublicKey(params.paymentMint);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -3601,7 +3621,7 @@ export function buildWithdrawPoolOracleFeeSplTx(params: {
   const pool = toPublicKey(params.poolAddress);
   const reserveDomain = toPublicKey(params.reserveDomainAddress);
   const assetMint = toPublicKey(params.paymentMint);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4067,7 +4087,7 @@ export function buildFundSponsorBudgetTx(params: {
   policySeriesAddress?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4132,7 +4152,7 @@ export function buildRecordPremiumPaymentTx(params: {
   protocolFeeVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4436,7 +4456,7 @@ function buildObligationFlowTx(params: {
           { pubkey: params.assetMint },
           { pubkey: params.vaultTokenAccountAddress, isWritable: true },
           { pubkey: params.recipientTokenAccountAddress, isWritable: true },
-          { pubkey: toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID) },
+          { pubkey: classicTokenProgramId(params.tokenProgramId) },
         ]
         : [
           optionalProtocolAccount(undefined),
@@ -4595,7 +4615,7 @@ export function buildSettleClaimCaseTx(params: {
   tokenProgramId?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   return buildProtocolTransactionFromInstruction({
     feePayer: authority,
     recentBlockhash: params.recentBlockhash,
@@ -4805,11 +4825,12 @@ export function buildDepositIntoCapitalClassTx(params: {
   tokenProgramId?: PublicKeyish | null;
   recentBlockhash: string;
   amount: bigint;
+  /** Backward-compatible wire field. On-chain this is min_shares_out; 0n means no minimum. */
   shares: bigint;
   poolTreasuryVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const owner = toPublicKey(params.owner);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   const lpPosition = deriveLpPositionPda({
     capitalClass: params.capitalClassAddress,
     owner,
@@ -4957,7 +4978,7 @@ export function buildProcessRedemptionQueueTx(params: {
   tokenProgramId?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
-  const tokenProgramId = toPublicKey(params.tokenProgramId ?? TOKEN_PROGRAM_ID);
+  const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
   const lpPosition = deriveLpPositionPda({
     capitalClass: params.capitalClassAddress,
     owner: params.lpOwnerAddress,

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -11590,261 +11590,291 @@
     },
     {
       "code": 6018,
+      "name": "Token2022NotSupported",
+      "msg": "Token-2022 custody rails are not supported by this protocol version"
+    },
+    {
+      "code": 6019,
+      "name": "FeeRecipientInvalid",
+      "msg": "Configured fee recipient is missing or invalid"
+    },
+    {
+      "code": 6020,
+      "name": "FeeRecipientMismatch",
+      "msg": "Fee withdrawal recipient does not match the configured fee recipient"
+    },
+    {
+      "code": 6021,
       "name": "FundingLineMismatch",
       "msg": "Funding line mismatch"
     },
     {
-      "code": 6019,
+      "code": 6022,
       "name": "FundingLineTypeMismatch",
       "msg": "Funding line type mismatch"
     },
     {
-      "code": 6020,
+      "code": 6023,
       "name": "InvalidObligationStateTransition",
       "msg": "Invalid obligation state transition"
     },
     {
-      "code": 6021,
+      "code": 6024,
       "name": "AmountExceedsOutstandingObligation",
       "msg": "Amount exceeds outstanding obligation"
     },
     {
-      "code": 6022,
+      "code": 6025,
       "name": "AmountExceedsReservedBalance",
       "msg": "Amount exceeds reserved balance"
     },
     {
-      "code": 6023,
+      "code": 6026,
       "name": "AmountExceedsApprovedClaim",
       "msg": "Amount exceeds approved claim"
     },
     {
-      "code": 6024,
+      "code": 6027,
       "name": "AmountMustBePositive",
       "msg": "Amount must be greater than zero"
     },
     {
-      "code": 6025,
+      "code": 6028,
       "name": "ClaimCaseLinkMismatch",
       "msg": "Claim case linkage mismatch"
     },
     {
-      "code": 6026,
+      "code": 6029,
       "name": "LinkedClaimMustSettleThroughObligation",
       "msg": "Linked claims must settle through the obligation path"
     },
     {
-      "code": 6027,
+      "code": 6030,
       "name": "AmountExceedsAvailableShares",
       "msg": "Amount exceeds available shares"
     },
     {
-      "code": 6028,
+      "code": 6031,
       "name": "AmountExceedsPendingRedemption",
       "msg": "Amount exceeds pending redemption"
     },
     {
-      "code": 6029,
+      "code": 6032,
       "name": "InvalidRedemptionAmount",
       "msg": "Redemption amount cannot be derived from the queued share state"
     },
     {
-      "code": 6030,
+      "code": 6033,
+      "name": "InvalidCapitalShareState",
+      "msg": "Deposit shares cannot be derived from the capital class NAV state"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidDepositShares",
+      "msg": "Deposit would mint zero shares"
+    },
+    {
+      "code": 6035,
+      "name": "MinimumSharesOutNotMet",
+      "msg": "Computed deposit shares are below the requested minimum"
+    },
+    {
+      "code": 6036,
       "name": "RestrictedCapitalClass",
       "msg": "Restricted capital class access failed"
     },
     {
-      "code": 6031,
+      "code": 6037,
       "name": "CapitalClassMismatch",
       "msg": "Capital class ledger mismatch"
     },
     {
-      "code": 6032,
+      "code": 6038,
       "name": "LPPositionHasActiveCapital",
       "msg": "LP position with active capital cannot be decredentialed"
     },
     {
-      "code": 6033,
+      "code": 6039,
       "name": "LockupActive",
       "msg": "Capital class lockup is still active"
     },
     {
-      "code": 6034,
+      "code": 6040,
       "name": "AllocationCapExceeded",
       "msg": "Allocation cap exceeded"
     },
     {
-      "code": 6035,
+      "code": 6041,
       "name": "AllocationPositionMismatch",
       "msg": "Allocation position mismatch"
     },
     {
-      "code": 6036,
+      "code": 6042,
       "name": "InsufficientFreeAllocationCapacity",
       "msg": "Insufficient free allocation capacity"
     },
     {
-      "code": 6037,
+      "code": 6043,
       "name": "ArithmeticError",
       "msg": "Arithmetic overflow or underflow"
     },
     {
-      "code": 6038,
+      "code": 6044,
       "name": "MembershipGateConfigurationInvalid",
       "msg": "Membership gate configuration is invalid"
     },
     {
-      "code": 6039,
+      "code": 6045,
       "name": "MembershipProofModeMismatch",
       "msg": "Membership proof mode does not match the configured plan posture"
     },
     {
-      "code": 6040,
+      "code": 6046,
       "name": "MembershipInviteAuthorityInvalid",
       "msg": "Invite authority is missing or invalid for this plan"
     },
     {
-      "code": 6041,
+      "code": 6047,
       "name": "MembershipInvitePermitExpired",
       "msg": "Invite permit is expired"
     },
     {
-      "code": 6042,
+      "code": 6048,
       "name": "MembershipTokenGateAccountMissing",
       "msg": "Token-gate proof account is missing"
     },
     {
-      "code": 6043,
+      "code": 6049,
       "name": "MembershipTokenGateOwnerMismatch",
       "msg": "Token-gate proof account owner does not match the enrolling wallet"
     },
     {
-      "code": 6044,
+      "code": 6050,
       "name": "MembershipTokenGateMintMismatch",
       "msg": "Token-gate proof account mint does not match the configured gate mint"
     },
     {
-      "code": 6045,
+      "code": 6051,
       "name": "MembershipTokenGateAmountTooLow",
       "msg": "Token-gate proof amount is below the configured minimum"
     },
     {
-      "code": 6046,
+      "code": 6052,
       "name": "MembershipAnchorSeatRequired",
       "msg": "Anchor-backed membership requires an anchor seat account"
     },
     {
-      "code": 6047,
+      "code": 6053,
       "name": "MembershipAnchorSeatAlreadyActive",
       "msg": "Anchor-backed membership seat is already active"
     },
     {
-      "code": 6048,
+      "code": 6054,
       "name": "MembershipAnchorSeatMismatch",
       "msg": "Anchor-backed membership seat does not match the provided anchor reference"
     },
     {
-      "code": 6049,
+      "code": 6055,
       "name": "MembershipAnchorReferenceMissing",
       "msg": "Anchor-backed membership requires a non-zero anchor reference"
     },
     {
-      "code": 6050,
+      "code": 6056,
       "name": "StringTooLong",
       "msg": "Bounded string field exceeds the canonical maximum"
     },
     {
-      "code": 6051,
+      "code": 6057,
       "name": "InvalidOracleQuorum",
       "msg": "Oracle quorum configuration is invalid"
     },
     {
-      "code": 6052,
+      "code": 6058,
       "name": "TooManyOracleSupportedSchemas",
       "msg": "Too many supported schema hashes were provided for one oracle profile"
     },
     {
-      "code": 6053,
+      "code": 6059,
       "name": "PoolOracleApprovalRequired",
       "msg": "Pool oracle approval is required before permissions can be granted"
     },
     {
-      "code": 6054,
+      "code": 6060,
       "name": "OracleProfileInactive",
       "msg": "Oracle profile is inactive"
     },
     {
-      "code": 6055,
+      "code": 6061,
       "name": "OracleProfileUnclaimed",
       "msg": "Oracle profile has not been claimed by its signing key"
     },
     {
-      "code": 6056,
+      "code": 6062,
       "name": "InvalidClaimAttestationDecision",
       "msg": "Claim attestation decision is not a recognized value"
     },
     {
-      "code": 6057,
+      "code": 6063,
       "name": "ClaimAttestationSchemaRequired",
       "msg": "Claim attestation must reference a registered schema key hash"
     },
     {
-      "code": 6058,
+      "code": 6064,
       "name": "ClaimAttestationSchemaUnsupported",
       "msg": "Oracle profile does not advertise support for the selected claim-attestation schema"
     },
     {
-      "code": 6059,
+      "code": 6065,
       "name": "TooManySchemaDependencies",
       "msg": "Too many schema dependency addresses were provided"
     },
     {
-      "code": 6060,
+      "code": 6066,
       "name": "DomainAssetVaultRequired",
       "msg": "Fee vault initialization requires the matching domain asset vault to exist"
     },
     {
-      "code": 6061,
+      "code": 6067,
       "name": "LiquidityPoolMismatch",
       "msg": "Liquidity pool reference does not match the supplied account"
     },
     {
-      "code": 6062,
+      "code": 6068,
       "name": "OracleProfileMismatch",
       "msg": "Oracle profile reference does not match the supplied account"
     },
     {
-      "code": 6063,
+      "code": 6069,
       "name": "FeeVaultMismatch",
       "msg": "Fee vault account does not match the expected scope"
     },
     {
-      "code": 6064,
+      "code": 6070,
       "name": "FeeVaultInsufficientBalance",
       "msg": "Fee vault has insufficient accrued balance for this withdrawal"
     },
     {
-      "code": 6065,
+      "code": 6071,
       "name": "FeeVaultRentExemptionBreach",
       "msg": "Fee vault withdrawal would breach the rent-exempt minimum balance"
     },
     {
-      "code": 6066,
+      "code": 6072,
       "name": "FeeVaultRailMismatch",
       "msg": "Fee vault rail and asset mint disagree (SOL vault used on SPL path or vice versa)"
     },
     {
-      "code": 6067,
+      "code": 6073,
       "name": "FeeVaultRequiredForConfiguredFee",
       "msg": "Configured class entry fee requires the matching pool treasury fee vault account"
     },
     {
-      "code": 6068,
+      "code": 6074,
       "name": "FeeVaultBpsMisconfigured",
       "msg": "Fee vault basis-points configuration is out of range"
     },
     {
-      "code": 6069,
+      "code": 6075,
       "name": "SettlementOutflowAccountsRequired",
       "msg": "Linked claim settlement requires the member, mint, vault token, recipient token, and token program accounts"
     }
@@ -13028,6 +13058,10 @@
           },
           {
             "name": "shares",
+            "docs": [
+              "Backward-compatible wire field. Interpreted as min_shares_out; zero",
+              "means accept the program-derived NAV share price with no minimum."
+            ],
             "type": "u64"
           }
         ]
@@ -13131,6 +13165,10 @@
             "type": "pubkey"
           },
           {
+            "name": "fee_recipient",
+            "type": "pubkey"
+          },
+          {
             "name": "rail",
             "docs": [
               "0 = ProtocolFeeVault, 1 = PoolTreasuryVault, 2 = PoolOracleFeeVault."
@@ -13156,6 +13194,10 @@
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "configured_recipient",
+            "type": "pubkey"
           },
           {
             "name": "recipient",
@@ -13516,6 +13558,13 @@
               "Asset mint of the rail (use `NATIVE_SOL_MINT` for SOL)."
             ],
             "type": "pubkey"
+          },
+          {
+            "name": "fee_recipient",
+            "docs": [
+              "Configured recipient owner for this oracle-fee rail."
+            ],
+            "type": "pubkey"
           }
         ]
       }
@@ -13532,6 +13581,13 @@
               "`NATIVE_SOL_MINT` for the SOL rail."
             ],
             "type": "pubkey"
+          },
+          {
+            "name": "fee_recipient",
+            "docs": [
+              "Configured recipient owner for this rail."
+            ],
+            "type": "pubkey"
           }
         ]
       }
@@ -13545,6 +13601,14 @@
             "name": "asset_mint",
             "docs": [
               "SPL mint for the fee rail. Pass `NATIVE_SOL_MINT` to bind a SOL-rail vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_recipient",
+            "docs": [
+              "Configured recipient owner for this rail. SOL withdraws must pay this",
+              "address directly; SPL withdraws must pay a token account owned by it."
             ],
             "type": "pubkey"
           }
@@ -14848,6 +14912,10 @@
             "type": "pubkey"
           },
           {
+            "name": "fee_recipient",
+            "type": "pubkey"
+          },
+          {
             "name": "accrued_fees",
             "type": "u64"
           },
@@ -15000,6 +15068,10 @@
             "type": "pubkey"
           },
           {
+            "name": "fee_recipient",
+            "type": "pubkey"
+          },
+          {
             "name": "accrued_fees",
             "type": "u64"
           },
@@ -15037,6 +15109,10 @@
           },
           {
             "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_recipient",
             "type": "pubkey"
           },
           {

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-4ed92002e062c6bdb16be6336aa56baf0d7ca263cb63bf47789d4df7e956badf
+13e4cf7c51320c9a67c17780c8841afefc6de5c2e018542e3918f2d49194d9cb
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -311,6 +311,7 @@ pub mod omegax_protocol {
             args.asset_mint != ZERO_PUBKEY,
             OmegaXProtocolError::VaultTokenAccountInvalid
         );
+        require_classic_spl_token(&ctx.accounts.asset_mint, &ctx.accounts.token_program)?;
 
         let vault = &mut ctx.accounts.domain_asset_vault;
         vault.reserve_domain = ctx.accounts.reserve_domain.key();
@@ -361,6 +362,7 @@ pub mod omegax_protocol {
         let vault = &mut ctx.accounts.protocol_fee_vault;
         vault.reserve_domain = ctx.accounts.reserve_domain.key();
         vault.asset_mint = args.asset_mint;
+        vault.fee_recipient = require_configured_fee_recipient(args.fee_recipient)?;
         vault.accrued_fees = 0;
         vault.withdrawn_fees = 0;
         vault.bump = ctx.bumps.protocol_fee_vault;
@@ -369,6 +371,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             scope: vault.reserve_domain,
             asset_mint: vault.asset_mint,
+            fee_recipient: vault.fee_recipient,
             rail: 0,
         });
 
@@ -405,6 +408,7 @@ pub mod omegax_protocol {
         let vault = &mut ctx.accounts.pool_treasury_vault;
         vault.liquidity_pool = ctx.accounts.liquidity_pool.key();
         vault.asset_mint = args.asset_mint;
+        vault.fee_recipient = require_configured_fee_recipient(args.fee_recipient)?;
         vault.accrued_fees = 0;
         vault.withdrawn_fees = 0;
         vault.bump = ctx.bumps.pool_treasury_vault;
@@ -413,6 +417,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             scope: vault.liquidity_pool,
             asset_mint: vault.asset_mint,
+            fee_recipient: vault.fee_recipient,
             rail: 1,
         });
 
@@ -463,6 +468,7 @@ pub mod omegax_protocol {
         vault.liquidity_pool = ctx.accounts.liquidity_pool.key();
         vault.oracle = args.oracle;
         vault.asset_mint = args.asset_mint;
+        vault.fee_recipient = require_configured_fee_recipient(args.fee_recipient)?;
         vault.accrued_fees = 0;
         vault.withdrawn_fees = 0;
         vault.bump = ctx.bumps.pool_oracle_fee_vault;
@@ -471,6 +477,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             scope: vault.liquidity_pool,
             asset_mint: vault.asset_mint,
+            fee_recipient: vault.fee_recipient,
             rail: 2,
         });
 
@@ -2027,13 +2034,12 @@ pub mod omegax_protocol {
         };
         let net_amount = checked_sub(amount, entry_fee)?;
 
-        // Default shares track the LP's net contribution (post-fee). Caller-supplied
-        // shares are honored verbatim — caller is responsible for accounting.
-        let shares = if args.shares == 0 {
-            net_amount
-        } else {
-            args.shares
-        };
+        let shares = deposit_shares_for_nav(
+            net_amount,
+            ctx.accounts.capital_class.total_shares,
+            ctx.accounts.capital_class.nav_assets,
+            args.shares,
+        )?;
         let owner = ctx.accounts.owner.key();
         let capital_class_key = ctx.accounts.capital_class.key();
         let restriction_mode = ctx.accounts.capital_class.restriction_mode;
@@ -2312,6 +2318,10 @@ pub mod omegax_protocol {
             ctx.accounts.protocol_fee_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_token_owner(
+            &ctx.accounts.recipient_token_account,
+            ctx.accounts.protocol_fee_vault.fee_recipient,
+        )?;
 
         transfer_from_domain_vault(
             args.amount,
@@ -2328,6 +2338,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient_token_account.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -2350,6 +2361,10 @@ pub mod omegax_protocol {
             ctx.accounts.protocol_fee_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_owner(
+            ctx.accounts.recipient.key(),
+            ctx.accounts.protocol_fee_vault.fee_recipient,
+        )?;
 
         let rent = Rent::get()?;
         let vault_ai = ctx.accounts.protocol_fee_vault.to_account_info();
@@ -2369,6 +2384,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -2391,6 +2407,10 @@ pub mod omegax_protocol {
             ctx.accounts.pool_treasury_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_token_owner(
+            &ctx.accounts.recipient_token_account,
+            ctx.accounts.pool_treasury_vault.fee_recipient,
+        )?;
 
         transfer_from_domain_vault(
             args.amount,
@@ -2407,6 +2427,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient_token_account.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -2429,6 +2450,10 @@ pub mod omegax_protocol {
             ctx.accounts.pool_treasury_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_owner(
+            ctx.accounts.recipient.key(),
+            ctx.accounts.pool_treasury_vault.fee_recipient,
+        )?;
 
         let rent = Rent::get()?;
         let vault_ai = ctx.accounts.pool_treasury_vault.to_account_info();
@@ -2448,6 +2473,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -2470,6 +2496,10 @@ pub mod omegax_protocol {
             ctx.accounts.pool_oracle_fee_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_token_owner(
+            &ctx.accounts.recipient_token_account,
+            ctx.accounts.pool_oracle_fee_vault.fee_recipient,
+        )?;
 
         transfer_from_domain_vault(
             args.amount,
@@ -2486,6 +2516,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient_token_account.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -2508,6 +2539,10 @@ pub mod omegax_protocol {
             ctx.accounts.pool_oracle_fee_vault.withdrawn_fees,
             args.amount,
         )?;
+        require_fee_recipient_owner(
+            ctx.accounts.recipient.key(),
+            ctx.accounts.pool_oracle_fee_vault.fee_recipient,
+        )?;
 
         let rent = Rent::get()?;
         let vault_ai = ctx.accounts.pool_oracle_fee_vault.to_account_info();
@@ -2527,6 +2562,7 @@ pub mod omegax_protocol {
             vault: vault.key(),
             asset_mint: vault.asset_mint,
             amount: args.amount,
+            configured_recipient: vault.fee_recipient,
             recipient: ctx.accounts.recipient.key(),
             withdrawn_total: new_withdrawn,
         });
@@ -3197,7 +3233,8 @@ pub struct CreateDomainAssetVault<'info> {
     // domain_asset_vault PDA via transfer_from_domain_vault (see lib.rs:5463
     // region). Operators no longer pre-create the token account externally.
     #[account(
-        constraint = asset_mint.key() == args.asset_mint @ OmegaXProtocolError::AssetMintMismatch
+        constraint = asset_mint.key() == args.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
+        constraint = asset_mint.to_account_info().owner == &anchor_spl::token::ID @ OmegaXProtocolError::Token2022NotSupported,
     )]
     pub asset_mint: InterfaceAccount<'info, Mint>,
     #[account(
@@ -3209,6 +3246,9 @@ pub struct CreateDomainAssetVault<'info> {
         token::authority = domain_asset_vault,
     )]
     pub vault_token_account: InterfaceAccount<'info, TokenAccount>,
+    #[account(
+        constraint = token_program.key() == anchor_spl::token::ID @ OmegaXProtocolError::Token2022NotSupported,
+    )]
     pub token_program: Interface<'info, TokenInterface>,
     pub system_program: Program<'info, System>,
 }
@@ -4625,6 +4665,7 @@ pub struct DomainAssetVault {
 pub struct ProtocolFeeVault {
     pub reserve_domain: Pubkey,
     pub asset_mint: Pubkey,
+    pub fee_recipient: Pubkey,
     pub accrued_fees: u64,
     pub withdrawn_fees: u64,
     pub bump: u8,
@@ -4635,6 +4676,7 @@ pub struct ProtocolFeeVault {
 pub struct PoolTreasuryVault {
     pub liquidity_pool: Pubkey,
     pub asset_mint: Pubkey,
+    pub fee_recipient: Pubkey,
     pub accrued_fees: u64,
     pub withdrawn_fees: u64,
     pub bump: u8,
@@ -4646,6 +4688,7 @@ pub struct PoolOracleFeeVault {
     pub liquidity_pool: Pubkey,
     pub oracle: Pubkey,
     pub asset_mint: Pubkey,
+    pub fee_recipient: Pubkey,
     pub accrued_fees: u64,
     pub withdrawn_fees: u64,
     pub bump: u8,
@@ -5169,6 +5212,9 @@ pub struct CreateDomainAssetVaultArgs {
 pub struct InitProtocolFeeVaultArgs {
     /// SPL mint for the fee rail. Pass `NATIVE_SOL_MINT` to bind a SOL-rail vault.
     pub asset_mint: Pubkey,
+    /// Configured recipient owner for this rail. SOL withdraws must pay this
+    /// address directly; SPL withdraws must pay a token account owned by it.
+    pub fee_recipient: Pubkey,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
@@ -5176,6 +5222,8 @@ pub struct InitPoolTreasuryVaultArgs {
     /// Asset mint must equal `liquidity_pool.deposit_asset_mint` for SPL pools, or
     /// `NATIVE_SOL_MINT` for the SOL rail.
     pub asset_mint: Pubkey,
+    /// Configured recipient owner for this rail.
+    pub fee_recipient: Pubkey,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
@@ -5185,6 +5233,8 @@ pub struct InitPoolOracleFeeVaultArgs {
     pub oracle: Pubkey,
     /// Asset mint of the rail (use `NATIVE_SOL_MINT` for SOL).
     pub asset_mint: Pubkey,
+    /// Configured recipient owner for this oracle-fee rail.
+    pub fee_recipient: Pubkey,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
@@ -5458,6 +5508,8 @@ pub struct UpdateLpPositionCredentialingArgs {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct DepositIntoCapitalClassArgs {
     pub amount: u64,
+    /// Backward-compatible wire field. Interpreted as min_shares_out; zero
+    /// means accept the program-derived NAV share price with no minimum.
     pub shares: u64,
 }
 
@@ -5745,6 +5797,7 @@ pub struct FeeVaultInitializedEvent {
     pub vault: Pubkey,
     pub scope: Pubkey,
     pub asset_mint: Pubkey,
+    pub fee_recipient: Pubkey,
     /// 0 = ProtocolFeeVault, 1 = PoolTreasuryVault, 2 = PoolOracleFeeVault.
     pub rail: u8,
 }
@@ -5762,6 +5815,7 @@ pub struct FeeWithdrawnEvent {
     pub vault: Pubkey,
     pub asset_mint: Pubkey,
     pub amount: u64,
+    pub configured_recipient: Pubkey,
     pub recipient: Pubkey,
     pub withdrawn_total: u64,
 }
@@ -5904,6 +5958,12 @@ pub enum OmegaXProtocolError {
     TokenAccountSelfTransferInvalid,
     #[msg("Vault token account does not match the domain asset vault")]
     VaultTokenAccountMismatch,
+    #[msg("Token-2022 custody rails are not supported by this protocol version")]
+    Token2022NotSupported,
+    #[msg("Configured fee recipient is missing or invalid")]
+    FeeRecipientInvalid,
+    #[msg("Fee withdrawal recipient does not match the configured fee recipient")]
+    FeeRecipientMismatch,
     #[msg("Funding line mismatch")]
     FundingLineMismatch,
     #[msg("Funding line type mismatch")]
@@ -5928,6 +5988,12 @@ pub enum OmegaXProtocolError {
     AmountExceedsPendingRedemption,
     #[msg("Redemption amount cannot be derived from the queued share state")]
     InvalidRedemptionAmount,
+    #[msg("Deposit shares cannot be derived from the capital class NAV state")]
+    InvalidCapitalShareState,
+    #[msg("Deposit would mint zero shares")]
+    InvalidDepositShares,
+    #[msg("Computed deposit shares are below the requested minimum")]
+    MinimumSharesOutNotMet,
     #[msg("Restricted capital class access failed")]
     RestrictedCapitalClass,
     #[msg("Capital class ledger mismatch")]
@@ -6738,6 +6804,38 @@ fn checked_u128_to_u64(value: u128) -> Result<u64> {
     u64::try_from(value).map_err(|_| OmegaXProtocolError::ArithmeticError.into())
 }
 
+fn deposit_shares_for_nav(
+    net_amount: u64,
+    total_shares: u64,
+    nav_assets: u64,
+    min_shares_out: u64,
+) -> Result<u64> {
+    require_positive_amount(net_amount)?;
+    let shares = if total_shares == 0 && nav_assets == 0 {
+        net_amount
+    } else {
+        require!(
+            total_shares > 0 && nav_assets > 0,
+            OmegaXProtocolError::InvalidCapitalShareState
+        );
+        let computed = (net_amount as u128)
+            .checked_mul(total_shares as u128)
+            .ok_or(OmegaXProtocolError::ArithmeticError)?
+            .checked_div(nav_assets as u128)
+            .ok_or(OmegaXProtocolError::ArithmeticError)?;
+        checked_u128_to_u64(computed)?
+    };
+
+    require!(shares > 0, OmegaXProtocolError::InvalidDepositShares);
+    if min_shares_out > 0 {
+        require!(
+            shares >= min_shares_out,
+            OmegaXProtocolError::MinimumSharesOutNotMet
+        );
+    }
+    Ok(shares)
+}
+
 fn prorata_amount(numerator: u64, denominator: u64, amount: u64) -> Result<u64> {
     require!(
         numerator > 0 && denominator > 0 && numerator <= denominator,
@@ -6773,6 +6871,27 @@ fn redemption_assets_to_process(
     }
 }
 
+fn require_classic_token_program_keys(mint_owner: Pubkey, token_program: Pubkey) -> Result<()> {
+    require_keys_eq!(
+        mint_owner,
+        anchor_spl::token::ID,
+        OmegaXProtocolError::Token2022NotSupported
+    );
+    require_keys_eq!(
+        token_program,
+        anchor_spl::token::ID,
+        OmegaXProtocolError::Token2022NotSupported
+    );
+    Ok(())
+}
+
+fn require_classic_spl_token<'info>(
+    asset_mint: &InterfaceAccount<'info, Mint>,
+    token_program: &Interface<'info, TokenInterface>,
+) -> Result<()> {
+    require_classic_token_program_keys(*asset_mint.to_account_info().owner, token_program.key())
+}
+
 fn transfer_to_domain_vault<'info>(
     amount: u64,
     authority: &Signer<'info>,
@@ -6782,6 +6901,7 @@ fn transfer_to_domain_vault<'info>(
     token_program: &Interface<'info, TokenInterface>,
     domain_asset_vault: &DomainAssetVault,
 ) -> Result<()> {
+    require_classic_spl_token(asset_mint, token_program)?;
     require_keys_eq!(
         source_token_account.owner,
         authority.key(),
@@ -6878,6 +6998,31 @@ fn require_fee_vault_balance(accrued: u64, withdrawn: u64, requested: u64) -> Re
     Ok(new_withdrawn)
 }
 
+fn require_configured_fee_recipient(fee_recipient: Pubkey) -> Result<Pubkey> {
+    require!(
+        fee_recipient != ZERO_PUBKEY,
+        OmegaXProtocolError::FeeRecipientInvalid
+    );
+    Ok(fee_recipient)
+}
+
+fn require_fee_recipient_owner(actual_owner: Pubkey, configured_recipient: Pubkey) -> Result<()> {
+    require_configured_fee_recipient(configured_recipient)?;
+    require_keys_eq!(
+        actual_owner,
+        configured_recipient,
+        OmegaXProtocolError::FeeRecipientMismatch
+    );
+    Ok(())
+}
+
+fn require_fee_recipient_token_owner<'info>(
+    recipient_token_account: &InterfaceAccount<'info, TokenAccount>,
+    configured_recipient: Pubkey,
+) -> Result<()> {
+    require_fee_recipient_owner(recipient_token_account.owner, configured_recipient)
+}
+
 // Phase 1.7 — SOL-rail withdrawal. Mutates the fee-vault PDA's lamports
 // directly (SystemProgram::transfer cannot move lamports out of program-owned
 // accounts). Rejects withdrawals that would breach the PDA's rent-exempt
@@ -6934,6 +7079,7 @@ fn transfer_from_domain_vault<'info>(
     asset_mint: &InterfaceAccount<'info, Mint>,
     token_program: &Interface<'info, TokenInterface>,
 ) -> Result<()> {
+    require_classic_spl_token(asset_mint, token_program)?;
     require_keys_eq!(
         vault_token_account.key(),
         domain_asset_vault.vault_token_account,
@@ -7813,6 +7959,29 @@ mod tests {
         assert_eq!(redeemable_assets_for_shares(3, 7, 700).unwrap(), 300);
         assert!(redeemable_assets_for_shares(1, 0, 100).is_err());
         assert!(redeemable_assets_for_shares(1, 100, 0).is_err());
+    }
+
+    #[test]
+    fn deposit_shares_bootstrap_one_to_one_only_from_empty_nav() {
+        assert_eq!(deposit_shares_for_nav(250, 0, 0, 0).unwrap(), 250);
+        assert!(deposit_shares_for_nav(250, 0, 1, 0).is_err());
+        assert!(deposit_shares_for_nav(250, 1, 0, 0).is_err());
+    }
+
+    #[test]
+    fn deposit_shares_are_priced_from_current_nav() {
+        assert_eq!(deposit_shares_for_nav(50, 1_000, 500, 0).unwrap(), 100);
+        assert_eq!(
+            deposit_shares_for_nav(1, 1_000_000, 1_000_000, 0).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn deposit_shares_reject_zero_out_and_minimum_miss() {
+        assert!(deposit_shares_for_nav(1, 1, 1_000_000, 0).is_err());
+        assert!(deposit_shares_for_nav(100, 1_000, 1_000, 101).is_err());
+        assert_eq!(deposit_shares_for_nav(100, 1_000, 1_000, 100).unwrap(), 100);
     }
 
     #[test]
@@ -9017,5 +9186,35 @@ mod tests {
     fn fee_vault_balance_rejects_overflow_on_withdrawn_sum() {
         // withdrawn near MAX, requesting any positive amount overflows.
         assert!(require_fee_vault_balance(u64::MAX, u64::MAX - 5, 10).is_err());
+    }
+
+    #[test]
+    fn configured_fee_recipient_must_be_nonzero_and_match() {
+        let recipient = Pubkey::new_unique();
+        let attacker = Pubkey::new_unique();
+
+        assert_eq!(
+            require_configured_fee_recipient(recipient).unwrap(),
+            recipient
+        );
+        assert!(require_configured_fee_recipient(ZERO_PUBKEY).is_err());
+        assert!(require_fee_recipient_owner(recipient, recipient).is_ok());
+        assert!(require_fee_recipient_owner(attacker, recipient).is_err());
+    }
+
+    #[test]
+    fn token_program_guard_rejects_non_classic_spl_token() {
+        assert!(
+            require_classic_token_program_keys(anchor_spl::token::ID, anchor_spl::token::ID)
+                .is_ok()
+        );
+        assert!(
+            require_classic_token_program_keys(Pubkey::new_unique(), anchor_spl::token::ID)
+                .is_err()
+        );
+        assert!(
+            require_classic_token_program_keys(anchor_spl::token::ID, Pubkey::new_unique())
+                .is_err()
+        );
     }
 }

--- a/tests/protocol_contract.test.ts
+++ b/tests/protocol_contract.test.ts
@@ -20,6 +20,9 @@ test("canonical contract exposes the health-capital-markets surface", () => {
     types: Array<{ name: string; type: { kind: string; fields?: Array<{ name: string }> } }>;
   };
   const depositArgs = idl.types.find((entry) => entry.name === "DepositIntoCapitalClassArgs");
+  const initProtocolFeeVaultArgs = idl.types.find((entry) => entry.name === "InitProtocolFeeVaultArgs");
+  const initPoolTreasuryVaultArgs = idl.types.find((entry) => entry.name === "InitPoolTreasuryVaultArgs");
+  const initPoolOracleFeeVaultArgs = idl.types.find((entry) => entry.name === "InitPoolOracleFeeVaultArgs");
   const requestRedemptionArgs = idl.types.find((entry) => entry.name === "RequestRedemptionArgs");
   const processRedemptionArgs = idl.types.find((entry) => entry.name === "ProcessRedemptionQueueArgs");
 
@@ -175,6 +178,18 @@ test("canonical contract exposes the health-capital-markets surface", () => {
   assert.deepEqual(
     depositArgs?.type.fields?.map((field) => field.name),
     ["amount", "shares"],
+  );
+  assert.deepEqual(
+    initProtocolFeeVaultArgs?.type.fields?.map((field) => field.name),
+    ["asset_mint", "fee_recipient"],
+  );
+  assert.deepEqual(
+    initPoolTreasuryVaultArgs?.type.fields?.map((field) => field.name),
+    ["asset_mint", "fee_recipient"],
+  );
+  assert.deepEqual(
+    initPoolOracleFeeVaultArgs?.type.fields?.map((field) => field.name),
+    ["oracle", "asset_mint", "fee_recipient"],
   );
   assert.deepEqual(
     requestRedemptionArgs?.type.fields?.map((field) => field.name),

--- a/tests/security/fee_recipient_guard_regression.test.ts
+++ b/tests/security/fee_recipient_guard_regression.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regression: fee withdrawals must be pinned to configured
+// recipients, not arbitrary accounts supplied by a privileged signer.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const programSource = readFileSync(
+  new URL("../../programs/omegax_protocol/src/lib.rs", import.meta.url),
+  "utf8",
+);
+
+function extractInstructionBody(name: string): string {
+  const startIdx = programSource.indexOf(`pub fn ${name}(`);
+  assert.notEqual(startIdx, -1, `instruction ${name} should exist`);
+
+  let i = programSource.indexOf("{", startIdx);
+  assert.notEqual(i, -1, `instruction ${name} should have a body`);
+
+  let depth = 1;
+  i += 1;
+  for (; i < programSource.length && depth > 0; i += 1) {
+    if (programSource[i] === "{") depth += 1;
+    else if (programSource[i] === "}") depth -= 1;
+  }
+  return programSource.slice(startIdx, i);
+}
+
+test("[CSO-2026-04-29] fee vault accounts store configured fee recipients", () => {
+  for (const accountName of ["ProtocolFeeVault", "PoolTreasuryVault", "PoolOracleFeeVault"]) {
+    const accountIdx = programSource.indexOf(`pub struct ${accountName}`);
+    assert.notEqual(accountIdx, -1, `${accountName} should exist`);
+    const accountBody = programSource.slice(accountIdx, programSource.indexOf("\n}\n", accountIdx));
+    assert.match(accountBody, /pub fee_recipient: Pubkey/);
+  }
+});
+
+test("[CSO-2026-04-29] SPL and SOL fee withdrawals validate configured recipients", () => {
+  for (const handler of [
+    "withdraw_protocol_fee_spl",
+    "withdraw_pool_treasury_spl",
+    "withdraw_pool_oracle_fee_spl",
+  ]) {
+    assert.match(
+      extractInstructionBody(handler),
+      /require_fee_recipient_token_owner\s*\(/,
+      `${handler} must validate recipient token account owner`,
+    );
+  }
+
+  for (const handler of [
+    "withdraw_protocol_fee_sol",
+    "withdraw_pool_treasury_sol",
+    "withdraw_pool_oracle_fee_sol",
+  ]) {
+    assert.match(
+      extractInstructionBody(handler),
+      /require_fee_recipient_owner\s*\(/,
+      `${handler} must validate SOL recipient address`,
+    );
+  }
+});

--- a/tests/security/token_program_guard_regression.test.ts
+++ b/tests/security/token_program_guard_regression.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// CSO-2026-04-29 regression: the public builders should not construct
+// Token-2022 custody transactions for the v1 protocol surface.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { SystemProgram } from "@solana/web3.js";
+
+import fixturesModule from "../../frontend/lib/devnet-fixtures.ts";
+import protocolModule from "../../frontend/lib/protocol.ts";
+
+const { DEVNET_PROTOCOL_FIXTURE_STATE } =
+  fixturesModule as typeof import("../../frontend/lib/devnet-fixtures.ts");
+
+const {
+  buildCreateDomainAssetVaultTx,
+  buildDepositIntoCapitalClassTx,
+  buildWithdrawProtocolFeeSplTx,
+} = protocolModule as typeof import("../../frontend/lib/protocol.ts");
+
+const recentBlockhash = "11111111111111111111111111111111";
+const wallet = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address;
+const recipient = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[1]!.address;
+const reserveDomain = DEVNET_PROTOCOL_FIXTURE_STATE.reserveDomains[0]!.address;
+const pool = DEVNET_PROTOCOL_FIXTURE_STATE.liquidityPools[0]!;
+const capitalClass = DEVNET_PROTOCOL_FIXTURE_STATE.capitalClasses.find((row) => row.liquidityPool === pool.address)
+  ?? DEVNET_PROTOCOL_FIXTURE_STATE.capitalClasses[0]!;
+
+test("[CSO-2026-04-29] custody builders reject non-classic token program ids", () => {
+  assert.throws(
+    () => buildCreateDomainAssetVaultTx({
+      authority: wallet,
+      reserveDomainAddress: reserveDomain,
+      assetMint: pool.depositAssetMint,
+      recentBlockhash,
+      tokenProgramId: SystemProgram.programId,
+    }),
+    /classic SPL Token program/,
+  );
+
+  assert.throws(
+    () => buildDepositIntoCapitalClassTx({
+      owner: wallet,
+      reserveDomainAddress: pool.reserveDomain,
+      poolAddress: pool.address,
+      poolDepositAssetMint: pool.depositAssetMint,
+      capitalClassAddress: capitalClass.address,
+      sourceTokenAccountAddress: wallet,
+      vaultTokenAccountAddress: recipient,
+      recentBlockhash,
+      amount: 1n,
+      shares: 0n,
+      tokenProgramId: SystemProgram.programId,
+    }),
+    /classic SPL Token program/,
+  );
+
+  assert.throws(
+    () => buildWithdrawProtocolFeeSplTx({
+      governanceAuthority: wallet,
+      reserveDomainAddress: reserveDomain,
+      paymentMint: pool.depositAssetMint,
+      recipientTokenAccount: recipient,
+      amount: 1n,
+      recentBlockhash,
+      tokenProgramId: SystemProgram.programId,
+    }),
+    /classic SPL Token program/,
+  );
+});


### PR DESCRIPTION
## Summary

Hardens the pre-mainnet protocol fund-flow surface across the three confirmed CSO findings:

- Computes capital-class deposit shares on-chain from NAV and treats the legacy `shares` arg as `min_shares_out`.
- Locks v1 custody rails to classic SPL Token and rejects Token-2022/non-classic token program overrides.
- Binds protocol, pool treasury, and oracle fee withdrawals to configured fee recipients.

## Details

- Adds on-chain guards for invalid capital share states, zero-share outcomes, and minimum share slippage failures.
- Adds classic SPL Token ownership/program checks at vault creation and domain-vault transfer helpers.
- Adds `fee_recipient` to fee vault account layouts and init args, then validates SPL and SOL withdrawal recipients against that configured key.
- Updates frontend builders and the pool treasury panel so unsupported token programs and wrong SOL recipients fail before transaction construction.
- Adds regression tests for fee-recipient binding and classic-token constraints.
- Regenerates IDL/contract artifacts and documents the remediation.

## Validation

Passed locally before this PR:

- `npm run anchor:idl`
- `npm run protocol:contract`
- `npm run rust:test`
- `npm run test:node`
- `npm run verify:public`
- `npm run test:e2e:localnet`
- `git diff --check`