### PR TITLE
[codex] Harden protocol review fee vault flows

### DIFF
--- a/.github/workflows/localnet-e2e.yml
+++ b/.github/workflows/localnet-e2e.yml
@@ -41,6 +41,8 @@ jobs:
     timeout-minutes: 45
     env:
       ANCHOR_VERSION: 0.32.1
+      SOLANA_CLI_VERSION: v3.1.14
+      SOLANA_CLI_INSTALL_SHA256: f2d4860409b14a7aacc6454431d3b5366f2795df696466fe5a7177b0adf5f761
       OMEGAX_E2E_KEEP_ARTIFACTS: '1'
     steps:
       - name: Checkout
@@ -88,13 +90,13 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~/.local/share/solana
-          key: solana-stable-${{ runner.os }}-v1
+          key: solana-${{ env.SOLANA_CLI_VERSION }}-${{ runner.os }}-v1
 
       - name: Install Solana CLI
         if: steps.solana-cache.outputs.cache-hit != 'true'
         run: |
-          curl -sSfL https://release.anza.xyz/stable/install -o /tmp/solana-install.sh
-          echo '4c69258d317fdd3cf65193053ea2c2f8c29f24a08161afb787b192262c72d070  /tmp/solana-install.sh' | sha256sum -c -
+          curl -sSfL "https://release.anza.xyz/${SOLANA_CLI_VERSION}/install" -o /tmp/solana-install.sh
+          echo "${SOLANA_CLI_INSTALL_SHA256}  /tmp/solana-install.sh" | sha256sum -c -
           sh /tmp/solana-install.sh
 
       - name: Add Solana CLI to PATH

--- a/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
+++ b/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
+// contract_sha256: e05a4f9f75cfab96df03f0e88974e1d7115d64c151b04d88bfab8101f4cc6ef0
 
 package com.omegax.protocol
 

--- a/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
+++ b/android-native/protocol/src/main/java/com/omegax/protocol/ProtocolContract.kt
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
+// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
 
 package com.omegax.protocol
 

--- a/docs/architecture/genesis-protect-claim-trace.md
+++ b/docs/architecture/genesis-protect-claim-trace.md
@@ -50,7 +50,7 @@ The default recipient is the member's own wallet. This step lets the member rout
 
 | Signer | Authority check | What changes |
 |--------|------------------|----|
-| Claims operator | `require_claim_operator` | New `ClaimEvidenceRef` PDA; `evidence_hash` and `evidence_ref_hash` recorded; raw evidence stays offchain |
+| Claims operator | `require_claim_operator` | `claim_case.evidence_ref_hash` and `claim_case.decision_support_hash` are updated in place; raw evidence stays offchain |
 
 **Member-visible**: the claim shows `evidence attached` with a reference URI (which resolves to OmegaX Health's evidence portal, NOT to a public link — raw medical content is never on-chain or in public docs).
 
@@ -70,7 +70,7 @@ The default recipient is the member's own wallet. This step lets the member rout
 
 | Signer | Authority check | What changes |
 |--------|------------------|----|
-| Claims operator | `require_claim_operator` | `claim_case.state` transitions `proposed` → `claimable` (or `denied` for unhappy path); decision metadata persisted |
+| Claims operator | `require_claim_operator` | `claim_case.intake_status` moves to `approved` or `denied`; adjudicator, approved/denied amounts, and decision metadata are persisted |
 
 **Member-visible**: claim shows `approved at tier 2 (overnight admission), USD 1,000 fixed benefit + up to USD 1,500 reimbursement top-up` — or `denied with reason hash <hex>` for unhappy paths.
 
@@ -80,7 +80,7 @@ The default recipient is the member's own wallet. This step lets the member rout
 
 | Signer | Authority check | What changes |
 |--------|------------------|----|
-| Claims operator (or oracle authority for the linked-protection lane) | `require_claim_operator` (or oracle linkage) | New `Obligation` PDA; `obligation.state = reserved`; `obligation.amount = USD 1,000` (fixed) + reimbursement top-up amount recorded separately; `funding_line.reserved += amount` |
+| Claims operator (or oracle authority for the linked-protection lane) | `require_claim_operator` (or oracle linkage) | Existing `Obligation` PDA moves from proposed to reserved; `obligation.reserved_amount` and `funding_line.reserved_amount` increase by the reserved amount |
 
 **Truth chain**: the reserve is now booked against the appropriate funding line. The premium funding line and the LP-allocation funding line each take their share according to the allocation cap and weight (see `frontend/lib/protocol.ts` reserve math). The encumbered-reserve number visible in the public console moves up.
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8698,6 +8698,11 @@
       min-height: 2.75rem;
       min-width: 2.75rem;
     }
+
+    .protocol-toolbar-icon-button {
+      min-height: 2.75rem;
+      min-width: 2.75rem;
+    }
   }
 
   /*
@@ -9334,11 +9339,20 @@
      * for SOURCE / SDK / DOCS / STATUS / AUDITS links no operator needs
      * mid-task. The sidebar nav already carries everything needed for in-task
      * navigation on mobile; the footer links are desktop reference material.
-     * Footer stays in the DOM for screen readers and crawlers but is hidden
-     * from the visual viewport.
+     * Footer stays in the accessibility tree and DOM for screen readers and
+     * crawlers but is hidden from the visual viewport.
      */
     .protocol-footer {
-      display: none;
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
     }
   }
 

--- a/frontend/components/capital-operator-drawer.tsx
+++ b/frontend/components/capital-operator-drawer.tsx
@@ -196,7 +196,6 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
       ) ?? null,
     [props.poolTreasuryVaults, props.selectedPool?.address, props.selectedPool?.depositAssetMint],
   );
-  const selectedClassRequiresFeeVault = (props.selectedClass?.feeBps ?? 0) > 0;
 
   async function run(label: string, factory: () => Promise<Transaction>) {
     if (!publicKey || !sendTransaction) return;
@@ -738,7 +737,7 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                           !canAct ||
                           !lpOwner ||
                           !selectedPoolAssetVault?.vaultTokenAccount ||
-                          (selectedClassRequiresFeeVault && !selectedPoolTreasuryVault) ||
+                          !selectedPoolTreasuryVault ||
                           !redemptionRecipientTokenAccount.trim() ||
                           busyOn("Process redemption queue")
                         }
@@ -754,7 +753,6 @@ export function CapitalOperatorDrawer(props: CapitalOperatorDrawerProps) {
                               lpOwnerAddress: lpOwner,
                               recentBlockhash: blockhash,
                               shares: parseBigIntInput(queueShares),
-                              poolTreasuryVaultAddress: selectedPoolTreasuryVault?.address ?? null,
                               vaultTokenAccountAddress: selectedPoolAssetVault!.vaultTokenAccount,
                               recipientTokenAccountAddress: redemptionRecipientTokenAccount.trim(),
                             });

--- a/frontend/components/capital-workbench.tsx
+++ b/frontend/components/capital-workbench.tsx
@@ -387,7 +387,9 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
   }, [selectedPool]);
   const treasuryWalletOracle = useMemo(() => {
     if (!walletAddress) return null;
-    const profile = snapshot.oracleProfiles.find((entry) => entry.oracle === walletAddress);
+    const profile = snapshot.oracleProfiles.find(
+      (entry) => entry.oracle === walletAddress || entry.admin === walletAddress,
+    );
     if (!profile) return null;
     return {
       address: profile.address,

--- a/frontend/components/plan-operator-drawer.tsx
+++ b/frontend/components/plan-operator-drawer.tsx
@@ -470,24 +470,34 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
   const obligationFlowFundingLine = selectedObligationFundingLine;
   const settleClaimFundingLine = selectedClaimFundingLine;
   const impairmentFundingLine = selectedObligationFundingLine ?? selectedFundingLineForClaimResolved;
-  const settlementAssetMint = settleClaimFundingLine?.assetMint ?? selectedObligation?.assetMint ?? null;
-  const selectedSettlementVault = useMemo(
+  const settleClaimAssetMint = settleClaimFundingLine?.assetMint ?? null;
+  const settleObligationAssetMint = selectedObligation?.assetMint ?? obligationFlowFundingLine?.assetMint ?? null;
+  const selectedClaimSettlementVault = useMemo(
     () =>
       props.domainAssetVaults.find(
         (vault) =>
           vault.reserveDomain === props.plan?.reserveDomain &&
-          vault.assetMint === settlementAssetMint,
+          vault.assetMint === settleClaimAssetMint,
       ) ?? null,
-    [props.domainAssetVaults, props.plan?.reserveDomain, settlementAssetMint],
+    [props.domainAssetVaults, props.plan?.reserveDomain, settleClaimAssetMint],
+  );
+  const selectedObligationSettlementVault = useMemo(
+    () =>
+      props.domainAssetVaults.find(
+        (vault) =>
+          vault.reserveDomain === props.plan?.reserveDomain &&
+          vault.assetMint === settleObligationAssetMint,
+      ) ?? null,
+    [props.domainAssetVaults, props.plan?.reserveDomain, settleObligationAssetMint],
   );
   const selectedSettlementProtocolFeeVault = useMemo(
     () =>
       props.protocolFeeVaults.find(
         (vault) =>
           vault.reserveDomain === props.plan?.reserveDomain &&
-          vault.assetMint === settlementAssetMint,
+          vault.assetMint === settleClaimAssetMint,
       ) ?? null,
-    [props.protocolFeeVaults, props.plan?.reserveDomain, settlementAssetMint],
+    [props.protocolFeeVaults, props.plan?.reserveDomain, settleClaimAssetMint],
   );
   const allocationFundingLineAddress =
     section === "funding"
@@ -517,9 +527,9 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
         (vault) =>
           vault.liquidityPool === selectedPool?.address &&
           vault.oracle === selectedClaim?.adjudicator &&
-          vault.assetMint === settlementAssetMint,
+          vault.assetMint === settleClaimAssetMint,
       ) ?? null,
-    [props.poolOracleFeeVaults, selectedPool?.address, selectedClaim?.adjudicator, settlementAssetMint],
+    [props.poolOracleFeeVaults, selectedPool?.address, selectedClaim?.adjudicator, settleClaimAssetMint],
   );
   const selectedFundingVault = useMemo(
     () =>
@@ -1146,7 +1156,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                           !selectedClaim ||
                           !settleClaimFundingLine ||
                           !selectedClaim.memberPosition ||
-                          !selectedSettlementVault?.vaultTokenAccount ||
+                          !selectedClaimSettlementVault?.vaultTokenAccount ||
                           !recipientTokenAccount.trim() ||
                           busyOn("Settle claim")
                         }
@@ -1171,7 +1181,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                               poolOracleFeeVaultAddress: selectedPoolOracleFeeVault?.address ?? null,
                               poolOraclePolicyAddress: selectedPoolOraclePolicy?.address ?? null,
                               memberPositionAddress: selectedClaim!.memberPosition,
-                              vaultTokenAccountAddress: selectedSettlementVault!.vaultTokenAccount,
+                              vaultTokenAccountAddress: selectedClaimSettlementVault!.vaultTokenAccount,
                               recipientTokenAccountAddress: recipientTokenAccount.trim(),
                             });
                           })
@@ -1191,7 +1201,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                             (Number.parseInt(settleObligationStatus, 10) || OBLIGATION_STATUS_CLAIMABLE_PAYABLE) === OBLIGATION_STATUS_SETTLED &&
                             (
                               !selectedObligationClaim?.memberPosition ||
-                              !selectedSettlementVault?.vaultTokenAccount ||
+                              !selectedObligationSettlementVault?.vaultTokenAccount ||
                               !recipientTokenAccount.trim()
                             )
                           ) ||
@@ -1220,7 +1230,7 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                               allocationPositionAddress: selectedObligation!.allocationPosition ?? null,
                               poolAssetMint: selectedPool?.depositAssetMint ?? null,
                               memberPositionAddress: selectedObligationClaim?.memberPosition ?? null,
-                              vaultTokenAccountAddress: selectedSettlementVault?.vaultTokenAccount ?? null,
+                              vaultTokenAccountAddress: selectedObligationSettlementVault?.vaultTokenAccount ?? null,
                               recipientTokenAccountAddress: recipientTokenAccount.trim() || null,
                             });
                           })

--- a/frontend/components/plan-operator-drawer.tsx
+++ b/frontend/components/plan-operator-drawer.tsx
@@ -490,15 +490,6 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
       ) ?? null,
     [props.domainAssetVaults, props.plan?.reserveDomain, settleObligationAssetMint],
   );
-  const selectedSettlementProtocolFeeVault = useMemo(
-    () =>
-      props.protocolFeeVaults.find(
-        (vault) =>
-          vault.reserveDomain === props.plan?.reserveDomain &&
-          vault.assetMint === settleClaimAssetMint,
-      ) ?? null,
-    [props.protocolFeeVaults, props.plan?.reserveDomain, settleClaimAssetMint],
-  );
   const allocationFundingLineAddress =
     section === "funding"
       ? selectedFundingLine?.address
@@ -1177,7 +1168,6 @@ export function PlanOperatorDrawer(props: PlanOperatorDrawerProps) {
                               capitalClassAddress: selectedObligation?.capitalClass ?? null,
                               allocationPositionAddress: selectedObligation?.allocationPosition ?? null,
                               poolAssetMint: selectedPool?.depositAssetMint ?? null,
-                              protocolFeeVaultAddress: selectedSettlementProtocolFeeVault?.address ?? null,
                               poolOracleFeeVaultAddress: selectedPoolOracleFeeVault?.address ?? null,
                               poolOraclePolicyAddress: selectedPoolOraclePolicy?.address ?? null,
                               memberPositionAddress: selectedClaim!.memberPosition,

--- a/frontend/components/pool-treasury-panel.tsx
+++ b/frontend/components/pool-treasury-panel.tsx
@@ -171,10 +171,10 @@ export function PoolTreasuryPanel({ poolAddress }: PoolTreasuryPanelProps) {
   }, [capabilities.canWithdrawProtocolFees, protocolFeeRecipient, publicKey, selectedProtocolFeeVault, sendTransaction]);
   const oracleFeeGuard = useMemo(() => {
     if (!capabilities.canWithdrawOracleFees) {
-      return "Oracle fee withdrawals require the matching active oracle signer with fee-withdraw permissions.";
+      return "Oracle fee withdrawals require the matching oracle wallet, oracle admin, or governance authority.";
     }
     if (!publicKey || !sendTransaction) {
-      return "Connect the authorized oracle wallet to withdraw oracle fees.";
+      return "Connect an authorized oracle or governance wallet to withdraw oracle fees.";
     }
     if (!selectedOracleFeeVault) {
       return "Select an oracle fee vault before submitting a withdrawal.";

--- a/frontend/components/term.tsx
+++ b/frontend/components/term.tsx
@@ -112,7 +112,8 @@ export function Term({ name, children }: TermProps) {
       {open ? (
         <span
           id={tooltipId}
-          role="tooltip"
+          role={entry.learnMoreHref ? "group" : "tooltip"}
+          aria-label={entry.learnMoreHref ? entry.label : undefined}
           className="omegax-term-popover"
         >
           <span className="omegax-term-popover-eyebrow">{entry.label}</span>

--- a/frontend/lib/generated/protocol-contract.js
+++ b/frontend/lib/generated/protocol-contract.js
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
+// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
 export const PROTOCOL_PROGRAM_ID = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B";
 export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "adjudicate_claim_case": Uint8Array.from([146, 99, 255, 26, 223, 88, 235, 114]),
@@ -705,6 +705,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
         { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
         { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+        { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -724,6 +725,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
         { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
         { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+        { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -743,6 +745,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
         { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
         { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+        { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },

--- a/frontend/lib/generated/protocol-contract.js
+++ b/frontend/lib/generated/protocol-contract.js
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
+// contract_sha256: e05a4f9f75cfab96df03f0e88974e1d7115d64c151b04d88bfab8101f4cc6ef0
 export const PROTOCOL_PROGRAM_ID = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B";
 export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "adjudicate_claim_case": Uint8Array.from([146, 99, 255, 26, 223, 88, 235, 114]),
@@ -378,7 +378,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
         { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "owner" }] },
-        { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -484,7 +484,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
         { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "lp_position.owner" }] },
-        { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -500,7 +500,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "funding_line_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [102, 117, 110, 100, 105, 110, 103, 95, 108, 105, 110, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "funding_line" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "plan_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 108, 97, 110, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "series_reserve_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
-        { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -603,7 +603,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "allocation_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "claim_case", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 108, 97, 105, 109, 95, 99, 97, 115, 101] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "claim_case.claim_id" }] },
         { name: "obligation", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
-        { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "funding_line.asset_mint" }] },
         { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "pool_oracle_policy", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
         { name: "member_position", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
+// contract_sha256: e05a4f9f75cfab96df03f0e88974e1d7115d64c151b04d88bfab8101f4cc6ef0
 
 export type ProtocolInstructionName =
   | "adjudicate_claim_case"
@@ -454,7 +454,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
       { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "owner" }] },
-      { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -560,7 +560,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 97, 112, 105, 116, 97, 108, 95, 99, 108, 97, 115, 115] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "capital_class.class_id" }] },
       { name: "pool_class_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 99, 108, 97, 115, 115, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 112, 95, 112, 111, 115, 105, 116, 105, 111, 110] }, { kind: "account", path: "capital_class" }, { kind: "account", path: "lp_position.owner" }] },
-      { name: "pool_treasury_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "liquidity_pool.deposit_asset_mint" }] },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -576,7 +576,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "funding_line_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [102, 117, 110, 100, 105, 110, 103, 95, 108, 105, 110, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "funding_line" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "plan_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 108, 97, 110, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "series_reserve_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
-      { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "source_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -679,7 +679,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "allocation_ledger", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "claim_case", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [99, 108, 97, 105, 109, 95, 99, 97, 115, 101] }, { kind: "account", path: "health_plan" }, { kind: "account", path: "claim_case.claim_id" }] },
       { name: "obligation", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
-      { name: "protocol_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "funding_line.asset_mint" }] },
       { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "pool_oracle_policy", writable: false, signer: false, optional: true, address: undefined, pdaSeeds: undefined },
       { name: "member_position", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: f095fb3ee9ddc7ea582401f4cf4ed1bf6f8ee8a602d2e9f66c592beba27d0256
+// contract_sha256: 2ed68cbcb34d0e79edef0c25abe51d64b0283cc77d1989679eca88fe98036360
 
 export type ProtocolInstructionName =
   | "adjudicate_claim_case"
@@ -781,6 +781,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "oracle_profile", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [111, 114, 97, 99, 108, 101, 95, 112, 114, 111, 102, 105, 108, 101] }, { kind: "account", path: "oracle_profile.oracle" }] },
       { name: "pool_oracle_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 111, 114, 97, 99, 108, 101, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_oracle_fee_vault.oracle" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
       { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
+      { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_oracle_fee_vault.asset_mint" }] },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -800,6 +801,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [108, 105, 113, 117, 105, 100, 105, 116, 121, 95, 112, 111, 111, 108] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "liquidity_pool.pool_id" }] },
       { name: "pool_treasury_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 111, 108, 95, 116, 114, 101, 97, 115, 117, 114, 121, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
       { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
+      { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "liquidity_pool.reserve_domain" }, { kind: "account", path: "pool_treasury_vault.asset_mint" }] },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
@@ -819,6 +821,7 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "reserve_domain", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [114, 101, 115, 101, 114, 118, 101, 95, 100, 111, 109, 97, 105, 110] }, { kind: "account", path: "reserve_domain.domain_id" }] },
       { name: "protocol_fee_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 102, 101, 101, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
       { name: "domain_asset_vault", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 118, 97, 117, 108, 116] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
+      { name: "domain_asset_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [100, 111, 109, 97, 105, 110, 95, 97, 115, 115, 101, 116, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "reserve_domain" }, { kind: "account", path: "protocol_fee_vault.asset_mint" }] },
       { name: "asset_mint", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "vault_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "recipient_token_account", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -3439,9 +3439,10 @@ export function buildSetProtocolEmergencyPauseTx(params: {
 // matches the on-chain authority requirement above.
 //
 // SPL builders need `reserveDomainAddress` to derive the matching
-// `DomainAssetVault` (where SPL fee tokens physically reside). SOL builders
-// don't reference DomainAssetVault — lamports come straight off the
-// fee-vault PDA via `transfer_lamports_from_fee_vault`.
+// `DomainAssetVault` and `DomainAssetLedger` (where SPL fee tokens physically
+// reside and where funded-balance accounting is reduced). SOL builders don't
+// reference DomainAssetVault — lamports come straight off the fee-vault PDA
+// via `transfer_lamports_from_fee_vault`.
 
 export function buildWithdrawProtocolFeeSplTx(params: {
   governanceAuthority: PublicKeyish;
@@ -3473,6 +3474,10 @@ export function buildWithdrawProtocolFeeSplTx(params: {
       },
       {
         pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetLedgerPda({ reserveDomain, assetMint }),
         isWritable: true,
       },
       { pubkey: assetMint },
@@ -3554,6 +3559,10 @@ export function buildWithdrawPoolTreasurySplTx(params: {
       },
       {
         pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetLedgerPda({ reserveDomain, assetMint }),
         isWritable: true,
       },
       { pubkey: assetMint },
@@ -3644,6 +3653,10 @@ export function buildWithdrawPoolOracleFeeSplTx(params: {
       },
       {
         pubkey: deriveDomainAssetVaultPda({ reserveDomain, assetMint }),
+        isWritable: true,
+      },
+      {
+        pubkey: deriveDomainAssetLedgerPda({ reserveDomain, assetMint }),
         isWritable: true,
       },
       { pubkey: assetMint },

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -4162,7 +4162,6 @@ export function buildRecordPremiumPaymentTx(params: {
   policySeriesAddress?: PublicKeyish | null;
   capitalClassAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
-  protocolFeeVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const authority = toPublicKey(params.authority);
   const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
@@ -4205,7 +4204,13 @@ export function buildRecordPremiumPaymentTx(params: {
         isWritable: true,
       },
       optionalSeriesReserveLedgerAccount(params.policySeriesAddress, params.assetMint),
-      optionalProtocolAccount(params.protocolFeeVaultAddress, true),
+      {
+        pubkey: deriveProtocolFeeVaultPda({
+          reserveDomain: params.reserveDomainAddress,
+          assetMint: params.assetMint,
+        }),
+        isWritable: true,
+      },
       { pubkey: params.sourceTokenAccountAddress, isWritable: true },
       { pubkey: params.assetMint },
       { pubkey: params.vaultTokenAccountAddress, isWritable: true },
@@ -4619,7 +4624,6 @@ export function buildSettleClaimCaseTx(params: {
   capitalClassAddress?: PublicKeyish | null;
   allocationPositionAddress?: PublicKeyish | null;
   poolAssetMint?: PublicKeyish | null;
-  protocolFeeVaultAddress?: PublicKeyish | null;
   poolOracleFeeVaultAddress?: PublicKeyish | null;
   poolOraclePolicyAddress?: PublicKeyish | null;
   memberPositionAddress?: PublicKeyish | null;
@@ -4673,7 +4677,13 @@ export function buildSettleClaimCaseTx(params: {
       optionalAllocationLedgerAccount(params.allocationPositionAddress, params.assetMint),
       { pubkey: params.claimCaseAddress, isWritable: true },
       optionalProtocolAccount(params.obligationAddress, true),
-      optionalProtocolAccount(params.protocolFeeVaultAddress, true),
+      {
+        pubkey: deriveProtocolFeeVaultPda({
+          reserveDomain: params.reserveDomainAddress,
+          assetMint: params.assetMint,
+        }),
+        isWritable: true,
+      },
       optionalProtocolAccount(params.poolOracleFeeVaultAddress, true),
       optionalProtocolAccount(params.poolOraclePolicyAddress),
       optionalProtocolAccount(params.memberPositionAddress),
@@ -4838,9 +4848,8 @@ export function buildDepositIntoCapitalClassTx(params: {
   tokenProgramId?: PublicKeyish | null;
   recentBlockhash: string;
   amount: bigint;
-  /** Backward-compatible wire field. On-chain this is min_shares_out; 0n means no minimum. */
+  /** Minimum accepted shares out; 0n means no minimum. */
   shares: bigint;
-  poolTreasuryVaultAddress?: PublicKeyish | null;
 }): Transaction {
   const owner = toPublicKey(params.owner);
   const tokenProgramId = classicTokenProgramId(params.tokenProgramId);
@@ -4883,7 +4892,13 @@ export function buildDepositIntoCapitalClassTx(params: {
         isWritable: true,
       },
       { pubkey: lpPosition, isWritable: true },
-      optionalProtocolAccount(params.poolTreasuryVaultAddress, true),
+      {
+        pubkey: derivePoolTreasuryVaultPda({
+          liquidityPool: params.poolAddress,
+          assetMint: params.poolDepositAssetMint,
+        }),
+        isWritable: true,
+      },
       { pubkey: params.sourceTokenAccountAddress, isWritable: true },
       { pubkey: params.poolDepositAssetMint },
       { pubkey: params.vaultTokenAccountAddress, isWritable: true },
@@ -4985,7 +5000,6 @@ export function buildProcessRedemptionQueueTx(params: {
   recentBlockhash: string;
   shares: bigint;
   assetAmount?: bigint;
-  poolTreasuryVaultAddress?: PublicKeyish | null;
   vaultTokenAccountAddress: PublicKeyish;
   recipientTokenAccountAddress: PublicKeyish;
   tokenProgramId?: PublicKeyish | null;
@@ -5030,7 +5044,13 @@ export function buildProcessRedemptionQueueTx(params: {
         isWritable: true,
       },
       { pubkey: lpPosition, isWritable: true },
-      optionalProtocolAccount(params.poolTreasuryVaultAddress, true),
+      {
+        pubkey: derivePoolTreasuryVaultPda({
+          liquidityPool: params.poolAddress,
+          assetMint: params.poolDepositAssetMint,
+        }),
+        isWritable: true,
+      },
       { pubkey: params.poolDepositAssetMint },
       { pubkey: params.vaultTokenAccountAddress, isWritable: true },
       { pubkey: params.recipientTokenAccountAddress, isWritable: true },

--- a/frontend/lib/ui-capabilities.ts
+++ b/frontend/lib/ui-capabilities.ts
@@ -87,6 +87,7 @@ export type WalletRole =
   | "compliance_authority"
   | "guardian"
   | "oracle"
+  | "oracle_admin"
   | "member"
   | "claim_delegate"
   | "capital_provider";
@@ -172,6 +173,7 @@ export const POOL_WORKSPACE_SECTION_META: Readonly<Record<PoolWorkspaceSection, 
       "pool_authority",
       "pool_operator",
       "oracle",
+      "oracle_admin",
     ],
     showInNav: true,
   },
@@ -198,6 +200,7 @@ export const POOL_WORKSPACE_SECTION_META: Readonly<Record<PoolWorkspaceSection, 
       "pool_operator",
       "risk_manager",
       "oracle",
+      "oracle_admin",
     ],
     showInNav: true,
   },
@@ -269,6 +272,7 @@ export type WalletCapabilities = {
   isGuardian: boolean;
   isRegisteredMember: boolean;
   isRegisteredOracle: boolean;
+  isOracleAdmin: boolean;
   isClaimDelegate: boolean;
   hasCapitalPosition: boolean;
   canCreatePool: boolean;
@@ -413,7 +417,8 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
   const isComplianceAuthority = sameAddress(walletAddress, input.poolControlAuthority?.complianceAuthority);
   const isGuardian = sameAddress(walletAddress, input.poolControlAuthority?.guardianAuthority);
   const isRegisteredMember = Boolean(input.walletMembership);
-  const isRegisteredOracle = Boolean(input.walletOracle);
+  const isRegisteredOracle = sameAddress(walletAddress, input.walletOracle?.oracle);
+  const isOracleAdmin = sameAddress(walletAddress, input.walletOracle?.admin);
   const isClaimDelegate =
     Boolean(input.walletClaimDelegate?.active)
     && sameAddress(walletAddress, input.walletClaimDelegate?.delegate);
@@ -438,6 +443,7 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
     if (isComplianceAuthority) roles.push("compliance_authority");
     if (isGuardian) roles.push("guardian");
     if (isRegisteredOracle) roles.push("oracle");
+    if (isOracleAdmin) roles.push("oracle_admin");
     if (isRegisteredMember) roles.push("member");
     if (isClaimDelegate) roles.push("claim_delegate");
     if (hasCapitalPosition) roles.push("capital_provider");
@@ -452,7 +458,7 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
   const canOperateQueueAsOperator = isPoolAuthority || isPoolOperator || isRiskManager;
   const canOperateOwnedRedemptionQueue = isConnected && (hasCapitalPosition || isPoolAuthority || isPoolOperator);
   const canManageOracleStake = isConnected && (isRegisteredOracle || canManageProtocolConfig);
-  const canManageOracleProfile = isRegisteredOracle || canManageProtocolConfig;
+  const canManageOracleProfile = isRegisteredOracle || isOracleAdmin || canManageProtocolConfig;
   const canOpenDisputes =
     isPoolAuthority || isPoolOperator || isRiskManager || isGuardian || canManageProtocolConfig;
 
@@ -469,6 +475,7 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
     isGuardian,
     isRegisteredMember,
     isRegisteredOracle,
+    isOracleAdmin,
     isClaimDelegate,
     hasCapitalPosition,
     canCreatePool: isConnected,
@@ -479,7 +486,7 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
     canManageSettings: canManagePoolControls,
     canManageTreasury: isPoolAuthority || isPoolOperator || isRiskManager || canManageProtocolConfig,
     canManageSchemas: isPoolAuthority || isPoolOperator || canManageProtocolConfig,
-    canManageOracles: isPoolAuthority || isPoolOperator || isGovernanceAuthority || isRegisteredOracle,
+    canManageOracles: isPoolAuthority || isPoolOperator || isGovernanceAuthority || isRegisteredOracle || isOracleAdmin,
     canManageLiquidity: isPoolAuthority || isPoolOperator || isRiskManager || hasCapitalPosition,
     canManageClaims: canReviewCoverageClaims,
     canManageCoverage: isPoolAuthority || isPoolOperator || isRegisteredMember || isClaimDelegate,
@@ -508,7 +515,7 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
     // disabled/enabled state before the chain rejects.
     canWithdrawPoolTreasury: isPoolAuthority || isPoolOperator || canManageProtocolConfig,
     canWithdrawProtocolFees: canManageProtocolConfig,
-    canWithdrawOracleFees: isRegisteredOracle || canManageProtocolConfig,
+    canWithdrawOracleFees: isRegisteredOracle || isOracleAdmin || canManageProtocolConfig,
     canOperateOwnedRedemptionQueue,
     canOperateQueueAsOperator,
     canUseExpertTools:
@@ -519,7 +526,8 @@ export function deriveWalletCapabilities(input: WalletCapabilityInput): WalletCa
       || isRiskManager
       || isComplianceAuthority
       || isGuardian
-      || isRegisteredOracle,
+      || isRegisteredOracle
+      || isOracleAdmin,
   };
 }
 

--- a/frontend/lib/use-token-price.ts
+++ b/frontend/lib/use-token-price.ts
@@ -61,13 +61,13 @@ async function fetchSolUsdPrice(): Promise<number> {
 }
 
 export function useSolUsdPrice(): UseSolUsdPriceResult {
-  const [price, setPrice] = useState<number | null>(() => readCache()?.price ?? null);
+  const [price, setPrice] = useState<number | null>(() => readFreshCache()?.price ?? null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const cached = readCache();
-    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    const cached = readFreshCache();
+    if (cached) {
       setPrice(cached.price);
       setLoading(false);
       return;
@@ -125,6 +125,12 @@ function readCache(): CachedPrice | null {
   } catch {
     return null;
   }
+}
+
+function readFreshCache(): CachedPrice | null {
+  const cached = readCache();
+  if (!cached) return null;
+  return Date.now() - cached.ts < CACHE_TTL_MS ? cached : null;
 }
 
 function writeCache(cached: CachedPrice): void {

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -9981,6 +9981,48 @@
           }
         },
         {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
           "name": "asset_mint"
         },
         {
@@ -10326,6 +10368,48 @@
           }
         },
         {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
           "name": "asset_mint"
         },
         {
@@ -10646,6 +10730,47 @@
                   117,
                   108,
                   116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
                 ]
               },
               {
@@ -11865,18 +11990,18 @@
     },
     {
       "code": 6073,
-      "name": "FeeVaultRequiredForConfiguredFee",
-      "msg": "Configured class entry fee requires the matching pool treasury fee vault account"
-    },
-    {
-      "code": 6074,
       "name": "FeeVaultBpsMisconfigured",
       "msg": "Fee vault basis-points configuration is out of range"
     },
     {
-      "code": 6075,
+      "code": 6074,
       "name": "SettlementOutflowAccountsRequired",
       "msg": "Linked claim settlement requires the member, mint, vault token, recipient token, and token program accounts"
+    },
+    {
+      "code": 6075,
+      "name": "FeeVaultRequiredForConfiguredFee",
+      "msg": "Configured fee basis points require the matching fee vault account"
     }
   ],
   "types": [

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -3272,13 +3272,44 @@
         },
         {
           "name": "pool_treasury_vault",
-          "docs": [
-            "Phase 1.6 — optional pool-treasury vault for entry-fee accrual.",
-            "When supplied, must match (liquidity_pool, deposit_asset_mint).",
-            "Required when capital_class.fee_bps is nonzero."
-          ],
           "writable": true,
-          "optional": true
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.deposit_asset_mint",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
         },
         {
           "name": "source_token_account",
@@ -5536,13 +5567,44 @@
         },
         {
           "name": "pool_treasury_vault",
-          "docs": [
-            "Phase 1.6 — optional pool-treasury vault for exit-fee accrual.",
-            "When supplied, must match (liquidity_pool, deposit_asset_mint).",
-            "Required when capital_class.fee_bps is nonzero."
-          ],
           "writable": true,
-          "optional": true
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.deposit_asset_mint",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
         },
         {
           "name": "asset_mint"
@@ -5857,13 +5919,44 @@
         },
         {
           "name": "protocol_fee_vault",
-          "docs": [
-            "Protocol fee vault for premium-time fee accrual. Required when",
-            "protocol_governance.protocol_fee_bps is nonzero.",
-            "Must match (health_plan.reserve_domain, funding_line.asset_mint)."
-          ],
           "writable": true,
-          "optional": true
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "health_plan.reserve_domain",
+                "account": "HealthPlan"
+              },
+              {
+                "kind": "account",
+                "path": "funding_line.asset_mint",
+                "account": "FundingLine"
+              }
+            ]
+          }
         },
         {
           "name": "source_token_account",
@@ -7971,13 +8064,44 @@
         },
         {
           "name": "protocol_fee_vault",
-          "docs": [
-            "Phase 1.6 — optional protocol fee vault for claim-settlement accrual.",
-            "When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).",
-            "Validated at runtime; absent means protocol-fee accrual is skipped (backward compat)."
-          ],
           "writable": true,
-          "optional": true
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "health_plan.reserve_domain",
+                "account": "HealthPlan"
+              },
+              {
+                "kind": "account",
+                "path": "funding_line.asset_mint",
+                "account": "FundingLine"
+              }
+            ]
+          }
         },
         {
           "name": "pool_oracle_fee_vault",
@@ -13184,8 +13308,8 @@
           {
             "name": "shares",
             "docs": [
-              "Backward-compatible wire field. Interpreted as min_shares_out; zero",
-              "means accept the program-derived NAV share price with no minimum."
+              "Minimum accepted shares out; zero means accept the program-derived",
+              "NAV share price with no minimum."
             ],
             "type": "u64"
           }

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-13e4cf7c51320c9a67c17780c8841afefc6de5c2e018542e3918f2d49194d9cb
+40aec9ce1907aa22e9ef95887925fb99ae0e10f616c57b24ac5e1252ce39723c
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-40aec9ce1907aa22e9ef95887925fb99ae0e10f616c57b24ac5e1252ce39723c
+d7103607469a917594bd3780178d476ea94b1fa41cddb079923ffafbefa9132b
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/core_accounts.rs

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -2331,6 +2331,11 @@ pub mod omegax_protocol {
             &ctx.accounts.asset_mint,
             &ctx.accounts.token_program,
         )?;
+        book_fee_withdrawal(
+            &mut ctx.accounts.domain_asset_vault.total_assets,
+            &mut ctx.accounts.domain_asset_ledger.sheet,
+            args.amount,
+        )?;
 
         let vault = &mut ctx.accounts.protocol_fee_vault;
         vault.withdrawn_fees = new_withdrawn;
@@ -2420,6 +2425,11 @@ pub mod omegax_protocol {
             &ctx.accounts.asset_mint,
             &ctx.accounts.token_program,
         )?;
+        book_fee_withdrawal(
+            &mut ctx.accounts.domain_asset_vault.total_assets,
+            &mut ctx.accounts.domain_asset_ledger.sheet,
+            args.amount,
+        )?;
 
         let vault = &mut ctx.accounts.pool_treasury_vault;
         vault.withdrawn_fees = new_withdrawn;
@@ -2508,6 +2518,11 @@ pub mod omegax_protocol {
             &ctx.accounts.recipient_token_account,
             &ctx.accounts.asset_mint,
             &ctx.accounts.token_program,
+        )?;
+        book_fee_withdrawal(
+            &mut ctx.accounts.domain_asset_vault.total_assets,
+            &mut ctx.accounts.domain_asset_ledger.sheet,
+            args.amount,
         )?;
 
         let vault = &mut ctx.accounts.pool_oracle_fee_vault;
@@ -4136,6 +4151,12 @@ pub struct WithdrawProtocolFeeSpl<'info> {
     )]
     pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
     #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_LEDGER, reserve_domain.key().as_ref(), protocol_fee_vault.asset_mint.as_ref()],
+        bump = domain_asset_ledger.bump,
+    )]
+    pub domain_asset_ledger: Box<Account<'info, DomainAssetLedger>>,
+    #[account(
         constraint = asset_mint.key() == protocol_fee_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
     )]
     pub asset_mint: InterfaceAccount<'info, Mint>,
@@ -4193,6 +4214,12 @@ pub struct WithdrawPoolTreasurySpl<'info> {
         bump = domain_asset_vault.bump,
     )]
     pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
+    #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_LEDGER, liquidity_pool.reserve_domain.as_ref(), pool_treasury_vault.asset_mint.as_ref()],
+        bump = domain_asset_ledger.bump,
+    )]
+    pub domain_asset_ledger: Box<Account<'info, DomainAssetLedger>>,
     #[account(
         constraint = asset_mint.key() == pool_treasury_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
     )]
@@ -4260,6 +4287,12 @@ pub struct WithdrawPoolOracleFeeSpl<'info> {
         bump = domain_asset_vault.bump,
     )]
     pub domain_asset_vault: Box<Account<'info, DomainAssetVault>>,
+    #[account(
+        mut,
+        seeds = [SEED_DOMAIN_ASSET_LEDGER, liquidity_pool.reserve_domain.as_ref(), pool_oracle_fee_vault.asset_mint.as_ref()],
+        bump = domain_asset_ledger.bump,
+    )]
+    pub domain_asset_ledger: Box<Account<'info, DomainAssetLedger>>,
     #[account(
         constraint = asset_mint.key() == pool_oracle_fee_vault.asset_mint @ OmegaXProtocolError::AssetMintMismatch,
     )]
@@ -6068,12 +6101,12 @@ pub enum OmegaXProtocolError {
     FeeVaultRentExemptionBreach,
     #[msg("Fee vault rail and asset mint disagree (SOL vault used on SPL path or vice versa)")]
     FeeVaultRailMismatch,
-    #[msg("Configured class entry fee requires the matching pool treasury fee vault account")]
-    FeeVaultRequiredForConfiguredFee,
     #[msg("Fee vault basis-points configuration is out of range")]
     FeeVaultBpsMisconfigured,
     #[msg("Linked claim settlement requires the member, mint, vault token, recipient token, and token program accounts")]
     SettlementOutflowAccountsRequired,
+    #[msg("Configured fee basis points require the matching fee vault account")]
+    FeeVaultRequiredForConfiguredFee,
 }
 
 fn require_id(value: &str) -> Result<()> {
@@ -7371,6 +7404,16 @@ fn book_inflow(target: &mut u64, amount: u64) -> Result<()> {
 fn book_inflow_sheet(sheet: &mut ReserveBalanceSheet, amount: u64) -> Result<()> {
     sheet.funded = checked_add(sheet.funded, amount)?;
     recompute_sheet(sheet)
+}
+
+fn book_fee_withdrawal(
+    domain_assets: &mut u64,
+    domain_sheet: &mut ReserveBalanceSheet,
+    amount: u64,
+) -> Result<()> {
+    *domain_assets = checked_sub(*domain_assets, amount)?;
+    domain_sheet.funded = checked_sub(domain_sheet.funded, amount)?;
+    recompute_sheet(domain_sheet)
 }
 
 fn book_owed(sheet: &mut ReserveBalanceSheet, amount: u64) -> Result<()> {

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -984,34 +984,28 @@ pub mod omegax_protocol {
         // internal claim that decrements `accrued_fees - withdrawn_fees`
         // headroom. No user-facing payout reduction here (premiums are not
         // refundable).
-        if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
-            require_keys_eq!(
-                vault.reserve_domain,
-                health_plan_reserve_domain,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            require_keys_eq!(
-                vault.asset_mint,
-                funding_line_asset_mint,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
-            if fee > 0 {
-                let vault_key = vault.key();
-                let vault_mint = vault.asset_mint;
-                let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
-                emit!(FeeAccruedEvent {
-                    vault: vault_key,
-                    asset_mint: vault_mint,
-                    amount: fee,
-                    accrued_total,
-                });
-            }
-        } else {
-            require!(
-                protocol_fee_bps == 0,
-                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
-            );
+        let vault = &mut ctx.accounts.protocol_fee_vault;
+        require_keys_eq!(
+            vault.reserve_domain,
+            health_plan_reserve_domain,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        require_keys_eq!(
+            vault.asset_mint,
+            funding_line_asset_mint,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        let fee = fee_share_from_bps(amount, protocol_fee_bps)?;
+        if fee > 0 {
+            let vault_key = vault.key();
+            let vault_mint = vault.asset_mint;
+            let accrued_total = accrue_fee(&mut vault.accrued_fees, fee)?;
+            emit!(FeeAccruedEvent {
+                vault: vault_key,
+                asset_mint: vault_mint,
+                amount: fee,
+                accrued_total,
+            });
         }
 
         emit!(FundingFlowRecordedEvent {
@@ -1670,25 +1664,18 @@ pub mod omegax_protocol {
         let asset_mint_key = ctx.accounts.funding_line.asset_mint;
         let protocol_fee_bps = ctx.accounts.protocol_governance.protocol_fee_bps;
 
-        let protocol_fee = if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref() {
-            require_keys_eq!(
-                vault.reserve_domain,
-                reserve_domain,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            require_keys_eq!(
-                vault.asset_mint,
-                asset_mint_key,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            fee_share_from_bps(amount, protocol_fee_bps)?
-        } else {
-            require!(
-                protocol_fee_bps == 0,
-                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
-            );
-            0
-        };
+        let protocol_fee_vault = &ctx.accounts.protocol_fee_vault;
+        require_keys_eq!(
+            protocol_fee_vault.reserve_domain,
+            reserve_domain,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        require_keys_eq!(
+            protocol_fee_vault.asset_mint,
+            asset_mint_key,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        let protocol_fee = fee_share_from_bps(amount, protocol_fee_bps)?;
 
         // Adjudicator oracle fee: requires BOTH pool_oracle_fee_vault and
         // pool_oracle_policy to be supplied. The vault fixes the recipient
@@ -1717,12 +1704,8 @@ pub mod omegax_protocol {
                 );
                 fee_share_from_bps(amount, policy.oracle_fee_bps)?
             }
-            (None, Some(policy)) => {
-                require!(
-                    policy.oracle_fee_bps == 0,
-                    OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
-                );
-                0
+            (None, Some(_)) => {
+                return Err(OmegaXProtocolError::FeeVaultRequiredForConfiguredFee.into());
             }
             (None, None) => 0,
             (Some(_), None) => {
@@ -1787,17 +1770,16 @@ pub mod omegax_protocol {
 
         // Accrue the protocol fee carve-out.
         if protocol_fee > 0 {
-            if let Some(vault) = ctx.accounts.protocol_fee_vault.as_deref_mut() {
-                let key = vault.key();
-                let mint = vault.asset_mint;
-                let total = accrue_fee(&mut vault.accrued_fees, protocol_fee)?;
-                emit!(FeeAccruedEvent {
-                    vault: key,
-                    asset_mint: mint,
-                    amount: protocol_fee,
-                    accrued_total: total,
-                });
-            }
+            let vault = &mut ctx.accounts.protocol_fee_vault;
+            let key = vault.key();
+            let mint = vault.asset_mint;
+            let total = accrue_fee(&mut vault.accrued_fees, protocol_fee)?;
+            emit!(FeeAccruedEvent {
+                vault: key,
+                asset_mint: mint,
+                amount: protocol_fee,
+                accrued_total: total,
+            });
         }
 
         // Accrue the adjudicator-oracle fee carve-out.
@@ -2004,7 +1986,7 @@ pub mod omegax_protocol {
 
         let amount = args.amount;
 
-        // Phase 1.6 — Pool-treasury entry fee. Validate the optional fee vault
+        // Phase 1.6 — Pool-treasury entry fee. Validate the canonical fee vault
         // matches (liquidity_pool, deposit_asset_mint), then compute the fee
         // against capital_class.fee_bps. The full `amount` remains physically
         // locked in the DomainAssetVault; the fee carve-out is removed from
@@ -2013,25 +1995,18 @@ pub mod omegax_protocol {
         let pool_key = ctx.accounts.liquidity_pool.key();
         let pool_deposit_mint = ctx.accounts.liquidity_pool.deposit_asset_mint;
         let class_fee_bps = ctx.accounts.capital_class.fee_bps;
-        let entry_fee = if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref() {
-            require_keys_eq!(
-                vault.liquidity_pool,
-                pool_key,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            require_keys_eq!(
-                vault.asset_mint,
-                pool_deposit_mint,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            fee_share_from_bps(amount, class_fee_bps)?
-        } else {
-            require!(
-                class_fee_bps == 0,
-                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
-            );
-            0
-        };
+        let pool_treasury_vault = &ctx.accounts.pool_treasury_vault;
+        require_keys_eq!(
+            pool_treasury_vault.liquidity_pool,
+            pool_key,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        require_keys_eq!(
+            pool_treasury_vault.asset_mint,
+            pool_deposit_mint,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        let entry_fee = fee_share_from_bps(amount, class_fee_bps)?;
         let net_amount = checked_sub(amount, entry_fee)?;
 
         let shares = deposit_shares_for_nav(
@@ -2066,20 +2041,18 @@ pub mod omegax_protocol {
 
         // Accrue the entry fee to the pool-treasury vault. SPL tokens already
         // sit in the DomainAssetVault from the transfer above; this only updates
-        // the rail's claim counter. Missing vaults are only allowed when
-        // capital_class.fee_bps == 0.
+        // the rail's claim counter.
         if entry_fee > 0 {
-            if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
-                let vault_key = vault.key();
-                let vault_mint = vault.asset_mint;
-                let accrued_total = accrue_fee(&mut vault.accrued_fees, entry_fee)?;
-                emit!(FeeAccruedEvent {
-                    vault: vault_key,
-                    asset_mint: vault_mint,
-                    amount: entry_fee,
-                    accrued_total,
-                });
-            }
+            let vault = &mut ctx.accounts.pool_treasury_vault;
+            let vault_key = vault.key();
+            let vault_mint = vault.asset_mint;
+            let accrued_total = accrue_fee(&mut vault.accrued_fees, entry_fee)?;
+            emit!(FeeAccruedEvent {
+                vault: vault_key,
+                asset_mint: vault_mint,
+                amount: entry_fee,
+                accrued_total,
+            });
         }
 
         emit!(CapitalClassDepositEvent {
@@ -2177,7 +2150,7 @@ pub mod omegax_protocol {
             ctx.accounts.lp_position.pending_redemption_assets,
         )?;
 
-        // Phase 1.6 — Pool-treasury exit fee. Validate the optional fee vault
+        // Phase 1.6 — Pool-treasury exit fee. Validate the canonical fee vault
         // matches (liquidity_pool, deposit_asset_mint), then compute the carve-out.
         // The full pending request is resolved (LP gives up claim on asset_amount),
         // but only `net_to_lp` physically leaves the vault — the fee carve-out
@@ -2185,25 +2158,18 @@ pub mod omegax_protocol {
         let pool_key = ctx.accounts.liquidity_pool.key();
         let pool_deposit_mint = ctx.accounts.liquidity_pool.deposit_asset_mint;
         let class_fee_bps = ctx.accounts.capital_class.fee_bps;
-        let exit_fee = if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref() {
-            require_keys_eq!(
-                vault.liquidity_pool,
-                pool_key,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            require_keys_eq!(
-                vault.asset_mint,
-                pool_deposit_mint,
-                OmegaXProtocolError::FeeVaultMismatch
-            );
-            fee_share_from_bps(asset_amount, class_fee_bps)?
-        } else {
-            require!(
-                class_fee_bps == 0,
-                OmegaXProtocolError::FeeVaultRequiredForConfiguredFee
-            );
-            0
-        };
+        let pool_treasury_vault = &ctx.accounts.pool_treasury_vault;
+        require_keys_eq!(
+            pool_treasury_vault.liquidity_pool,
+            pool_key,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        require_keys_eq!(
+            pool_treasury_vault.asset_mint,
+            pool_deposit_mint,
+            OmegaXProtocolError::FeeVaultMismatch
+        );
+        let exit_fee = fee_share_from_bps(asset_amount, class_fee_bps)?;
         let net_to_lp = checked_sub(asset_amount, exit_fee)?;
 
         ctx.accounts.lp_position.pending_redemption_shares = checked_sub(
@@ -2281,19 +2247,18 @@ pub mod omegax_protocol {
 
         // Accrue the exit fee to the pool-treasury vault. SPL tokens are still
         // physically in the vault_token_account; only the rail's claim counter
-        // changes. Missing vaults are only allowed when class_fee_bps == 0.
+        // changes.
         if exit_fee > 0 {
-            if let Some(vault) = ctx.accounts.pool_treasury_vault.as_deref_mut() {
-                let vault_key = vault.key();
-                let vault_mint = vault.asset_mint;
-                let accrued_total = accrue_fee(&mut vault.accrued_fees, exit_fee)?;
-                emit!(FeeAccruedEvent {
-                    vault: vault_key,
-                    asset_mint: vault_mint,
-                    amount: exit_fee,
-                    accrued_total,
-                });
-            }
+            let vault = &mut ctx.accounts.pool_treasury_vault;
+            let vault_key = vault.key();
+            let vault_mint = vault.asset_mint;
+            let accrued_total = accrue_fee(&mut vault.accrued_fees, exit_fee)?;
+            emit!(FeeAccruedEvent {
+                vault: vault_key,
+                asset_mint: vault_mint,
+                amount: exit_fee,
+                accrued_total,
+            });
         }
 
         Ok(())
@@ -3602,11 +3567,14 @@ pub struct RecordPremiumPayment<'info> {
     pub plan_reserve_ledger: Box<Account<'info, PlanReserveLedger>>,
     #[account(mut)]
     pub series_reserve_ledger: Option<Box<Account<'info, SeriesReserveLedger>>>,
-    /// Protocol fee vault for premium-time fee accrual. Required when
-    /// protocol_governance.protocol_fee_bps is nonzero.
-    /// Must match (health_plan.reserve_domain, funding_line.asset_mint).
-    #[account(mut)]
-    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
+    #[account(
+        mut,
+        seeds = [SEED_PROTOCOL_FEE_VAULT, health_plan.reserve_domain.as_ref(), funding_line.asset_mint.as_ref()],
+        bump = protocol_fee_vault.bump,
+        constraint = protocol_fee_vault.reserve_domain == health_plan.reserve_domain @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = protocol_fee_vault.asset_mint == funding_line.asset_mint @ OmegaXProtocolError::FeeVaultMismatch,
+    )]
+    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,
@@ -3896,11 +3864,14 @@ pub struct SettleClaimCase<'info> {
     pub claim_case: Box<Account<'info, ClaimCase>>,
     #[account(mut)]
     pub obligation: Option<Box<Account<'info, Obligation>>>,
-    /// Phase 1.6 — optional protocol fee vault for claim-settlement accrual.
-    /// When supplied, must match (health_plan.reserve_domain, funding_line.asset_mint).
-    /// Validated at runtime; absent means protocol-fee accrual is skipped (backward compat).
-    #[account(mut)]
-    pub protocol_fee_vault: Option<Box<Account<'info, ProtocolFeeVault>>>,
+    #[account(
+        mut,
+        seeds = [SEED_PROTOCOL_FEE_VAULT, health_plan.reserve_domain.as_ref(), funding_line.asset_mint.as_ref()],
+        bump = protocol_fee_vault.bump,
+        constraint = protocol_fee_vault.reserve_domain == health_plan.reserve_domain @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = protocol_fee_vault.asset_mint == funding_line.asset_mint @ OmegaXProtocolError::FeeVaultMismatch,
+    )]
+    pub protocol_fee_vault: Box<Account<'info, ProtocolFeeVault>>,
     /// Phase 1.6 — optional pool-oracle fee vault for adjudicator revshare.
     /// When supplied alongside `pool_oracle_policy`, the bps from policy is
     /// applied to the gross amount and credited to the supplied oracle vault.
@@ -4044,11 +4015,14 @@ pub struct DepositIntoCapitalClass<'info> {
         bump
     )]
     pub lp_position: Box<Account<'info, LPPosition>>,
-    /// Phase 1.6 — optional pool-treasury vault for entry-fee accrual.
-    /// When supplied, must match (liquidity_pool, deposit_asset_mint).
-    /// Required when capital_class.fee_bps is nonzero.
-    #[account(mut)]
-    pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), liquidity_pool.deposit_asset_mint.as_ref()],
+        bump = pool_treasury_vault.bump,
+        constraint = pool_treasury_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_treasury_vault.asset_mint == liquidity_pool.deposit_asset_mint @ OmegaXProtocolError::FeeVaultMismatch,
+    )]
+    pub pool_treasury_vault: Box<Account<'info, PoolTreasuryVault>>,
     #[account(mut)]
     pub source_token_account: InterfaceAccount<'info, TokenAccount>,
     pub asset_mint: InterfaceAccount<'info, Mint>,
@@ -4092,11 +4066,14 @@ pub struct ProcessRedemptionQueue<'info> {
     pub pool_class_ledger: Box<Account<'info, PoolClassLedger>>,
     #[account(mut, seeds = [SEED_LP_POSITION, capital_class.key().as_ref(), lp_position.owner.as_ref()], bump = lp_position.bump)]
     pub lp_position: Box<Account<'info, LPPosition>>,
-    /// Phase 1.6 — optional pool-treasury vault for exit-fee accrual.
-    /// When supplied, must match (liquidity_pool, deposit_asset_mint).
-    /// Required when capital_class.fee_bps is nonzero.
-    #[account(mut)]
-    pub pool_treasury_vault: Option<Box<Account<'info, PoolTreasuryVault>>>,
+    #[account(
+        mut,
+        seeds = [SEED_POOL_TREASURY_VAULT, liquidity_pool.key().as_ref(), liquidity_pool.deposit_asset_mint.as_ref()],
+        bump = pool_treasury_vault.bump,
+        constraint = pool_treasury_vault.liquidity_pool == liquidity_pool.key() @ OmegaXProtocolError::FeeVaultMismatch,
+        constraint = pool_treasury_vault.asset_mint == liquidity_pool.deposit_asset_mint @ OmegaXProtocolError::FeeVaultMismatch,
+    )]
+    pub pool_treasury_vault: Box<Account<'info, PoolTreasuryVault>>,
     // PT-2026-04-27-01/02 fix: outflow CPI accounts. Recipient must be the LP
     // position's owner — there is no delegate-recipient pattern for redemptions.
     #[account(
@@ -5541,8 +5518,8 @@ pub struct UpdateLpPositionCredentialingArgs {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct DepositIntoCapitalClassArgs {
     pub amount: u64,
-    /// Backward-compatible wire field. Interpreted as min_shares_out; zero
-    /// means accept the program-derived NAV share price with no minimum.
+    /// Minimum accepted shares out; zero means accept the program-derived
+    /// NAV share price with no minimum.
     pub shares: u64,
 }
 

--- a/scripts/support/genesis_live_bootstrap_config.ts
+++ b/scripts/support/genesis_live_bootstrap_config.ts
@@ -436,7 +436,7 @@ export function loadGenesisLiveBootstrapConfig(params: {
   // collapse onto a single keypair. Without this guard the defaults silently
   // route every role through governanceAuthority — a single compromise drains
   // the whole protocol.
-  if (env.OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS === "1") {
+  if (env.OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS === "1" && !(targetingMainnet && breakGlass)) {
     const toBase58 = (value: PublicKey | string): string =>
       typeof value === "string" ? value : value.toBase58();
     const roleKeys: Array<[string, PublicKey | string]> = [

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -3536,7 +3536,44 @@
           "name": "pool_treasury_vault",
           "writable": true,
           "signer": false,
-          "optional": true
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.deposit_asset_mint",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
         },
         {
           "name": "source_token_account",
@@ -5958,7 +5995,44 @@
           "name": "pool_treasury_vault",
           "writable": true,
           "signer": false,
-          "optional": true
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  114,
+                  101,
+                  97,
+                  115,
+                  117,
+                  114,
+                  121,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool"
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.deposit_asset_mint",
+                "account": "LiquidityPool"
+              }
+            ]
+          }
         },
         {
           "name": "asset_mint",
@@ -6304,7 +6378,44 @@
           "name": "protocol_fee_vault",
           "writable": true,
           "signer": false,
-          "optional": true
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "health_plan.reserve_domain",
+                "account": "HealthPlan"
+              },
+              {
+                "kind": "account",
+                "path": "funding_line.asset_mint",
+                "account": "FundingLine"
+              }
+            ]
+          }
         },
         {
           "name": "source_token_account",
@@ -8577,7 +8688,44 @@
           "name": "protocol_fee_vault",
           "writable": true,
           "signer": false,
-          "optional": true
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "health_plan.reserve_domain",
+                "account": "HealthPlan"
+              },
+              {
+                "kind": "account",
+                "path": "funding_line.asset_mint",
+                "account": "FundingLine"
+              }
+            ]
+          }
         },
         {
           "name": "pool_oracle_fee_vault",

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -10732,6 +10732,50 @@
           }
         },
         {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_oracle_fee_vault.asset_mint",
+                "account": "PoolOracleFeeVault"
+              }
+            ]
+          }
+        },
+        {
           "name": "asset_mint",
           "writable": false,
           "signer": false,
@@ -11106,6 +11150,50 @@
           }
         },
         {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "liquidity_pool.reserve_domain",
+                "account": "LiquidityPool"
+              },
+              {
+                "kind": "account",
+                "path": "pool_treasury_vault.asset_mint",
+                "account": "PoolTreasuryVault"
+              }
+            ]
+          }
+        },
+        {
           "name": "asset_mint",
           "writable": false,
           "signer": false,
@@ -11452,6 +11540,49 @@
                   117,
                   108,
                   116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "reserve_domain"
+              },
+              {
+                "kind": "account",
+                "path": "protocol_fee_vault.asset_mint",
+                "account": "ProtocolFeeVault"
+              }
+            ]
+          }
+        },
+        {
+          "name": "domain_asset_ledger",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  111,
+                  109,
+                  97,
+                  105,
+                  110,
+                  95,
+                  97,
+                  115,
+                  115,
+                  101,
+                  116,
+                  95,
+                  108,
+                  101,
+                  100,
+                  103,
+                  101,
+                  114
                 ]
               },
               {

--- a/tests/genesis_live_bootstrap_config.test.ts
+++ b/tests/genesis_live_bootstrap_config.test.ts
@@ -213,6 +213,29 @@ test("Mainnet bootstrap break-glass override allows local-signer defaults but wa
   assert.match(captured, /BREAK-GLASS.*OMEGAX_ALLOW_LOCAL_SIGNER_FOR_MAINNET=1 active/);
 });
 
+test("Mainnet bootstrap break-glass override bypasses distinct-key validation when flag remains set", () => {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stderr as any).write = () => true;
+  let config: ReturnType<typeof loadGenesisLiveBootstrapConfig>;
+  try {
+    config = loadGenesisLiveBootstrapConfig({
+      governanceAuthority: GOVERNANCE,
+      env: {
+        ...baseMainnetEnv(),
+        OMEGAX_ALLOW_LOCAL_SIGNER_FOR_MAINNET: "1",
+        OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS: "1",
+      },
+    });
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = originalWrite;
+  }
+
+  assert.equal(config.roles.sponsor, GOVERNANCE);
+  assert.equal(config.roles.claimsOperator, GOVERNANCE);
+});
+
 test("OMEGAX_LIVE_CLUSTER_OVERRIDE=devnet bypasses the mainnet guard even on a mainnet RPC URL", () => {
   // Operator running an isolated rehearsal against a private mainnet-beta-
   // like cluster can opt out via the cluster override. The older opt-in

--- a/tests/protocol_withdraw_builders.test.ts
+++ b/tests/protocol_withdraw_builders.test.ts
@@ -34,6 +34,7 @@ const {
   derivePoolTreasuryVaultPda,
   derivePoolOracleFeeVaultPda,
   deriveDomainAssetVaultPda,
+  deriveDomainAssetLedgerPda,
   deriveDomainAssetVaultTokenAccountPda,
   deriveOracleProfilePda,
   getProgramId,
@@ -101,8 +102,8 @@ test("buildWithdrawProtocolFeeSplTx: programId, discriminator, authority, vault 
   });
   const ix = assertProtocolIxShape(tx, "withdraw_protocol_fee_spl", AUTHORITY);
   // Account order per on-chain struct: authority, governance, reserve_domain,
-  // protocol_fee_vault, domain_asset_vault, asset_mint, vault_token_account,
-  // recipient_token_account, token_program.
+  // protocol_fee_vault, domain_asset_vault, domain_asset_ledger, asset_mint,
+  // vault_token_account, recipient_token_account, token_program.
   assert.equal(ix.keys[1]!.pubkey.toBase58(), deriveProtocolGovernancePda().toBase58());
   assert.equal(ix.keys[2]!.pubkey.toBase58(), RESERVE_DOMAIN.toBase58());
   assert.equal(
@@ -113,15 +114,19 @@ test("buildWithdrawProtocolFeeSplTx: programId, discriminator, authority, vault 
     ix.keys[4]!.pubkey.toBase58(),
     deriveDomainAssetVaultPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
   );
-  assert.equal(ix.keys[5]!.pubkey.toBase58(), SPL_MINT.toBase58());
   assert.equal(
-    ix.keys[6]!.pubkey.toBase58(),
+    ix.keys[5]!.pubkey.toBase58(),
+    deriveDomainAssetLedgerPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
+  );
+  assert.equal(ix.keys[6]!.pubkey.toBase58(), SPL_MINT.toBase58());
+  assert.equal(
+    ix.keys[7]!.pubkey.toBase58(),
     deriveDomainAssetVaultTokenAccountPda({
       reserveDomain: RESERVE_DOMAIN,
       assetMint: SPL_MINT,
     }).toBase58(),
   );
-  assert.equal(ix.keys[7]!.pubkey.toBase58(), RECIPIENT_ATA.toBase58());
+  assert.equal(ix.keys[8]!.pubkey.toBase58(), RECIPIENT_ATA.toBase58());
 });
 
 test("buildWithdrawProtocolFeeSolTx: SOL rail uses NATIVE_SOL_MINT in vault seed", () => {
@@ -145,7 +150,7 @@ test("buildWithdrawProtocolFeeSolTx: SOL rail uses NATIVE_SOL_MINT in vault seed
   );
   assert.equal(ix.keys[4]!.pubkey.toBase58(), RECIPIENT_SYS.toBase58());
   // SOL rail does NOT thread DomainAssetVault — the vault PDA holds lamports
-  // directly. The struct only has 6 accounts vs 9 for the SPL variant.
+  // directly. The struct only has 6 accounts vs 10 for the SPL variant.
   assert.equal(ix.keys.length, 6);
 });
 
@@ -161,7 +166,8 @@ test("buildWithdrawPoolTreasurySplTx: pool-scoped vault PDA, asset_mint check", 
   });
   const ix = assertProtocolIxShape(tx, "withdraw_pool_treasury_spl", AUTHORITY);
   // Account order: authority, governance, liquidity_pool, pool_treasury_vault,
-  // domain_asset_vault, asset_mint, vault_token_account, recipient, token_program.
+  // domain_asset_vault, domain_asset_ledger, asset_mint, vault_token_account,
+  // recipient, token_program.
   assert.equal(ix.keys[2]!.pubkey.toBase58(), POOL.toBase58());
   assert.equal(
     ix.keys[3]!.pubkey.toBase58(),
@@ -170,6 +176,10 @@ test("buildWithdrawPoolTreasurySplTx: pool-scoped vault PDA, asset_mint check", 
   assert.equal(
     ix.keys[4]!.pubkey.toBase58(),
     deriveDomainAssetVaultPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[5]!.pubkey.toBase58(),
+    deriveDomainAssetLedgerPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
   );
 });
 
@@ -208,8 +218,8 @@ test("buildWithdrawPoolOracleFeeSplTx: oracle_profile + per-oracle vault PDA", (
   });
   const ix = assertProtocolIxShape(tx, "withdraw_pool_oracle_fee_spl", ORACLE);
   // Account order: authority, governance, liquidity_pool, oracle_profile,
-  // pool_oracle_fee_vault, domain_asset_vault, asset_mint, vault_token_account,
-  // recipient, token_program.
+  // pool_oracle_fee_vault, domain_asset_vault, domain_asset_ledger, asset_mint,
+  // vault_token_account, recipient, token_program.
   assert.equal(
     ix.keys[3]!.pubkey.toBase58(),
     deriveOracleProfilePda({ oracle: ORACLE }).toBase58(),
@@ -221,6 +231,10 @@ test("buildWithdrawPoolOracleFeeSplTx: oracle_profile + per-oracle vault PDA", (
       oracle: ORACLE,
       assetMint: SPL_MINT,
     }).toBase58(),
+  );
+  assert.equal(
+    ix.keys[6]!.pubkey.toBase58(),
+    deriveDomainAssetLedgerPda({ reserveDomain: RESERVE_DOMAIN, assetMint: SPL_MINT }).toBase58(),
   );
 });
 

--- a/tests/security/fee_accrual_guards_regression.test.ts
+++ b/tests/security/fee_accrual_guards_regression.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // CSO-2026-04-29 regressions for fee accrual:
-// configured premium and LP exit fees must fail closed when callers omit the
-// matching fee-vault account, and builders must preserve optional-account slots.
+// configured premium and LP entry/exit flows must always carry the canonical
+// fee-vault PDA instead of preserving legacy omission paths.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -23,7 +23,8 @@ const {
   buildDepositIntoCapitalClassTx,
   buildProcessRedemptionQueueTx,
   buildRecordPremiumPaymentTx,
-  getProgramId,
+  derivePoolTreasuryVaultPda,
+  deriveProtocolFeeVaultPda,
   listProtocolInstructionAccounts,
 } = protocolModule as typeof import("../../frontend/lib/protocol.ts");
 
@@ -52,18 +53,20 @@ function assertAccountCount(name: Parameters<typeof listProtocolInstructionAccou
   );
 }
 
-test("[CSO-2026-04-29] configured premium and LP exit fees require fee vault accounts", () => {
+test("[CSO-2026-04-29] fee-accrual handlers removed missing-vault compatibility branches", () => {
   const premiumBody = extractInstructionBody("record_premium_payment");
+  const depositBody = extractInstructionBody("deposit_into_capital_class");
   const redemptionBody = extractInstructionBody("process_redemption_queue");
 
-  assert.match(premiumBody, /protocol_fee_bps\s*==\s*0/);
-  assert.match(premiumBody, /FeeVaultRequiredForConfiguredFee/);
-  assert.match(redemptionBody, /class_fee_bps\s*==\s*0/);
-  assert.match(redemptionBody, /FeeVaultRequiredForConfiguredFee/);
+  assert.doesNotMatch(premiumBody, /protocol_fee_vault\.as_deref/);
+  assert.doesNotMatch(premiumBody, /protocol_fee_bps\s*==\s*0/);
+  assert.doesNotMatch(depositBody, /pool_treasury_vault\.as_deref/);
+  assert.doesNotMatch(depositBody, /class_fee_bps\s*==\s*0/);
+  assert.doesNotMatch(redemptionBody, /pool_treasury_vault\.as_deref/);
+  assert.doesNotMatch(redemptionBody, /class_fee_bps\s*==\s*0/);
 });
 
-test("[CSO-2026-04-29] fee-accrual builders preserve optional fee-vault slots", () => {
-  const programId = getProgramId().toBase58();
+test("[CSO-2026-04-29] fee-accrual builders derive canonical fee-vault PDAs", () => {
   const recentBlockhash = "11111111111111111111111111111111";
   const authority = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address;
   const recipient = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[1]!.address;
@@ -89,22 +92,13 @@ test("[CSO-2026-04-29] fee-accrual builders preserve optional fee-vault slots", 
     policySeriesAddress: fundingLine.policySeries ?? null,
   });
   assertAccountCount("record_premium_payment", recordPremium.instructions[0]!.keys.length);
-  assert.equal(recordPremium.instructions[0]!.keys[9]!.pubkey.toBase58(), programId);
-
-  const recordPremiumWithVault = buildRecordPremiumPaymentTx({
-    authority,
-    healthPlanAddress: plan.address,
-    reserveDomainAddress: plan.reserveDomain,
-    fundingLineAddress: fundingLine.address,
-    assetMint: fundingLine.assetMint,
-    sourceTokenAccountAddress: authority,
-    vaultTokenAccountAddress: recipient,
-    recentBlockhash,
-    amount: 1n,
-    policySeriesAddress: fundingLine.policySeries ?? null,
-    protocolFeeVaultAddress: recipient,
-  });
-  assert.equal(recordPremiumWithVault.instructions[0]!.keys[9]!.pubkey.toBase58(), recipient);
+  assert.equal(
+    recordPremium.instructions[0]!.keys[9]!.pubkey.toBase58(),
+    deriveProtocolFeeVaultPda({
+      reserveDomain: plan.reserveDomain,
+      assetMint: fundingLine.assetMint,
+    }).toBase58(),
+  );
 
   const deposit = buildDepositIntoCapitalClassTx({
     owner: authority,
@@ -119,7 +113,13 @@ test("[CSO-2026-04-29] fee-accrual builders preserve optional fee-vault slots", 
     shares: 1n,
   });
   assertAccountCount("deposit_into_capital_class", deposit.instructions[0]!.keys.length);
-  assert.equal(deposit.instructions[0]!.keys[8]!.pubkey.toBase58(), programId);
+  assert.equal(
+    deposit.instructions[0]!.keys[8]!.pubkey.toBase58(),
+    derivePoolTreasuryVaultPda({
+      liquidityPool: pool.address,
+      assetMint: pool.depositAssetMint,
+    }).toBase58(),
+  );
 
   const redemption = buildProcessRedemptionQueueTx({
     authority,
@@ -134,7 +134,13 @@ test("[CSO-2026-04-29] fee-accrual builders preserve optional fee-vault slots", 
     recipientTokenAccountAddress: recipient,
   });
   assertAccountCount("process_redemption_queue", redemption.instructions[0]!.keys.length);
-  assert.equal(redemption.instructions[0]!.keys[8]!.pubkey.toBase58(), programId);
+  assert.equal(
+    redemption.instructions[0]!.keys[8]!.pubkey.toBase58(),
+    derivePoolTreasuryVaultPda({
+      liquidityPool: pool.address,
+      assetMint: pool.depositAssetMint,
+    }).toBase58(),
+  );
   assert.equal(redemption.instructions[0]!.keys[10]!.pubkey.toBase58(), pool.address);
   assert.equal(redemption.instructions[0]!.keys[11]!.pubkey.toBase58(), recipient);
 });

--- a/tests/security/fee_recipient_guard_regression.test.ts
+++ b/tests/security/fee_recipient_guard_regression.test.ts
@@ -62,3 +62,19 @@ test("[CSO-2026-04-29] SPL and SOL fee withdrawals validate configured recipient
     );
   }
 });
+
+test("[CSO-2026-04-29] SPL fee withdrawals debit domain vault accounting", () => {
+  assert.match(programSource, /fn book_fee_withdrawal\s*\(/);
+
+  for (const handler of [
+    "withdraw_protocol_fee_spl",
+    "withdraw_pool_treasury_spl",
+    "withdraw_pool_oracle_fee_spl",
+  ]) {
+    assert.match(
+      extractInstructionBody(handler),
+      /book_fee_withdrawal\s*\(/,
+      `${handler} must debit DomainAssetVault and DomainAssetLedger funded balances after SPL fee outflow`,
+    );
+  }
+});

--- a/tests/security/fee_vault_required_regression.test.ts
+++ b/tests/security/fee_vault_required_regression.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// CSO-2026-04-29 regression: a configured pool entry fee must fail closed
-// when the caller omits the matching pool_treasury_vault account.
+// CSO-2026-04-29 regression: capital-class fee flows must always carry the
+// canonical pool_treasury_vault account. No legacy omission branch is allowed.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -29,19 +29,19 @@ function extractInstructionBody(name: string): string {
   return programSource.slice(startIdx, i);
 }
 
-test("[CSO-2026-04-29] deposit entry fees require the pool treasury vault when fee_bps is nonzero", () => {
+test("[CSO-2026-04-29] deposit entry fees require the pool treasury vault account unconditionally", () => {
   const body = extractInstructionBody("deposit_into_capital_class");
-  const missingVaultBranch = /let\s+entry_fee\s*=\s*if\s+let\s+Some\(vault\)[\s\S]+?\}\s+else\s+\{([\s\S]+?)\};/.exec(body);
 
-  assert.ok(missingVaultBranch, "deposit_into_capital_class must keep an explicit missing-vault branch");
+  assert.doesNotMatch(body, /if\s+let\s+Some\(vault\)\s*=\s*ctx\.accounts\.pool_treasury_vault/);
+  assert.doesNotMatch(body, /class_fee_bps\s*==\s*0/);
   assert.match(
-    missingVaultBranch[1],
-    /class_fee_bps\s*==\s*0/,
-    "missing pool_treasury_vault must only be allowed when class_fee_bps is zero",
+    programSource,
+    /pub pool_treasury_vault: Box<Account<'info, PoolTreasuryVault>>/,
+    "pool_treasury_vault must be a required Anchor account, not an optional legacy slot",
   );
   assert.match(
-    missingVaultBranch[1],
-    /FeeVaultRequiredForConfiguredFee/,
-    "missing pool_treasury_vault with nonzero entry fee must return the dedicated fee-vault error",
+    programSource,
+    /seeds = \[SEED_POOL_TREASURY_VAULT, liquidity_pool\.key\(\)\.as_ref\(\), liquidity_pool\.deposit_asset_mint\.as_ref\(\)\]/,
+    "pool_treasury_vault must be the canonical pool+asset PDA",
   );
 });

--- a/tests/security/settlement_fee_guards_regression.test.ts
+++ b/tests/security/settlement_fee_guards_regression.test.ts
@@ -2,8 +2,8 @@
 //
 // CSO-2026-04-29 regressions for claim settlement:
 // - linked obligations cannot be marked settled without an SPL outflow
-// - configured settlement fee bps cannot be bypassed by omitting fee vaults
-// - public builders must keep Anchor optional-account placeholders in order
+// - settlement must carry the canonical protocol fee vault account
+// - public builders must keep optional account placeholders in order
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -25,7 +25,7 @@ const {
   OBLIGATION_STATUS_SETTLED,
   buildSettleClaimCaseTx,
   buildSettleObligationTx,
-  getProgramId,
+  deriveProtocolFeeVaultPda,
   listProtocolInstructionAccounts,
 } = protocolModule as typeof import("../../frontend/lib/protocol.ts");
 
@@ -64,12 +64,14 @@ test("[CSO-2026-04-29] linked obligation settlement requires SPL outflow account
   assert.match(body, /token_program\.is_some\(\)/);
 });
 
-test("[CSO-2026-04-29] claim settlement fee vault omission is allowed only for zero bps", () => {
+test("[CSO-2026-04-29] claim settlement removed fee-vault omission compatibility branches", () => {
   const body = extractInstructionBody("settle_claim_case");
 
-  assert.match(body, /protocol_fee_bps\s*==\s*0/);
-  assert.match(body, /policy\.oracle_fee_bps\s*==\s*0/);
+  assert.doesNotMatch(body, /protocol_fee_bps\s*==\s*0/);
+  assert.doesNotMatch(body, /policy\.oracle_fee_bps\s*==\s*0/);
+  assert.match(body, /let protocol_fee_vault = &ctx\.accounts\.protocol_fee_vault/);
   assert.match(body, /vault\.oracle[\s\S]+ctx\.accounts\.claim_case\.adjudicator/);
+  assert.match(body, /\(None, Some\(_\)\)[\s\S]+FeeVaultRequiredForConfiguredFee/);
 });
 
 test("[CSO-2026-04-29] settlement builders preserve fee and outflow account slots", () => {
@@ -84,7 +86,6 @@ test("[CSO-2026-04-29] settlement builders preserve fee and outflow account slot
   const vaultTokenAccount = vault.address;
   const recipientTokenAccount = DEVNET_PROTOCOL_FIXTURE_STATE.wallets[1]!.address;
   const recentBlockhash = "11111111111111111111111111111111";
-  const programId = getProgramId().toBase58();
 
   const settleClaim = buildSettleClaimCaseTx({
     authority: DEVNET_PROTOCOL_FIXTURE_STATE.wallets[0]!.address,
@@ -105,7 +106,13 @@ test("[CSO-2026-04-29] settlement builders preserve fee and outflow account slot
     recipientTokenAccountAddress: recipientTokenAccount,
   });
   assertAccountCount("settle_claim_case", settleClaim.instructions[0]!.keys.length);
-  assert.equal(settleClaim.instructions[0]!.keys[14]!.pubkey.toBase58(), programId);
+  assert.equal(
+    settleClaim.instructions[0]!.keys[14]!.pubkey.toBase58(),
+    deriveProtocolFeeVaultPda({
+      reserveDomain: claim.reserveDomain,
+      assetMint: fundingLine.assetMint,
+    }).toBase58(),
+  );
   assert.equal(settleClaim.instructions[0]!.keys[17]!.pubkey.toBase58(), claim.memberPosition);
   assert.equal(settleClaim.instructions[0]!.keys[19]!.pubkey.toBase58(), vaultTokenAccount);
   assert.equal(settleClaim.instructions[0]!.keys[20]!.pubkey.toBase58(), recipientTokenAccount);


### PR DESCRIPTION
## Summary

- Address Codex review feedback across protocol fund-flow hardening, frontend builders, generated artifacts, docs, and regression tests.
- Remove legacy fee-vault omission compatibility paths now that the protocol is still devnet-only.
- Make protocol fee vault and pool treasury vault accounts canonical required PDAs in premium, settlement, deposit, and redemption flows.

## Validation

- `npm run anchor:idl`
- `npm run protocol:contract`
- `npm run test:node` (175 passed)
- `npm run verify:public`