### PR TITLE
Fix devnet actuarial BN balance parsing

### DIFF
--- a/scripts/support/devnet_founder_rehearsal_core.ts
+++ b/scripts/support/devnet_founder_rehearsal_core.ts
@@ -610,6 +610,14 @@ function toBigInt(value: BigNumberish | null | undefined): bigint {
   if (typeof value === "bigint") return value;
   if (typeof value === "number") return BigInt(Math.trunc(value));
   if (typeof value === "string" && value.trim()) return BigInt(value);
+  if (
+    value &&
+    typeof value === "object" &&
+    value.constructor?.name === "BN" &&
+    typeof (value as { toString?: unknown }).toString === "function"
+  ) {
+    return BigInt((value as { toString(): string }).toString());
+  }
   return 0n;
 }
 

--- a/tests/devnet_founder_rehearsal.test.ts
+++ b/tests/devnet_founder_rehearsal.test.ts
@@ -250,6 +250,84 @@ test("devnet founder chain inputs derive activated reserve while leaving pending
   assert.equal(inputs[0]!.reservedRaw, 25_000_000n);
 });
 
+test("devnet founder chain inputs parse Anchor BN balance sheets before actuarial math", () => {
+  class BN {
+    constructor(private readonly value: bigint) {}
+    toString() {
+      return this.value.toString();
+    }
+  }
+  const nowTs = 1_777_000_000;
+  const usdcMint = "USDC111111111111111111111111111111111111111";
+  const campaign = "Campaign111111111111111111111111111111111111";
+  const inputs = chainInputsFromSnapshot({
+    nowTs,
+    reserveDomain: "Reserve111111111111111111111111111111111111",
+    assets: [{
+      ...FOUNDER_ASSET_RAILS[0]!,
+      mint: usdcMint,
+    }],
+    ledgers: [{
+      address: "Ledger1111111111111111111111111111111111111",
+      reserveDomain: "Reserve111111111111111111111111111111111111",
+      assetMint: usdcMint,
+      sheet: {
+        funded: new BN(134_000_000n),
+        settled: new BN(25_000_000n),
+      },
+    }],
+    rails: [{
+      address: "Rail111111111111111111111111111111111111111",
+      reserveDomain: "Reserve111111111111111111111111111111111111",
+      assetMint: usdcMint,
+      oracleAuthority: "Oracle111111111111111111111111111111111111",
+      assetSymbol: "USDC",
+      role: 0,
+      payoutPriority: 1,
+      oracleSource: 3,
+      oracleFeedIdHex: "11".repeat(32),
+      maxStalenessSeconds: 86_400,
+      haircutBps: 0,
+      maxExposureBps: 10_000,
+      depositEnabled: true,
+      payoutEnabled: true,
+      capacityEnabled: true,
+      active: true,
+      lastPriceUsd1e8: 100_000_000n,
+      lastPriceConfidenceBps: 5,
+      lastPricePublishedAtTs: nowTs,
+      lastPriceSlot: 1n,
+      lastPriceProofHashHex: "22".repeat(32),
+      auditNonce: 1n,
+      bump: 255,
+    }],
+    commitmentPositions: [
+      commitmentPosition(campaign, usdcMint, 159_000_000n, COMMITMENT_POSITION_WATERFALL_RESERVE_ACTIVATED),
+    ],
+    obligations: [],
+  });
+
+  assert.equal(inputs[0]!.fundedRaw, 159_000_000n);
+  assert.equal(inputs[0]!.settledRaw, 25_000_000n);
+  const report = evaluateChainActuarialGate({
+    nowTs,
+    activatedTravel30Members: 1,
+    assets: inputs,
+    assumptions: {
+      seed: 1,
+      trials: 20,
+      baselineClaimFrequency: 0.04,
+      maxPayoutUsd: 3_000,
+      severityMinUsd: 75,
+      severityModeUsd: 650,
+      severityP95Usd: 2_250,
+      severityMaxUsd: 3_000,
+    },
+  });
+  assert.equal(report.assetRows[0]!.encumberedUsd, 25);
+  assert.equal(report.assetRows[0]!.freeUsd, 134);
+});
+
 test("devnet founder raw amount conversion handles stable, SOL, BTC, ETH, and OMEGAX rails", () => {
   const bySymbol = Object.fromEntries(FOUNDER_ASSET_RAILS.map((asset) => [asset.symbol, asset]));
   assert.equal(rawAmountForUsd({ usd: 159, decimals: bySymbol.USDC.decimals, priceUsd1e8: bySymbol.USDC.priceUsd1e8 }), 159_000_000n);


### PR DESCRIPTION
## Summary
- parses Anchor BN-like reserve sheet values before chain-sourced actuarial evaluation
- adds a regression proving settled claim amounts reduce free reserve in the Founder rehearsal report
- reran the devnet actuarial-only rehearsal and generated a corrected evidence bundle

## Validation
- node --import tsx --test tests/devnet_founder_rehearsal.test.ts
- npm run devnet:founder:rehearsal -- --execute --resume --actuarial-only

Corrected evidence bundle: artifacts/devnet-founder-rehearsal-2026-05-03T18-06-44-891Z/