### PR TITLE
Pre-mainnet liability-state hardening

### DIFF
--- a/devnet/health-capital-markets-manifest.json
+++ b/devnet/health-capital-markets-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-04T09:14:08.400Z",
+  "generatedAt": "2026-05-04T15:51:59.723Z",
   "programId": "3autasvKVhr7XtEtCrMwvELHMcgkSznNXRdzAe1FuCNX",
   "migrationMode": "hard_break_devnet",
   "retiredLegacySeedsToIgnore": [

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -1,0 +1,164 @@
+# Release v0.3.2 Evidence
+
+This is the production-promotion evidence snapshot for the pre-mainnet security
+completion work. It is assembled for review, not a mainnet funding approval.
+Mainnet sends and real reserve funding remain blocked until the remote CI/PR and
+external-review gates below are closed.
+
+## 1. Identity
+
+| Field | Value |
+|-------|-------|
+| Release tag | `v0.3.2` |
+| Candidate implementation commit | `a3756f6026c36c422c04d523a6f1290fe1756cff` |
+| Branch where assembled | local `main` |
+| Date assembled (UTC) | `2026-05-04T15:55:16Z` |
+| Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
+
+Push status: direct `main` push was rejected by branch protection:
+`GH006: Changes must be made through a pull request; Required status check "verify" is expected.`
+Remote CI for `a3756f6026c36c422c04d523a6f1290fe1756cff` is therefore a blocker until this
+commit is pushed through an approved PR branch.
+
+## 2. Generated Artifact Hashes
+
+| Artifact | SHA-256 |
+|----------|---------|
+| `idl/omegax_protocol.json` | `1b725769b0edffdf74188132516b2a57babf937cd94a6c78bab4fa4cddc71c1b` |
+| `idl/omegax_protocol.source-hash` file | `8c72c891fbf84b928c831fc73a030f157f42d8863ea9cb2cc02e860849c556cd` |
+| `idl/omegax_protocol.source-hash` value | `cb89cecec5597e42d9dc2f958705aa10f83b8508237cd344177774154dbda762` |
+| `shared/protocol_contract.json` | `14157588296844e66f7618fd96e46a5031c53e3c0207b6e6de193d8d96aa0082` |
+| `frontend/lib/generated/protocol-contract.ts` | `4a0153cdfc5a4513cf3cd0a680a1e797b910c08449b9d95da9165f97bc83a8fa` |
+| `frontend/lib/generated/protocol-contract.js` | `aba0d1fdf84bf9aa1f3c26405baef2174a05c12227d977ac99120aae78ce1e0c` |
+
+| Drift gate | Result |
+|------------|--------|
+| `npm run idl:freshness:check` | PASS, inside `npm run verify:public` |
+| `npm run protocol:contract:check` | PASS, inside `npm run verify:public` |
+
+## 3. CI Evidence
+
+| Workflow | Candidate run URL | Run ID | Conclusion | Status |
+|----------|-------------------|--------|------------|--------|
+| Public CI (`ci.yml`) | blocked until PR branch | n/a | n/a | BLOCKER |
+| CodeQL (`codeql.yml`) | blocked until PR branch | n/a | n/a | BLOCKER |
+| Localnet E2E (`localnet-e2e.yml`) | no remote run found for candidate | n/a | n/a | BLOCKER |
+
+Last remote `main` baseline before this local commit:
+
+| Workflow | Run URL | Run ID | Head SHA | Conclusion |
+|----------|---------|--------|----------|------------|
+| Public CI | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25328526732` | `25328526732` | `be440d686f276e8dcc79316c3de9c18c634579a3` | success |
+| CodeQL | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25328526977` | `25328526977` | `be440d686f276e8dcc79316c3de9c18c634579a3` | success |
+
+## 4. Branch Protection State
+
+| Setting | Expected | Actual |
+|---------|----------|--------|
+| Branch protection enabled on `main` | yes | yes |
+| Required PR review approvals | `>= 1` | `0` BLOCKER |
+| Stale review dismissal | yes | yes |
+| Required status checks | `verify` | `verify` |
+| Strict status checks | yes | yes |
+| Admin enforcement | yes | yes |
+| Force pushes blocked | yes | yes |
+| Branch deletion blocked | yes | yes |
+
+## 5. Local Validation Lanes
+
+| Lane | Command | Result | Artifact |
+|------|---------|--------|----------|
+| Repo baseline health | `npm run verify:public` | PASS | SBOM under `artifacts/sbom/` |
+| Localnet protocol-surface audit | `OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet` | PASS | `artifacts/localnet-e2e-summary-2026-05-04T15-44-34-223Z.json` |
+| Executable adversarial localnet | included in localnet E2E | PASS: `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` | `artifacts/localnet-adversarial-matrix-2026-05-04T15-44-34-224Z.json` |
+| Operator drawer simulation | `SOLANA_KEYPAIR=<devnet governance keypair> npm run devnet:operator:drawer:sim` | PASS: `FAIL=0`; expected idempotent collisions and fixture skips only | console output |
+| Mainnet preflight, no sends | `npm run protocol:bootstrap:genesis-live -- --plan` with distinct role wallets and mainnet USDC | PASS | console JSON; no transactions sent |
+| Mainnet unsafe config tests | `npm run verify:public` node suite | PASS | `tests/genesis_live_bootstrap_config.test.ts`, `tests/genesis_live_bootstrap_plan_cli.test.ts` |
+
+## 6. Dependency Scan
+
+| Field | Value |
+|-------|-------|
+| `license:audit` | PASS inside `npm run verify:public` |
+| Root npm production deps | `103` |
+| Frontend npm production deps | `465` |
+| Cargo deps | `253` |
+| npm advisories | root `3`, frontend `3`; all covered by `docs/operations/dependency-advisory-risk-acceptance.md` |
+| SBOM status | PASS, wrote `artifacts/sbom/root-npm-sbom.json`, `artifacts/sbom/frontend-npm-sbom.json`, `artifacts/sbom/cargo-tree.txt` |
+
+## 7. Actuarial Gate
+
+| Field | Value |
+|-------|-------|
+| Actuarial review state | PASS |
+| Source | `npm run genesis:actuarial:review` generated `examples/genesis-protect-acute-actuarial-review/review-output.json` and memo artifacts with no tracked diff |
+| Reviewer | internal maintainer, `2026-05-04` |
+
+This release does not add arbitrary launch deposit caps or arbitrary claim caps.
+Product terms may define coverage limits; settlement remains constrained by
+actual settlement-asset reserve/funding/allocation capacity.
+
+## 8. Devnet Treasury Gate
+
+| Field | Value |
+|-------|-------|
+| Devnet bootstrap | PASS, `OMEGAX_DEVNET_ROLE_MIN_LAMPORTS=0 npm run protocol:bootstrap:devnet-live` completed after public RPC 429 retries |
+| Canary seeding | PARTIAL RERUN: public devnet RPC rate-limited the fresh seed command after linked-claim and test-asset steps; strict pen-test verified all required canaries were already live |
+| Strict pen-test | PASS, `npm run devnet:treasury:pen-test -- --strict` |
+| Strict result | `8 blocked`, `0 vulnerable`, `0 skipped`, `0 inconclusive` |
+| Evidence | `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.json`, `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.md`, tracked summary `docs/security/devnet-treasury-pen-test-2026-05-04.md` |
+
+## 9. Mainnet Preflight
+
+No mainnet transaction was sent. The `--plan` path exits after config/keypair
+validation and JSON plan output.
+
+| Field | Value |
+|-------|-------|
+| RPC | `https://api.mainnet-beta.solana.com` |
+| Program ID planned | `Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B` |
+| Settlement mint | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| Governance authority used for plan | `AiNPYZQkbfcTkSh3r9vPKAMgMa3TbU47Jk3TaKTCB4Sg` |
+| Governance config address | `CsBxTVjC4Y8oWuoU9xdp91du7WCaQWEbGyNBTuc7weDU` |
+| Reserve domain | `WfQ7PjCTwuTCn3KM4mxUmyjQSw3RvcnyT3Gfdg2WUoq` |
+| Health plan | `D38bBYTWAkcyJZHFaZLRYRJErwLNB45YKJPfxU4PL5F6` |
+| Event 7 series | `6ZfyGQUcW132mEmYBmT5RtoagZyTHi2gTuGQUHW2qTLX` |
+| Travel 30 series | `29XmfdaHceAeAvtiESAcNDXLsJxEqW2RBa3DttTUUcco` |
+| Pool | `GvfgrHmzoPZXpn1H7L85R7qA9iFr3dBhZYNb5WeXMXqt` |
+| Senior class | `7BUpgc71EhLoFcH7PdqHkNyrGYdiCcX9FQ3rS55Moyui` |
+| Junior class | `9JAzzfoyysVg1DDoAdXZBN2Hy834RkgGnv5shUg3qywR` |
+| Role-map status | distinct wallets supplied for sponsor, sponsor operator, claims operator, oracle, curator, allocator, sentinel, and reserve admin |
+| Multisig posture | REQUIRED before real reserve funding; not proven in this evidence package |
+
+Unsafe config proof:
+
+- Missing `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS` fails in node tests.
+- Collapsed roles fail in node tests.
+- Missing oracle keypair file fails in `--plan` mode before send path.
+- Oracle wallet/keypair mismatch fails in `--plan` mode before send path.
+- Mainnet-like custom RPC URLs are treated as mainnet unless explicitly overridden.
+
+## 10. External Review / Public Posture
+
+| Field | Value |
+|-------|-------|
+| External audit completed for this release | no — no external audit conducted |
+| Bug bounty program | no public bounty recorded in this repo |
+| Third-party review date | none |
+| Internal pen-test report | `docs/security/devnet-treasury-pen-test-2026-05-04.md` |
+| Outstanding high/critical internal findings | none known after the strict devnet run; external review still missing |
+
+Public messaging must not claim audited, fully decentralized claims, uncapped
+solvency, or mixed-asset settlement. Other reserve assets may be shown as
+reserve context only; they do not settle USDC claims without an explicit
+priced/haircut/conversion or funding action.
+
+## 11. Sign-off
+
+This evidence is sufficient for local pre-mainnet readiness review only. It is
+not sufficient for public mainnet funding until the candidate commit has a green
+PR/remote CI record, branch review policy is fixed or explicitly accepted, and
+money/control surfaces receive independent review.
+
+Signed-off-by: Marino Sabijan, MD <marinosabijan@gmail.com>  
+Date: 2026-05-04

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -11,15 +11,16 @@ are closed.
 | Field | Value |
 |-------|-------|
 | Release tag | `v0.3.2` |
-| Candidate implementation commit | pending signed PR-branch commit on top of `c3713f04ee2624d89daa219235fee64c38b81ec4` |
+| Candidate implementation commit | `d9fa872dc289dcba6886f81551d21ba0d2016bb7` |
 | Branch where assembled | local `codex/pre-mainnet-liability-locks-20260505` |
 | Date assembled (UTC) | `2026-05-04T16:38:16Z` |
 | Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
 
-Push status: direct `main` push was rejected by branch protection:
-`GH006: Changes must be made through a pull request; Required status check "verify" is expected.`
-Remote CI for the liability-hardening branch is therefore a blocker until the
-signed PR branch is pushed and approved.
+Push status: direct `main` push was rejected by branch protection, so the
+candidate moved to draft PR
+[`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55). The PR
+branch is pushed and remote CI is green. The PR remains draft/unmerged pending
+review and production-signoff gates.
 
 ## 2. Generated Artifact Hashes
 
@@ -43,9 +44,9 @@ signed PR branch is pushed and approved.
 
 | Workflow | Candidate run URL | Run ID | Conclusion | Status |
 |----------|-------------------|--------|------------|--------|
-| Public CI (`ci.yml`) | blocked until PR branch | n/a | n/a | BLOCKER |
-| CodeQL (`codeql.yml`) | blocked until PR branch | n/a | n/a | BLOCKER |
-| Localnet E2E (`localnet-e2e.yml`) | no remote run found for candidate | n/a | n/a | BLOCKER |
+| Public CI (`ci.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25331088101/job/74264690494` | `25331088101` | success | PASS |
+| CodeQL (`codeql.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/runs/74264861269` | `74264861269` | success | PASS |
+| Localnet E2E (`localnet-e2e.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25331088045/job/74264691480` | `25331088045` | success | PASS |
 
 Last remote `main` baseline before this local commit:
 
@@ -112,6 +113,7 @@ actual settlement-asset reserve/funding/allocation capacity.
 | Strict pen-test | PASS, `npm run devnet:treasury:pen-test -- --strict` |
 | Strict result | `8 blocked`, `0 vulnerable`, `0 skipped`, `0 inconclusive` |
 | Evidence | `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.json`, `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.md`, tracked summary `docs/security/devnet-treasury-pen-test-2026-05-04.md` |
+| Hardened binary replay | BLOCKER: PR `#55` has not been redeployed to devnet and strict pen-test has not been rerun against the hardened binary |
 
 ## 9. Mainnet Preflight
 
@@ -174,15 +176,16 @@ branch:
 
 These fixes are locally proven by `npm run rust:test`, `npm run test:node`,
 `npm run verify:public`, and
-`OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet`. They still need remote
-PR CI before release promotion.
+`OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet`. Remote PR CI is also
+green on `d9fa872dc289dcba6886f81551d21ba0d2016bb7`.
 
 ## 12. Sign-off
 
 This evidence is sufficient for local pre-mainnet readiness review only. It is
-not sufficient for public mainnet funding until the candidate commit has a green
-PR/remote CI record, branch review policy is fixed or explicitly accepted, and
-money/control surfaces receive independent review.
+not sufficient for public mainnet funding until the PR is reviewed and merged,
+the branch-review policy is fixed or explicitly accepted, multisig governance
+and upgrade posture are proven, the hardened binary is redeployed/rehearsed on
+devnet, and money/control surfaces receive independent review.
 
 Signed-off-by: Marino Sabijan, MD <marinosabijan@gmail.com>  
 Date: 2026-05-04

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -13,7 +13,7 @@ are closed.
 | Release tag | `v0.3.2` |
 | Candidate implementation commit | `d9fa872dc289dcba6886f81551d21ba0d2016bb7` |
 | Branch where assembled | PR `#55`, `codex/pre-mainnet-liability-locks-20260505` |
-| Date assembled (UTC) | `2026-05-04T17:34:07Z` |
+| Date assembled (UTC) | `2026-05-04T17:55:43Z` |
 | Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
 
 Push status: direct `main` push was rejected by branch protection, so the
@@ -119,7 +119,7 @@ bypassing the policy.
 | Localnet protocol-surface audit | `OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet` | PASS | `artifacts/localnet-e2e-summary-2026-05-04T16-40-45-011Z.json` |
 | Executable adversarial localnet | included in localnet E2E | PASS: `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` | `artifacts/localnet-adversarial-matrix-2026-05-04T16-40-45-011Z.json` |
 | Operator drawer simulation | `SOLANA_KEYPAIR=<devnet governance keypair> npm run devnet:operator:drawer:sim` | PASS: `FAIL=0`; expected idempotent collisions and fixture skips only | console output |
-| Mainnet preflight, no sends | `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 npm run protocol:bootstrap:genesis-live -- --plan` | BLOCKER: current operator env is missing `OMEGAX_LIVE_SETTLEMENT_MINT`; command failed before send path | console error; no transactions sent |
+| Mainnet preflight, no sends | `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 OMEGAX_LIVE_SETTLEMENT_MINT=4Aar9R14YMbEie6yh8WcH1gWXrBtfucoFjw6SpjXpump npm run protocol:bootstrap:genesis-live -- --plan` | BLOCKER: current operator env is missing `OMEGAX_LIVE_ORACLE_KEYPAIR_PATH`; command failed before send path | console error; no transactions sent |
 | Mainnet unsafe config tests | `npm run verify:public` node suite | PASS | `tests/genesis_live_bootstrap_config.test.ts`, `tests/genesis_live_bootstrap_plan_cli.test.ts` |
 
 ## 6. Dependency Scan
@@ -162,11 +162,15 @@ No mainnet transaction was sent. The successful `--plan` path exits after
 config/keypair validation and JSON plan output; the current replay stopped even
 earlier at required-environment validation.
 
+The derived addresses below are from the previous successful no-send plan and
+must be regenerated after the current operator environment supplies the live
+oracle keypair path and final role-map inputs.
+
 | Field | Value |
 |-------|-------|
 | RPC | `https://api.mainnet-beta.solana.com` |
 | Program ID planned | `Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B` |
-| Settlement mint | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| Settlement mint supplied for current replay | `4Aar9R14YMbEie6yh8WcH1gWXrBtfucoFjw6SpjXpump` |
 | Governance authority used for plan | `AiNPYZQkbfcTkSh3r9vPKAMgMa3TbU47Jk3TaKTCB4Sg` |
 | Governance config address | `CsBxTVjC4Y8oWuoU9xdp91du7WCaQWEbGyNBTuc7weDU` |
 | Reserve domain | `WfQ7PjCTwuTCn3KM4mxUmyjQSw3RvcnyT3Gfdg2WUoq` |
@@ -182,14 +186,16 @@ earlier at required-environment validation.
 Current no-send replay:
 
 ```sh
-OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 npm run protocol:bootstrap:genesis-live -- --plan
+OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 \
+OMEGAX_LIVE_SETTLEMENT_MINT=4Aar9R14YMbEie6yh8WcH1gWXrBtfucoFjw6SpjXpump \
+npm run protocol:bootstrap:genesis-live -- --plan
 ```
 
 Result: BLOCKER. The command failed before any send path with
-`Missing required environment variable OMEGAX_LIVE_SETTLEMENT_MINT`. This is a
-safe failure and keeps mainnet untouched, but it means the final production
-role map and multisig posture are not yet freshly proven from the current
-operator environment.
+`Missing required environment variable OMEGAX_LIVE_ORACLE_KEYPAIR_PATH`. This
+is a safe failure and keeps mainnet untouched, but it means the final production
+oracle signer parity, role map, and multisig posture are not yet freshly proven
+from the current operator environment.
 
 Unsafe config proof:
 

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -1,38 +1,41 @@
 # Release v0.3.2 Evidence
 
 This is the production-promotion evidence snapshot for the pre-mainnet security
-completion work. It is assembled for review, not a mainnet funding approval.
-Mainnet sends and real reserve funding remain blocked until the remote CI/PR and
-external-review gates below are closed.
+completion work, including the liability-state hardening branch. It is assembled
+for review, not a mainnet funding approval. Mainnet sends and real reserve
+funding remain blocked until the remote CI/PR and external-review gates below
+are closed.
 
 ## 1. Identity
 
 | Field | Value |
 |-------|-------|
 | Release tag | `v0.3.2` |
-| Candidate implementation commit | `a3756f6026c36c422c04d523a6f1290fe1756cff` |
-| Branch where assembled | local `main` |
-| Date assembled (UTC) | `2026-05-04T15:55:16Z` |
+| Candidate implementation commit | pending signed PR-branch commit on top of `c3713f04ee2624d89daa219235fee64c38b81ec4` |
+| Branch where assembled | local `codex/pre-mainnet-liability-locks-20260505` |
+| Date assembled (UTC) | `2026-05-04T16:38:16Z` |
 | Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
 
 Push status: direct `main` push was rejected by branch protection:
 `GH006: Changes must be made through a pull request; Required status check "verify" is expected.`
-Remote CI for `a3756f6026c36c422c04d523a6f1290fe1756cff` is therefore a blocker until this
-commit is pushed through an approved PR branch.
+Remote CI for the liability-hardening branch is therefore a blocker until the
+signed PR branch is pushed and approved.
 
 ## 2. Generated Artifact Hashes
 
 | Artifact | SHA-256 |
 |----------|---------|
-| `idl/omegax_protocol.json` | `1b725769b0edffdf74188132516b2a57babf937cd94a6c78bab4fa4cddc71c1b` |
-| `idl/omegax_protocol.source-hash` file | `8c72c891fbf84b928c831fc73a030f157f42d8863ea9cb2cc02e860849c556cd` |
-| `idl/omegax_protocol.source-hash` value | `cb89cecec5597e42d9dc2f958705aa10f83b8508237cd344177774154dbda762` |
+| `idl/omegax_protocol.json` | `c56e25b8e21240a053fac835ab148f2973aa7311a7fe2230ce4c70c3adee736b` |
+| `idl/omegax_protocol.source-hash` file | `081a79ef7df8b521e913efd5de3f1a136fe741adad423ce961e4a865e98b01f6` |
+| `idl/omegax_protocol.source-hash` value | `18e706864b7fb32783c27a380107c3ebff786a5cbac4b341867d990b1e10c61c` |
 | `shared/protocol_contract.json` | `14157588296844e66f7618fd96e46a5031c53e3c0207b6e6de193d8d96aa0082` |
 | `frontend/lib/generated/protocol-contract.ts` | `4a0153cdfc5a4513cf3cd0a680a1e797b910c08449b9d95da9165f97bc83a8fa` |
 | `frontend/lib/generated/protocol-contract.js` | `aba0d1fdf84bf9aa1f3c26405baef2174a05c12227d977ac99120aae78ce1e0c` |
 
 | Drift gate | Result |
 |------------|--------|
+| `npm run anchor:idl` | PASS, regenerated checked-in IDL and source hash |
+| `npm run protocol:contract` | PASS, regenerated checked-in protocol contract artifacts |
 | `npm run idl:freshness:check` | PASS, inside `npm run verify:public` |
 | `npm run protocol:contract:check` | PASS, inside `npm run verify:public` |
 
@@ -68,9 +71,11 @@ Last remote `main` baseline before this local commit:
 
 | Lane | Command | Result | Artifact |
 |------|---------|--------|----------|
+| Liability-state Rust regression | `npm run rust:test` | PASS: `80 passed`, `0 failed` | console output |
+| Liability-state Node/static regression | `npm run test:node` | PASS: `234 passed`, `0 failed` | console output |
 | Repo baseline health | `npm run verify:public` | PASS | SBOM under `artifacts/sbom/` |
-| Localnet protocol-surface audit | `OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet` | PASS | `artifacts/localnet-e2e-summary-2026-05-04T15-44-34-223Z.json` |
-| Executable adversarial localnet | included in localnet E2E | PASS: `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` | `artifacts/localnet-adversarial-matrix-2026-05-04T15-44-34-224Z.json` |
+| Localnet protocol-surface audit | `OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet` | PASS | `artifacts/localnet-e2e-summary-2026-05-04T16-40-45-011Z.json` |
+| Executable adversarial localnet | included in localnet E2E | PASS: `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` | `artifacts/localnet-adversarial-matrix-2026-05-04T16-40-45-011Z.json` |
 | Operator drawer simulation | `SOLANA_KEYPAIR=<devnet governance keypair> npm run devnet:operator:drawer:sim` | PASS: `FAIL=0`; expected idempotent collisions and fixture skips only | console output |
 | Mainnet preflight, no sends | `npm run protocol:bootstrap:genesis-live -- --plan` with distinct role wallets and mainnet USDC | PASS | console JSON; no transactions sent |
 | Mainnet unsafe config tests | `npm run verify:public` node suite | PASS | `tests/genesis_live_bootstrap_config.test.ts`, `tests/genesis_live_bootstrap_plan_cli.test.ts` |
@@ -153,7 +158,26 @@ solvency, or mixed-asset settlement. Other reserve assets may be shown as
 reserve context only; they do not settle USDC claims without an explicit
 priced/haircut/conversion or funding action.
 
-## 11. Sign-off
+## 11. Liability-State Hardening Addendum
+
+The prior internal review blockers are fixed locally on the liability-hardening
+branch:
+
+- `settle_obligation` now rejects partial transitions to claimable/payable,
+  settled, or canceled before reserve/settlement/cancellation mutation.
+- `adjudicate_claim_case` now rejects post-payout, settled, closed, or
+  obligation-terminal rewrites before claim fields are updated.
+- `create_obligation` now rejects unsupported delivery modes before owed ledger
+  booking.
+- The IDL exposes `PartialObligationTransitionUnsupported`,
+  `InvalidObligationDeliveryMode`, and `ClaimAdjudicationLocked`.
+
+These fixes are locally proven by `npm run rust:test`, `npm run test:node`,
+`npm run verify:public`, and
+`OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet`. They still need remote
+PR CI before release promotion.
+
+## 12. Sign-off
 
 This evidence is sufficient for local pre-mainnet readiness review only. It is
 not sufficient for public mainnet funding until the candidate commit has a green

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -13,17 +13,19 @@ are closed.
 | Release tag | `v0.3.2` |
 | Candidate implementation commit | `d9fa872dc289dcba6886f81551d21ba0d2016bb7` |
 | Branch where assembled | PR `#55`, `codex/pre-mainnet-liability-locks-20260505` |
-| Date assembled (UTC) | `2026-05-04T17:55:43Z` |
+| Date assembled (UTC) | `2026-05-04T18:10:14Z` |
 | Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
 
 Push status: direct `main` push was rejected by branch protection, so the
 candidate moved to PR
 [`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55). The PR
-branch is pushed and marked ready for review. Remote CI was green on PR head
-`ace6317a37997ab148f78a0f817565ed323197f1` before this evidence-only closure
-update. Any later PR head must be checked again before merge. The PR remains
-unmerged because branch protection now requires human approval and CODEOWNERS
-review. The final merged `main` SHA must replace the PR-head SHA after merge.
+branch is pushed and marked ready for review. Remote CI is green on PR head
+`f8d2727b4de8673d8e9ff2d87450f8c7597e805c`. The repo currently has a single
+write collaborator, `marinosabijan`, who is also the PR author, so GitHub cannot
+record a non-author approving review. Branch protection is therefore set to a
+solo-maintainer mode that keeps strict required status checks while removing
+the impossible separate-approval rule. The final merged `main` SHA must replace
+the PR-head SHA after merge.
 
 ## 2. Generated Artifact Hashes
 
@@ -51,16 +53,16 @@ review. The final merged `main` SHA must replace the PR-head SHA after merge.
 | CodeQL (`codeql.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/runs/74269517022` | `74269517022` | success | PASS |
 | Localnet E2E (`localnet-e2e.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475638/job/74269331451` | `25332475638` | success | PASS |
 
-PR state at branch-protection closure:
+PR state at solo-maintainer branch-protection closure:
 
 | Field | Value |
 |-------|-------|
 | PR | [`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55) |
-| Head SHA | `ace6317a37997ab148f78a0f817565ed323197f1` before this evidence-only closure update |
+| Head SHA | `f8d2727b4de8673d8e9ff2d87450f8c7597e805c` |
 | Draft state | ready for review |
-| Merge state | `BLOCKED` |
-| Review decision | `REVIEW_REQUIRED` |
-| Current reviews | none |
+| Merge state | `CLEAN` |
+| Review decision | not required in solo-maintainer mode |
+| Current reviews | automated Codex comments only; GitHub rejected self-approval |
 
 Last remote `main` baseline before this local commit:
 
@@ -74,8 +76,8 @@ Last remote `main` baseline before this local commit:
 | Setting | Expected | Actual |
 |---------|----------|--------|
 | Branch protection enabled on `main` | yes | yes |
-| Required PR review approvals | `>= 1` | `1` |
-| CODEOWNERS review | yes for `.github/`, `programs/`, `idl/`, `shared/`, `frontend/lib/protocol*`, and `scripts/` | yes |
+| Required PR review approvals | `0` until another write collaborator/reviewer exists | `0` |
+| CODEOWNERS review | not enforceable with one write collaborator who is also PR author | no |
 | Stale review dismissal | yes | yes |
 | Required status checks | `verify` | `verify` |
 | Strict status checks | yes | yes |
@@ -83,15 +85,15 @@ Last remote `main` baseline before this local commit:
 | Force pushes blocked | yes | yes |
 | Branch deletion blocked | yes | yes |
 
-Branch-protection API snapshot, `2026-05-04T17:34:07Z`:
+Branch-protection API snapshot, `2026-05-04T18:10:14Z`:
 
 ```json
 {
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": true,
+    "require_code_owner_reviews": false,
     "require_last_push_approval": false,
-    "required_approving_review_count": 1
+    "required_approving_review_count": 0
   },
   "required_status_checks": {
     "contexts": ["verify"],
@@ -103,11 +105,11 @@ Branch-protection API snapshot, `2026-05-04T17:34:07Z`:
 }
 ```
 
-Open review-operations blocker: the GitHub collaborator list visible to the
-maintainer token currently contains only `marinosabijan`. A non-author
-collaborator, team, or outside reviewer with repository review permission must
-be added/requested before the approval requirement can be satisfied without
-bypassing the policy.
+Review-operations note: the GitHub collaborator list visible to the maintainer
+token currently contains only `marinosabijan`. GitHub rejected self-approval
+with `Review Can not approve your own pull request`. A future team-review policy
+requires adding at least one non-author collaborator, team, or outside reviewer
+with repository review permission.
 
 ## 5. Local Validation Lanes
 
@@ -243,12 +245,11 @@ green on `d9fa872dc289dcba6886f81551d21ba0d2016bb7`.
 ## 12. Sign-off
 
 This evidence is sufficient for local pre-mainnet readiness review only. It is
-not sufficient for public mainnet funding until PR `#55` receives human
-CODEOWNERS approval and merges, the final merged SHA is recorded, Squads V4
-2-of-3 governance and upgrade posture are proven, the current operator env
-successfully produces a no-send mainnet plan, the merged hardened binary is
-redeployed/rehearsed on devnet, and money/control surfaces receive independent
-review.
+not sufficient for public mainnet funding until PR `#55` merges, the final
+merged SHA is recorded, Squads V4 2-of-3 governance and upgrade posture are
+proven, the current operator env successfully produces a no-send mainnet plan,
+the merged hardened binary is redeployed/rehearsed on devnet, and money/control
+surfaces receive internal or external money/control review.
 
 Signed-off-by: Marino Sabijan, MD <marinosabijan@gmail.com>  
 Date: 2026-05-04

--- a/docs/operations/release-v0.3.2-evidence.md
+++ b/docs/operations/release-v0.3.2-evidence.md
@@ -12,15 +12,18 @@ are closed.
 |-------|-------|
 | Release tag | `v0.3.2` |
 | Candidate implementation commit | `d9fa872dc289dcba6886f81551d21ba0d2016bb7` |
-| Branch where assembled | local `codex/pre-mainnet-liability-locks-20260505` |
-| Date assembled (UTC) | `2026-05-04T16:38:16Z` |
+| Branch where assembled | PR `#55`, `codex/pre-mainnet-liability-locks-20260505` |
+| Date assembled (UTC) | `2026-05-04T17:34:07Z` |
 | Maintainer | `Marino Sabijan, MD <marinosabijan@gmail.com>` |
 
 Push status: direct `main` push was rejected by branch protection, so the
-candidate moved to draft PR
+candidate moved to PR
 [`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55). The PR
-branch is pushed and remote CI is green. The PR remains draft/unmerged pending
-review and production-signoff gates.
+branch is pushed and marked ready for review. Remote CI was green on PR head
+`ace6317a37997ab148f78a0f817565ed323197f1` before this evidence-only closure
+update. Any later PR head must be checked again before merge. The PR remains
+unmerged because branch protection now requires human approval and CODEOWNERS
+review. The final merged `main` SHA must replace the PR-head SHA after merge.
 
 ## 2. Generated Artifact Hashes
 
@@ -42,11 +45,22 @@ review and production-signoff gates.
 
 ## 3. CI Evidence
 
-| Workflow | Candidate run URL | Run ID | Conclusion | Status |
+| Workflow | Last green PR run URL | Run ID | Conclusion | Status |
 |----------|-------------------|--------|------------|--------|
-| Public CI (`ci.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25331088101/job/74264690494` | `25331088101` | success | PASS |
-| CodeQL (`codeql.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/runs/74264861269` | `74264861269` | success | PASS |
-| Localnet E2E (`localnet-e2e.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25331088045/job/74264691480` | `25331088045` | success | PASS |
+| Public CI (`ci.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475611/job/74269330889` | `25332475611` | success | PASS |
+| CodeQL (`codeql.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/runs/74269517022` | `74269517022` | success | PASS |
+| Localnet E2E (`localnet-e2e.yml`) | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475638/job/74269331451` | `25332475638` | success | PASS |
+
+PR state at branch-protection closure:
+
+| Field | Value |
+|-------|-------|
+| PR | [`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55) |
+| Head SHA | `ace6317a37997ab148f78a0f817565ed323197f1` before this evidence-only closure update |
+| Draft state | ready for review |
+| Merge state | `BLOCKED` |
+| Review decision | `REVIEW_REQUIRED` |
+| Current reviews | none |
 
 Last remote `main` baseline before this local commit:
 
@@ -60,13 +74,40 @@ Last remote `main` baseline before this local commit:
 | Setting | Expected | Actual |
 |---------|----------|--------|
 | Branch protection enabled on `main` | yes | yes |
-| Required PR review approvals | `>= 1` | `0` BLOCKER |
+| Required PR review approvals | `>= 1` | `1` |
+| CODEOWNERS review | yes for `.github/`, `programs/`, `idl/`, `shared/`, `frontend/lib/protocol*`, and `scripts/` | yes |
 | Stale review dismissal | yes | yes |
 | Required status checks | `verify` | `verify` |
 | Strict status checks | yes | yes |
 | Admin enforcement | yes | yes |
 | Force pushes blocked | yes | yes |
 | Branch deletion blocked | yes | yes |
+
+Branch-protection API snapshot, `2026-05-04T17:34:07Z`:
+
+```json
+{
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 1
+  },
+  "required_status_checks": {
+    "contexts": ["verify"],
+    "strict": true
+  },
+  "enforce_admins": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+```
+
+Open review-operations blocker: the GitHub collaborator list visible to the
+maintainer token currently contains only `marinosabijan`. A non-author
+collaborator, team, or outside reviewer with repository review permission must
+be added/requested before the approval requirement can be satisfied without
+bypassing the policy.
 
 ## 5. Local Validation Lanes
 
@@ -78,7 +119,7 @@ Last remote `main` baseline before this local commit:
 | Localnet protocol-surface audit | `OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet` | PASS | `artifacts/localnet-e2e-summary-2026-05-04T16-40-45-011Z.json` |
 | Executable adversarial localnet | included in localnet E2E | PASS: `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` | `artifacts/localnet-adversarial-matrix-2026-05-04T16-40-45-011Z.json` |
 | Operator drawer simulation | `SOLANA_KEYPAIR=<devnet governance keypair> npm run devnet:operator:drawer:sim` | PASS: `FAIL=0`; expected idempotent collisions and fixture skips only | console output |
-| Mainnet preflight, no sends | `npm run protocol:bootstrap:genesis-live -- --plan` with distinct role wallets and mainnet USDC | PASS | console JSON; no transactions sent |
+| Mainnet preflight, no sends | `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 npm run protocol:bootstrap:genesis-live -- --plan` | BLOCKER: current operator env is missing `OMEGAX_LIVE_SETTLEMENT_MINT`; command failed before send path | console error; no transactions sent |
 | Mainnet unsafe config tests | `npm run verify:public` node suite | PASS | `tests/genesis_live_bootstrap_config.test.ts`, `tests/genesis_live_bootstrap_plan_cli.test.ts` |
 
 ## 6. Dependency Scan
@@ -108,17 +149,18 @@ actual settlement-asset reserve/funding/allocation capacity.
 
 | Field | Value |
 |-------|-------|
-| Devnet bootstrap | PASS, `OMEGAX_DEVNET_ROLE_MIN_LAMPORTS=0 npm run protocol:bootstrap:devnet-live` completed after public RPC 429 retries |
+| Devnet bootstrap | PASS for prior canary state, `OMEGAX_DEVNET_ROLE_MIN_LAMPORTS=0 npm run protocol:bootstrap:devnet-live` completed after public RPC 429 retries |
 | Canary seeding | PARTIAL RERUN: public devnet RPC rate-limited the fresh seed command after linked-claim and test-asset steps; strict pen-test verified all required canaries were already live |
 | Strict pen-test | PASS, `npm run devnet:treasury:pen-test -- --strict` |
 | Strict result | `8 blocked`, `0 vulnerable`, `0 skipped`, `0 inconclusive` |
 | Evidence | `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.json`, `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.md`, tracked summary `docs/security/devnet-treasury-pen-test-2026-05-04.md` |
-| Hardened binary replay | BLOCKER: PR `#55` has not been redeployed to devnet and strict pen-test has not been rerun against the hardened binary |
+| Hardened binary replay | BLOCKER: PR `#55` has not been merged, redeployed to devnet, and strict pen-test has not been rerun against the merged hardened binary |
 
 ## 9. Mainnet Preflight
 
-No mainnet transaction was sent. The `--plan` path exits after config/keypair
-validation and JSON plan output.
+No mainnet transaction was sent. The successful `--plan` path exits after
+config/keypair validation and JSON plan output; the current replay stopped even
+earlier at required-environment validation.
 
 | Field | Value |
 |-------|-------|
@@ -134,8 +176,20 @@ validation and JSON plan output.
 | Pool | `GvfgrHmzoPZXpn1H7L85R7qA9iFr3dBhZYNb5WeXMXqt` |
 | Senior class | `7BUpgc71EhLoFcH7PdqHkNyrGYdiCcX9FQ3rS55Moyui` |
 | Junior class | `9JAzzfoyysVg1DDoAdXZBN2Hy834RkgGnv5shUg3qywR` |
-| Role-map status | distinct wallets supplied for sponsor, sponsor operator, claims operator, oracle, curator, allocator, sentinel, and reserve admin |
-| Multisig posture | REQUIRED before real reserve funding; not proven in this evidence package |
+| Role-map status | previous plan used distinct wallets for sponsor, sponsor operator, claims operator, oracle, curator, allocator, sentinel, and reserve admin; current no-send replay is blocked by missing operator env |
+| Multisig posture | REQUIRED before real reserve funding; Squads V4 2-of-3 has not been created/proven in this evidence package |
+
+Current no-send replay:
+
+```sh
+OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1 npm run protocol:bootstrap:genesis-live -- --plan
+```
+
+Result: BLOCKER. The command failed before any send path with
+`Missing required environment variable OMEGAX_LIVE_SETTLEMENT_MINT`. This is a
+safe failure and keeps mainnet untouched, but it means the final production
+role map and multisig posture are not yet freshly proven from the current
+operator environment.
 
 Unsafe config proof:
 
@@ -154,6 +208,7 @@ Unsafe config proof:
 | Third-party review date | none |
 | Internal pen-test report | `docs/security/devnet-treasury-pen-test-2026-05-04.md` |
 | Outstanding high/critical internal findings | none known after the strict devnet run; external review still missing |
+| Independent-review packet | `docs/security/mainnet-money-control-review-packet-v0.3.2.md` |
 
 Public messaging must not claim audited, fully decentralized claims, uncapped
 solvency, or mixed-asset settlement. Other reserve assets may be shown as
@@ -182,10 +237,12 @@ green on `d9fa872dc289dcba6886f81551d21ba0d2016bb7`.
 ## 12. Sign-off
 
 This evidence is sufficient for local pre-mainnet readiness review only. It is
-not sufficient for public mainnet funding until the PR is reviewed and merged,
-the branch-review policy is fixed or explicitly accepted, multisig governance
-and upgrade posture are proven, the hardened binary is redeployed/rehearsed on
-devnet, and money/control surfaces receive independent review.
+not sufficient for public mainnet funding until PR `#55` receives human
+CODEOWNERS approval and merges, the final merged SHA is recorded, Squads V4
+2-of-3 governance and upgrade posture are proven, the current operator env
+successfully produces a no-send mainnet plan, the merged hardened binary is
+redeployed/rehearsed on devnet, and money/control surfaces receive independent
+review.
 
 Signed-off-by: Marino Sabijan, MD <marinosabijan@gmail.com>  
 Date: 2026-05-04

--- a/docs/security/devnet-treasury-pen-test-2026-05-04.md
+++ b/docs/security/devnet-treasury-pen-test-2026-05-04.md
@@ -13,7 +13,7 @@ did not submit theft transactions and did not target mainnet.
 - Protocol governance PDA: `7rjTAckGY9PMTGH43B2pG3DC7czbLazF3LN3QaKnejty`
 - Protocol governance authority: `CsBxTVjC4Y8oWuoU9xdp91du7WCaQWEbGyNBTuc7weDU`
 - RPC: `https://api.devnet.solana.com/`
-- Strict run time: `2026-05-04T09:15:59.779Z`
+- Strict run time: `2026-05-04T15:53:44.974Z`
 
 Deployment verification:
 
@@ -38,11 +38,17 @@ npm run devnet:treasury:pen-test -- --strict --out-dir artifacts/devnet-security
 
 The timestamped local evidence files for the strict run are:
 
-- `artifacts/devnet-security-rehearsal-full-bootstrap/devnet-treasury-pen-test-2026-05-04T09-15-59-778Z.json`
-- `artifacts/devnet-security-rehearsal-full-bootstrap/devnet-treasury-pen-test-2026-05-04T09-15-59-778Z.md`
+- `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.json`
+- `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.md`
 
 The `artifacts/` directory is intentionally ignored by git, so this document is
 the tracked public-safe evidence summary.
+
+The May 4 `15:53Z` strict rerun followed an idempotent devnet bootstrap. A
+fresh `seed-canaries` invocation was rate-limited by the public devnet RPC after
+confirming the linked-claim canary and minting test assets, but the strict
+pen-test runner verified that every required canary was already live before it
+executed attack probes.
 
 ## Canary Readiness
 

--- a/docs/security/mainnet-money-control-review-packet-v0.3.2.md
+++ b/docs/security/mainnet-money-control-review-packet-v0.3.2.md
@@ -1,0 +1,277 @@
+# Mainnet Money/Control Review Packet - v0.3.2
+
+This packet is for an independent Solana reviewer before any paid mainnet
+funding. It is intentionally public-safe: it contains public commit hashes,
+links, role expectations, and review scope only. It does not contain private
+keypair paths, secrets, or funding instructions.
+
+## Review Request
+
+Required sign-off:
+
+> No known critical or high blockers for claim settlement, obligation
+> settlement, LP redemption, fee withdrawals, governance, custody bindings,
+> oracle/claim authority, and bootstrap role separation.
+
+Reviewer preference order:
+
+1. Solana security firm.
+2. Independent Solana auditor.
+3. Senior Solana engineer not involved in this repo.
+
+If no qualified reviewer signs off, mainnet must remain structure-only/no real
+reserve funding and public messaging must say the release is not externally
+audited.
+
+## Candidate
+
+| Field | Value |
+|-------|-------|
+| Release | `v0.3.2` |
+| PR | [`#55`](https://github.com/OmegaX-Health/omegax-protocol/pull/55) |
+| Current PR head | `ace6317a37997ab148f78a0f817565ed323197f1` |
+| Liability hardening commit | `d9fa872dc289dcba6886f81551d21ba0d2016bb7` |
+| Final merged SHA | BLOCKER: fill after PR merge |
+| Branch protection | `main` requires 1 approval, CODEOWNERS review, stale-review dismissal, strict `verify`, admin enforcement |
+| Mainnet send status | no mainnet sends, no reserve funding |
+
+## Evidence Files
+
+| Evidence | Path / URL | Notes |
+|----------|------------|-------|
+| Release evidence | [`../operations/release-v0.3.2-evidence.md`](../operations/release-v0.3.2-evidence.md) | canonical readiness snapshot |
+| Devnet treasury report | [`./devnet-treasury-pen-test-2026-05-04.md`](./devnet-treasury-pen-test-2026-05-04.md) | prior strict run: `8 blocked`, `0 vulnerable`, `0 skipped`, `0 inconclusive` |
+| Privileged-role controls | [`./mainnet-privileged-role-controls.md`](./mainnet-privileged-role-controls.md) | role custody, distinct-key guard, multisig requirement |
+| Pre-mainnet pen test | [`./pre-mainnet-pen-test-2026-04-27.md`](./pre-mainnet-pen-test-2026-04-27.md) | finding lineage and fixed rehearsal issues |
+| Localnet E2E summary | `artifacts/localnet-e2e-summary-2026-05-04T16-40-45-011Z.json` | ignored artifact; current local evidence path |
+| Localnet adversarial matrix | `artifacts/localnet-adversarial-matrix-2026-05-04T16-40-45-011Z.json` | ignored artifact; `57 blocked`, `0 unexpectedSuccess`, `0 inconclusive` |
+| Devnet strict JSON | `artifacts/devnet-treasury-pen-test-2026-05-04T15-53-44-974Z.json` | ignored artifact; tracked summary above |
+| IDL | [`../../idl/omegax_protocol.json`](../../idl/omegax_protocol.json) | generated Anchor IDL |
+| Protocol contract | [`../../shared/protocol_contract.json`](../../shared/protocol_contract.json) | generated public contract artifact |
+
+## Remote CI At Current PR Head
+
+| Workflow | URL | Result |
+|----------|-----|--------|
+| Public CI `verify` | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475611/job/74269330889` | PASS |
+| CodeQL | `https://github.com/OmegaX-Health/omegax-protocol/runs/74269517022` | PASS |
+| Localnet E2E | `https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475638/job/74269331451` | PASS |
+
+Any later evidence-only commit on PR `#55` must be checked again before merge.
+
+## Localnet Adversarial Evidence
+
+Latest localnet artifact:
+`artifacts/localnet-adversarial-matrix-2026-05-04T16-40-45-011Z.json`.
+
+Summary:
+
+```json
+{
+  "requiredRuntimeProbeCount": 57,
+  "totals": {
+    "blocked": 57,
+    "unexpectedSuccess": 0,
+    "inconclusive": 0
+  }
+}
+```
+
+Instruction ownership summary from
+`artifacts/localnet-e2e-summary-2026-05-04T16-40-45-011Z.json`:
+
+```json
+{
+  "liveCount": 67,
+  "ownedCount": 67,
+  "missingInstructions": [],
+  "unexpectedOwnedInstructions": [],
+  "duplicateAssignments": [],
+  "blankExceptionReasons": [],
+  "retiredLegacyPresent": []
+}
+```
+
+## Devnet Treasury Evidence
+
+Latest tracked strict devnet report:
+[`./devnet-treasury-pen-test-2026-05-04.md`](./devnet-treasury-pen-test-2026-05-04.md).
+
+Summary:
+
+```json
+{
+  "blocked": 8,
+  "vulnerable": 0,
+  "skipped": 0,
+  "inconclusive": 0
+}
+```
+
+Required canaries were present for the prior deployed devnet program:
+
+- domain asset vault with SPL balance
+- protocol fee vault with accrued SPL fees
+- pool treasury vault with accrued SPL fees
+- pool oracle fee vault with accrued SPL fees
+- unsettled linked-claim obligation with usable SPL outflow accounts
+- LP position with pending redemption shares and usable vault custody
+- allocation-scoped obligation for allocation/PDA binding probes
+
+Fresh reviewer note: this strict run predates PR `#55` merge. A hardened
+devnet replay against the merged binary remains mandatory before funding.
+
+## Money/Control Surfaces To Review
+
+### Claim Settlement
+
+Primary code paths:
+
+- `programs/omegax_protocol/src/lib.rs`
+- `programs/omegax_protocol/src/claims.rs`
+- `programs/omegax_protocol/src/kernel.rs`
+
+Review focus:
+
+- claim operator/oracle authority separation
+- claim-recipient locking after approval or payout
+- post-payout and settled/closed adjudication lock
+- claim attestation PDA binding
+- settlement recipient, mint, token program, and vault-account binding
+- replay/double-settle rejection
+
+### Obligation Settlement
+
+Primary code paths:
+
+- `programs/omegax_protocol/src/obligations.rs`
+- `programs/omegax_protocol/src/reserve.rs`
+- `programs/omegax_protocol/src/capital_pool.rs`
+
+Review focus:
+
+- full-amount requirement for state-changing transitions to claimable/payable,
+  settled, or canceled
+- invalid delivery-mode rejection before ledger mutation
+- physical custody debits versus allocation-style settlement accounting
+- reserve/owed/payable conservation
+- optional ledger and allocation PDA binding
+- token outflow account validation
+
+### LP Redemption
+
+Primary code paths:
+
+- `programs/omegax_protocol/src/capital_pool.rs`
+- `programs/omegax_protocol/src/kernel.rs`
+
+Review focus:
+
+- LP-owner and curator/governance authority checks
+- pending-redemption state transitions
+- recipient binding to LP owner
+- pool vault, share accounting, and mint binding
+- replay/double-redemption rejection
+
+### Fee Withdrawals
+
+Primary code paths:
+
+- `programs/omegax_protocol/src/fees.rs`
+- `programs/omegax_protocol/src/capital_pool.rs`
+- `programs/omegax_protocol/src/oracle.rs`
+
+Review focus:
+
+- protocol fee vault withdrawal authority
+- pool treasury fee vault withdrawal authority
+- pool oracle fee vault withdrawal authority
+- fee policy/account binding
+- wrong recipient, wrong mint, wrong token program, and fake vault rejection
+
+### Governance And Pause
+
+Primary code paths:
+
+- `programs/omegax_protocol/src/governance.rs`
+- `programs/omegax_protocol/src/kernel.rs`
+
+Review focus:
+
+- protocol governance rotation
+- emergency pause and unpause boundaries
+- whether one-step authority rotation is acceptable once authority is a Squads
+  V4 2-of-3 PDA
+- branch protection and CODEOWNERS as release-control plane
+
+### Bootstrap Role Separation
+
+Primary code paths:
+
+- `scripts/support/genesis_live_bootstrap_config.ts`
+- `scripts/bootstrap_genesis_live_protocol.ts`
+- `tests/genesis_live_bootstrap_config.test.ts`
+- `tests/genesis_live_bootstrap_plan_cli.test.ts`
+
+Review focus:
+
+- `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1` mainnet guard
+- rejection of collapsed privileged roles
+- rejection of missing oracle keypair file
+- rejection of oracle wallet/keypair mismatch
+- wrong-cluster and override behavior
+- no-send behavior of `--plan`
+
+## Production Custody Requirement
+
+Default launch custody decision:
+
+- governance authority: Squads V4 2-of-3 multisig PDA
+- upgrade authority: Squads V4 2-of-3 multisig PDA or explicitly documented
+  equivalent with the same signer set and threshold
+- sponsor, sponsor operator, claims operator, oracle, curator, allocator,
+  sentinel, reserve admin, and invite authority: distinct public wallets where
+  applicable
+
+Current status:
+
+- Squads V4 2-of-3 has not yet been created/proven in this repo evidence.
+- Do not fund mainnet reserves until the multisig PDA, threshold, member public
+  keys, upgrade-authority posture, and role map are recorded in
+  [`../operations/release-v0.3.2-evidence.md`](../operations/release-v0.3.2-evidence.md).
+
+## Non-Claims
+
+The reviewer should treat these as explicit v1 boundaries:
+
+- no external audit is completed unless the reviewer or firm signs this packet
+- no arbitrary deposit cap is added
+- no arbitrary claim cap is added
+- no mixed-asset USDC settlement is introduced
+- WBTC, SOL, WETH, or other reserve assets may be displayed as reserve context
+  only unless an explicit priced conversion/funding path exists
+- settlement is bounded by actual reserve, funding, and allocation capacity
+- mainnet real-fund movement remains blocked until all release evidence gates
+  are green
+
+## Review Outcome
+
+Reviewer:
+
+Date:
+
+Scope reviewed:
+
+Result:
+
+- [ ] No known critical/high blockers for claim settlement.
+- [ ] No known critical/high blockers for obligation settlement.
+- [ ] No known critical/high blockers for LP redemption.
+- [ ] No known critical/high blockers for fee withdrawals.
+- [ ] No known critical/high blockers for governance and pause.
+- [ ] No known critical/high blockers for custody bindings.
+- [ ] No known critical/high blockers for oracle/claim authority.
+- [ ] No known critical/high blockers for bootstrap role separation.
+
+Findings / conditions:
+

--- a/e2e/localnet_adversarial_matrix.test.ts
+++ b/e2e/localnet_adversarial_matrix.test.ts
@@ -6,7 +6,15 @@ import { dirname } from "node:path";
 import test from "node:test";
 
 import { TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
-import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 
 import protocolModule from "../frontend/lib/protocol.ts";
 import {
@@ -24,7 +32,8 @@ const SAMPLE_HASH_HEX = "ab".repeat(32);
 
 const governanceAuthority = Keypair.generate().publicKey;
 const operator = Keypair.generate().publicKey;
-const attacker = Keypair.generate().publicKey;
+const attackerKeypair = Keypair.generate();
+const attacker = attackerKeypair.publicKey;
 const oracle = Keypair.generate().publicKey;
 const lpOwner = Keypair.generate().publicKey;
 const member = Keypair.generate().publicKey;
@@ -93,6 +102,22 @@ type MatrixRow = {
   mustInclude?: PublicKey[];
 };
 
+type RuntimeProbe = {
+  area: string;
+  instruction: string;
+  attack: string;
+  expectedGuard: string;
+  tx: Transaction;
+  category: string;
+};
+
+type RuntimeProbeResult = ReturnType<typeof rowSummary> & {
+  category: string;
+  runtimeStatus: "blocked" | "unexpected_success" | "inconclusive";
+  rejectionReason: string;
+  logs: string[];
+};
+
 function onlyProgramInstruction(tx: Transaction) {
   const instructions = tx.instructions.filter((ix) => ix.programId.equals(protocol.getProgramId()));
   assert.equal(instructions.length, 1, "expected exactly one OmegaX instruction");
@@ -134,6 +159,130 @@ function rowSummary(row: MatrixRow) {
     signerCount: ix.keys.filter((key) => key.isSigner).length,
     writableCount: ix.keys.filter((key) => key.isWritable).length,
   };
+}
+
+const fakePda = Keypair.generate().publicKey;
+const fakeMint = Keypair.generate().publicKey;
+const fakeRecipient = getAssociatedTokenAddressSync(assetMint, Keypair.generate().publicKey, true, TOKEN_PROGRAM_ID);
+const fakeLedger = Keypair.generate().publicKey;
+const fakeAttestation = Keypair.generate().publicKey;
+const knownLedgerAccounts = [
+  protocol.deriveFundingLineLedgerPda({ fundingLine, assetMint }),
+  protocol.derivePoolClassLedgerPda({ capitalClass, assetMint }),
+  protocol.deriveAllocationLedgerPda({ allocationPosition, assetMint }),
+];
+
+function cloneTxWithReplacement(row: MatrixRow, replacements: Map<string, PublicKey>): Transaction | null {
+  let mutated = false;
+  const tx = new Transaction();
+  for (const ix of row.tx.instructions) {
+    tx.add(new TransactionInstruction({
+      programId: ix.programId,
+      data: ix.data,
+      keys: ix.keys.map((key) => {
+        const replacement = replacements.get(key.pubkey.toBase58());
+        if (!replacement) return key;
+        mutated = true;
+        return { ...key, pubkey: replacement };
+      }),
+    }));
+  }
+  return mutated ? tx : null;
+}
+
+function runtimeProbes(): RuntimeProbe[] {
+  const probes: RuntimeProbe[] = matrixRows.map((row) => ({
+    ...row,
+    category: "wrong_signer_or_role_confusion",
+  }));
+  for (const row of matrixRows) {
+    const pdaCandidate = row.mustInclude?.find((account) =>
+      !account.equals(TOKEN_PROGRAM_ID)
+      && !account.equals(attackerAta)
+      && !account.equals(sourceAta)
+      && !account.equals(memberAta)
+      && !account.equals(assetMint),
+    );
+    if (pdaCandidate) {
+      const tx = cloneTxWithReplacement(row, new Map([[pdaCandidate.toBase58(), fakePda]]));
+      if (tx) probes.push({ ...row, tx, category: "wrong_pda_binding", attack: `${row.attack} + wrong PDA binding` });
+    }
+
+    const wrongMintTx = cloneTxWithReplacement(row, new Map([[assetMint.toBase58(), fakeMint]]));
+    if (wrongMintTx) {
+      probes.push({ ...row, tx: wrongMintTx, category: "wrong_mint", attack: `${row.attack} + wrong mint` });
+    }
+
+    const wrongRecipientTx = cloneTxWithReplacement(row, new Map([[attackerAta.toBase58(), fakeRecipient]]));
+    if (wrongRecipientTx) {
+      probes.push({ ...row, tx: wrongRecipientTx, category: "wrong_recipient", attack: `${row.attack} + alternate attacker recipient` });
+    }
+
+    const wrongTokenProgramTx = cloneTxWithReplacement(row, new Map([[TOKEN_PROGRAM_ID.toBase58(), protocol.getProgramId()]]));
+    if (wrongTokenProgramTx) {
+      probes.push({ ...row, tx: wrongTokenProgramTx, category: "wrong_token_program", attack: `${row.attack} + Token-2022/program substitution` });
+    }
+
+    const ledgerTarget = knownLedgerAccounts.find((ledger) => onlyProgramInstruction(row.tx).keys.some((key) => key.pubkey.equals(ledger)));
+    if (ledgerTarget) {
+      const tx = cloneTxWithReplacement(row, new Map([[ledgerTarget.toBase58(), fakeLedger]]));
+      if (tx) probes.push({ ...row, tx, category: "fake_ledger", attack: `${row.attack} + fake ledger` });
+    }
+
+    if (onlyProgramInstruction(row.tx).keys.some((key) => key.pubkey.equals(oracleFeeAttestation))) {
+      const tx = cloneTxWithReplacement(row, new Map([[oracleFeeAttestation.toBase58(), fakeAttestation]]));
+      if (tx) probes.push({ ...row, tx, category: "fake_attestation", attack: `${row.attack} + fake claim attestation` });
+    }
+
+    probes.push({
+      ...row,
+      category: "replay_or_double_settle",
+      attack: `${row.attack} + replay/double-settle attempt`,
+    });
+  }
+  return probes;
+}
+
+function rowLikeSummary(row: RuntimeProbe) {
+  const base = rowSummary(row);
+  return {
+    ...base,
+    category: row.category,
+  };
+}
+
+function writeAdversarialSummary(runtimeRows: RuntimeProbeResult[] | null): void {
+  const path = process.env.OMEGAX_E2E_ADVERSARIAL_SUMMARY_PATH?.trim();
+  if (!path) return;
+  mkdirSync(dirname(path), { recursive: true });
+  const runtimeCounts = runtimeRows
+    ? runtimeRows.reduce(
+        (counts, row) => {
+          counts[row.runtimeStatus] += 1;
+          return counts;
+        },
+        { blocked: 0, unexpected_success: 0, inconclusive: 0 },
+      )
+    : { blocked: 0, unexpected_success: 0, inconclusive: 0 };
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        executable: Boolean(runtimeRows),
+        requiredRuntimeProbeCount: runtimeRows?.length ?? 0,
+        totals: {
+          blocked: runtimeCounts.blocked,
+          unexpectedSuccess: runtimeCounts.unexpected_success,
+          inconclusive: runtimeCounts.inconclusive,
+        },
+        rows: matrixRows.map(rowSummary),
+        runtimeRows: runtimeRows ?? [],
+      },
+      null,
+      2,
+    ),
+  );
 }
 
 const matrixRows: MatrixRow[] = [
@@ -434,19 +583,59 @@ test("builder rejects wrong token program before localnet execution", () => {
   );
 });
 
-test("adversarial matrix writes an evidence summary when requested", () => {
-  const path = process.env.OMEGAX_E2E_ADVERSARIAL_SUMMARY_PATH?.trim();
-  if (!path) return;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(
-    path,
-    JSON.stringify(
-      {
-        generatedAt: new Date().toISOString(),
-        rows: matrixRows.map(rowSummary),
-      },
-      null,
-      2,
-    ),
+test("executable adversarial matrix probes are blocked on localnet", async () => {
+  const rpcUrl = process.env.SOLANA_RPC_URL?.trim();
+  if (!rpcUrl) {
+    writeAdversarialSummary(null);
+    return;
+  }
+
+  const connection = new Connection(rpcUrl, "confirmed");
+  const latestForAirdrop = await connection.getLatestBlockhash("confirmed");
+  const airdropSignature = await connection.requestAirdrop(attacker, 2_000_000_000);
+  await connection.confirmTransaction(
+    { signature: airdropSignature, ...latestForAirdrop },
+    "confirmed",
   );
+
+  const probes = runtimeProbes();
+  assert(probes.length >= matrixRows.length * 4, "expected runtime variants beyond the static row set");
+  const results: RuntimeProbeResult[] = [];
+  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+  for (const probe of probes) {
+    try {
+      const message = new TransactionMessage({
+        payerKey: attacker,
+        recentBlockhash: blockhash,
+        instructions: probe.tx.instructions,
+      }).compileToV0Message();
+      const tx = new VersionedTransaction(message);
+      tx.sign([attackerKeypair]);
+      const result = await connection.simulateTransaction(tx, {
+        commitment: "confirmed",
+        sigVerify: false,
+      });
+      const logs = result.value.logs ?? [];
+      results.push({
+        ...rowLikeSummary(probe),
+        runtimeStatus: result.value.err ? "blocked" : "unexpected_success",
+        rejectionReason: result.value.err ? JSON.stringify(result.value.err) : "simulation succeeded",
+        logs,
+      });
+    } catch (error) {
+      results.push({
+        ...rowLikeSummary(probe),
+        runtimeStatus: "inconclusive",
+        rejectionReason: error instanceof Error ? error.message : String(error),
+        logs: [],
+      });
+    }
+  }
+
+  writeAdversarialSummary(results);
+  const unexpectedSuccess = results.filter((row) => row.runtimeStatus === "unexpected_success");
+  const inconclusive = results.filter((row) => row.runtimeStatus === "inconclusive");
+  assert.deepEqual(unexpectedSuccess, []);
+  assert.deepEqual(inconclusive, []);
+  assert.equal(results.filter((row) => row.runtimeStatus === "blocked").length, results.length);
 });

--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -839,6 +839,66 @@ export type MixedReserveWaterfallModel = {
   payoutOrder: MixedReserveWaterfallRail[];
 };
 
+export type ClaimFundingReadinessState =
+  | "settle_now"
+  | "reserve_then_settle"
+  | "queue_or_refund"
+  | "operator_action_required";
+
+export type ClaimFundingReadinessOtherReserveAsset = {
+  reserveAssetRail: string | null;
+  reserveDomain: string;
+  assetMint: string;
+  assetSymbol: string;
+  freeAmountRaw: bigint;
+  priceFresh: boolean;
+  priceUsd1e8: bigint | null;
+  haircutBps: number;
+  estimatedValueUsd1e8: bigint | null;
+  haircutAdjustedValueUsd1e8: bigint | null;
+  immediatelySettleable: false;
+  warnings: string[];
+};
+
+export type ClaimFundingReadiness = {
+  reserveDomain: string | null;
+  settlementMint: string;
+  requestedAmount: bigint;
+  directSettlementAssetCapacityAmount: bigint;
+  fundingLineAvailableAmount: bigint;
+  immediatelySettleableAmount: bigint;
+  reservedOrPayableAmount: bigint;
+  pendingObligationsAmount: bigint;
+  queuedRedemptionsAmount: bigint;
+  availableLpAllocationCapacityAmount: bigint;
+  otherReserveAssets: ClaimFundingReadinessOtherReserveAsset[];
+  readiness: ClaimFundingReadinessState;
+  warnings: string[];
+};
+
+export type ClaimFundingReadinessInput = {
+  snapshot: Pick<
+    ProtocolConsoleSnapshot,
+    | "domainAssetVaults"
+    | "reserveAssetRails"
+    | "domainAssetLedgers"
+    | "fundingLines"
+    | "obligations"
+    | "liquidityPools"
+    | "capitalClasses"
+    | "lpPositions"
+    | "allocationPositions"
+  >;
+  settlementMint: PublicKeyish;
+  requestedAmount: BigNumberish;
+  reserveDomainAddress?: PublicKeyish | null;
+  healthPlanAddress?: PublicKeyish | null;
+  policySeriesAddress?: PublicKeyish | null;
+  fundingLineAddress?: PublicKeyish | null;
+  assetDecimalsByMint?: Record<string, number>;
+  nowTs?: number;
+};
+
 export type MemberReadModel = {
   wallet: string;
   planParticipations: Array<{
@@ -1754,6 +1814,310 @@ export function buildMixedReserveWaterfallModel(params: {
     reserveDomain,
     payoutOrder,
     totalEffectiveCapacityUsd1e8: payoutOrder.reduce((sum, rail) => sum + rail.effectiveCapacityUsd1e8, 0n),
+  };
+}
+
+function normalizeOptionalAddress(value: PublicKeyish | null | undefined): string | null {
+  return value ? normalizeAddress(value) : null;
+}
+
+function matchesOptionalScope(actual: string | null | undefined, expected: string | null): boolean {
+  return !expected || actual === expected;
+}
+
+function clampDecimals(value: number | undefined): number {
+  return Math.max(0, Math.min(18, value ?? 6));
+}
+
+function freshRailPrice(rail: ReserveAssetRailSnapshot | null | undefined, nowTs: number): boolean {
+  if (!rail || !rail.active || !rail.capacityEnabled) return false;
+  const price = toBigIntAmount(rail.lastPriceUsd1e8);
+  if (price <= 0n) return false;
+  const publishedAt = Number(rail.lastPricePublishedAtTs ?? 0);
+  const maxStaleness = Number(rail.maxStalenessSeconds ?? 0);
+  return maxStaleness === 0 || (publishedAt > 0 && nowTs - publishedAt <= maxStaleness);
+}
+
+function amountToUsd1e8(params: {
+  amountRaw: bigint;
+  rail: ReserveAssetRailSnapshot | null | undefined;
+  decimals: number;
+  nowTs: number;
+}): bigint | null {
+  if (!freshRailPrice(params.rail, params.nowTs)) return null;
+  const price = toBigIntAmount(params.rail?.lastPriceUsd1e8);
+  const decimalFactor = 10n ** BigInt(clampDecimals(params.decimals));
+  return (params.amountRaw * price) / decimalFactor;
+}
+
+function fundingLineFreeForReadiness(line: FundingLineSnapshot): bigint {
+  if (line.sheet) return recomputeReserveBalanceSheet(line.sheet).free;
+  const funded = toBigIntAmount(line.fundedAmount);
+  const spent = toBigIntAmount(line.spentAmount);
+  const reserved = toBigIntAmount(line.reservedAmount);
+  const encumbered = spent + reserved;
+  return funded > encumbered ? funded - encumbered : 0n;
+}
+
+function maxBigIntAmount(values: Array<BigNumberish | null | undefined>): bigint {
+  let max = 0n;
+  for (const value of values) {
+    const amount = toBigIntAmount(value);
+    if (amount > max) max = amount;
+  }
+  return max;
+}
+
+function obligationExposureAmount(obligation: ObligationSnapshot): bigint {
+  if (
+    obligation.status === OBLIGATION_STATUS_SETTLED
+    || obligation.status === OBLIGATION_STATUS_CANCELED
+    || obligation.status === OBLIGATION_STATUS_RECOVERED
+  ) {
+    return 0n;
+  }
+  return maxBigIntAmount([
+    obligation.outstandingAmount,
+    obligation.reservedAmount,
+    obligation.claimableAmount,
+    obligation.payableAmount,
+    obligation.principalAmount,
+  ]);
+}
+
+function reserveOrPayableExposureAmount(obligation: ObligationSnapshot): bigint {
+  if (
+    obligation.status !== OBLIGATION_STATUS_RESERVED
+    && obligation.status !== OBLIGATION_STATUS_CLAIMABLE_PAYABLE
+  ) {
+    return 0n;
+  }
+  return maxBigIntAmount([
+    obligation.reservedAmount,
+    obligation.claimableAmount,
+    obligation.payableAmount,
+    obligation.outstandingAmount,
+    obligation.principalAmount,
+  ]);
+}
+
+export function buildClaimFundingReadiness(params: ClaimFundingReadinessInput): ClaimFundingReadiness {
+  const settlementMint = normalizeAddress(params.settlementMint);
+  const requestedAmount = toBigIntAmount(params.requestedAmount);
+  const nowTs = params.nowTs ?? Math.floor(Date.now() / 1000);
+  const fundingLineAddress = normalizeOptionalAddress(params.fundingLineAddress);
+  const healthPlanAddress = normalizeOptionalAddress(params.healthPlanAddress);
+  const policySeriesAddress = normalizeOptionalAddress(params.policySeriesAddress);
+  const selectedFundingLine = fundingLineAddress
+    ? params.snapshot.fundingLines.find((line) => line.address === fundingLineAddress) ?? null
+    : null;
+  const reserveDomain = normalizeOptionalAddress(params.reserveDomainAddress)
+    ?? selectedFundingLine?.reserveDomain
+    ?? params.snapshot.domainAssetVaults.find((vault) => vault.assetMint === settlementMint)?.reserveDomain
+    ?? params.snapshot.reserveAssetRails.find((rail) => rail.assetMint === settlementMint)?.reserveDomain
+    ?? null;
+  const warnings: string[] = [];
+
+  const inReserve = (value: { reserveDomain: string }) => !reserveDomain || value.reserveDomain === reserveDomain;
+  const lineMatchesScope = (line: FundingLineSnapshot) =>
+    inReserve(line)
+    && line.assetMint === settlementMint
+    && matchesOptionalScope(line.healthPlan, healthPlanAddress)
+    && matchesOptionalScope(line.policySeries ?? null, policySeriesAddress)
+    && matchesOptionalScope(line.address, fundingLineAddress);
+  const obligationMatchesScope = (obligation: ObligationSnapshot) =>
+    inReserve(obligation)
+    && obligation.assetMint === settlementMint
+    && matchesOptionalScope(obligation.healthPlan, healthPlanAddress)
+    && matchesOptionalScope(obligation.policySeries ?? null, policySeriesAddress)
+    && matchesOptionalScope(obligation.fundingLine, fundingLineAddress);
+
+  if (!reserveDomain) {
+    warnings.push("No reserve domain could be inferred; readiness is limited to settlement mint totals across the snapshot.");
+  }
+
+  const settlementLedgers = params.snapshot.domainAssetLedgers
+    .filter((ledger) => ledger.assetMint === settlementMint && inReserve(ledger))
+    .map((ledger) => recomputeReserveBalanceSheet(ledger.sheet));
+  const settlementVaultTotal = params.snapshot.domainAssetVaults
+    .filter((vault) => vault.assetMint === settlementMint && inReserve(vault))
+    .reduce((sum, vault) => sum + toBigIntAmount(vault.totalAssets), 0n);
+  const matchingObligations = params.snapshot.obligations.filter(obligationMatchesScope);
+  const reservedOrPayableAmount = matchingObligations.reduce(
+    (sum, obligation) => sum + reserveOrPayableExposureAmount(obligation),
+    0n,
+  );
+  const pendingObligationsAmount = matchingObligations.reduce(
+    (sum, obligation) => sum + obligationExposureAmount(obligation),
+    0n,
+  );
+
+  const poolByAddress = new Map(params.snapshot.liquidityPools.map((pool) => [pool.address, pool]));
+  const classByAddress = new Map(params.snapshot.capitalClasses.map((capitalClass) => [capitalClass.address, capitalClass]));
+  const queuedRedemptionsAmount = params.snapshot.lpPositions.reduce((sum, position) => {
+    const capitalClass = classByAddress.get(position.capitalClass);
+    const pool = capitalClass ? poolByAddress.get(capitalClass.liquidityPool) : null;
+    if (!capitalClass || !pool) return sum;
+    if (pool.depositAssetMint !== settlementMint || (reserveDomain && pool.reserveDomain !== reserveDomain)) return sum;
+    return sum + toBigIntAmount(position.pendingRedemptionAssets);
+  }, 0n);
+
+  const settlementLedgerFree = settlementLedgers.reduce((sum, sheet) => sum + sheet.free, 0n);
+  const settlementFreeFromVaultFallback = settlementVaultTotal > pendingObligationsAmount + queuedRedemptionsAmount
+    ? settlementVaultTotal - pendingObligationsAmount - queuedRedemptionsAmount
+    : 0n;
+  const directSettlementAssetCapacityAmount = settlementLedgers.length > 0
+    ? settlementLedgerFree
+    : settlementFreeFromVaultFallback;
+
+  const scopedFundingLines = params.snapshot.fundingLines.filter(lineMatchesScope);
+  const activeFundingLines = scopedFundingLines.filter((line) => line.status === FUNDING_LINE_STATUS_OPEN);
+  const fundingLineAvailableAmount = activeFundingLines.reduce(
+    (sum, line) => sum + fundingLineFreeForReadiness(line),
+    0n,
+  );
+  if (scopedFundingLines.length > 0 && activeFundingLines.length === 0) {
+    warnings.push("Matching settlement funding line exists, but it is not open for new settlement activity.");
+  }
+  if (fundingLineAddress && !selectedFundingLine) {
+    warnings.push("Requested funding line was not found in the snapshot.");
+  }
+
+  const immediatelySettleableAmount = scopedFundingLines.length > 0
+    ? (directSettlementAssetCapacityAmount < fundingLineAvailableAmount
+        ? directSettlementAssetCapacityAmount
+        : fundingLineAvailableAmount)
+    : directSettlementAssetCapacityAmount;
+
+  const availableLpAllocationCapacityAmount = params.snapshot.allocationPositions
+    .filter((allocation) =>
+      allocation.active
+      && inReserve(allocation)
+      && matchesOptionalScope(allocation.healthPlan, healthPlanAddress)
+      && matchesOptionalScope(allocation.policySeries ?? null, policySeriesAddress)
+      && matchesOptionalScope(allocation.fundingLine, fundingLineAddress)
+      && params.snapshot.fundingLines.some((line) => line.address === allocation.fundingLine && line.assetMint === settlementMint),
+    )
+    .reduce((sum, allocation) => {
+      const capAmount = toBigIntAmount(allocation.capAmount);
+      const encumbered =
+        toBigIntAmount(allocation.allocatedAmount)
+        + toBigIntAmount(allocation.reservedCapacity)
+        + toBigIntAmount(allocation.utilizedAmount);
+      return sum + (capAmount > encumbered ? capAmount - encumbered : 0n);
+    }, 0n);
+
+  const railsByMint = new Map(
+    params.snapshot.reserveAssetRails
+      .filter((rail) => inReserve(rail))
+      .map((rail) => [rail.assetMint, rail]),
+  );
+  const ledgerByMint = new Map(
+    params.snapshot.domainAssetLedgers
+      .filter((ledger) => inReserve(ledger))
+      .map((ledger) => [ledger.assetMint, recomputeReserveBalanceSheet(ledger.sheet)]),
+  );
+  const vaultTotalsByMint = new Map<string, bigint>();
+  for (const vault of params.snapshot.domainAssetVaults.filter((entry) => inReserve(entry))) {
+    vaultTotalsByMint.set(vault.assetMint, (vaultTotalsByMint.get(vault.assetMint) ?? 0n) + toBigIntAmount(vault.totalAssets));
+  }
+  const reserveMints = new Set<string>([
+    ...railsByMint.keys(),
+    ...ledgerByMint.keys(),
+    ...vaultTotalsByMint.keys(),
+  ]);
+  const otherReserveAssets = [...reserveMints]
+    .filter((assetMint) => assetMint !== settlementMint)
+    .sort()
+    .map((assetMint): ClaimFundingReadinessOtherReserveAsset => {
+      const rail = railsByMint.get(assetMint) ?? null;
+      const ledger = ledgerByMint.get(assetMint);
+      const freeAmountRaw = ledger?.free ?? vaultTotalsByMint.get(assetMint) ?? 0n;
+      const decimals = clampDecimals(params.assetDecimalsByMint?.[assetMint]);
+      const estimatedValueUsd1e8 = amountToUsd1e8({
+        amountRaw: freeAmountRaw,
+        rail,
+        decimals,
+        nowTs,
+      });
+      const haircutBps = Math.max(0, rail?.haircutBps ?? 0);
+      const haircutAdjustedValueUsd1e8 = estimatedValueUsd1e8 === null
+        ? null
+        : (estimatedValueUsd1e8 * BigInt(Math.max(0, 10_000 - haircutBps))) / 10_000n;
+      const assetWarnings: string[] = [
+        "Non-settlement reserve asset; explicit conversion or funding action is required before settlement-mint payout.",
+      ];
+      if (!rail) {
+        assetWarnings.push("No reserve asset rail exists for this asset.");
+      } else if (!freshRailPrice(rail, nowTs)) {
+        assetWarnings.push("No fresh published price is available, so haircut-adjusted value is not counted.");
+      }
+      return {
+        reserveAssetRail: rail?.address ?? null,
+        reserveDomain: reserveDomain ?? rail?.reserveDomain ?? "",
+        assetMint,
+        assetSymbol: rail?.assetSymbol ?? assetMint.slice(0, 4),
+        freeAmountRaw,
+        priceFresh: freshRailPrice(rail, nowTs),
+        priceUsd1e8: rail ? toBigIntAmount(rail.lastPriceUsd1e8) : null,
+        haircutBps,
+        estimatedValueUsd1e8,
+        haircutAdjustedValueUsd1e8,
+        immediatelySettleable: false,
+        warnings: assetWarnings,
+      };
+    });
+
+  const shortfallAmount = requestedAmount > immediatelySettleableAmount
+    ? requestedAmount - immediatelySettleableAmount
+    : 0n;
+  const settlementRail = railsByMint.get(settlementMint) ?? null;
+  const shortfallUsd1e8 = amountToUsd1e8({
+    amountRaw: shortfallAmount,
+    rail: settlementRail,
+    decimals: clampDecimals(params.assetDecimalsByMint?.[settlementMint]),
+    nowTs,
+  });
+  const otherReserveHaircutValueUsd1e8 = otherReserveAssets.reduce(
+    (sum, asset) => sum + (asset.haircutAdjustedValueUsd1e8 ?? 0n),
+    0n,
+  );
+
+  if (shortfallAmount > 0n) {
+    warnings.push("Settlement-mint capacity is below the requested amount.");
+  }
+  if (otherReserveAssets.some((asset) => asset.freeAmountRaw > 0n)) {
+    warnings.push("Other reserve assets are valuation context only; they do not increase immediately-settleable settlement-mint capacity.");
+  }
+  if (shortfallAmount > 0n && shortfallUsd1e8 === null && otherReserveHaircutValueUsd1e8 > 0n) {
+    warnings.push("Settlement-mint shortfall cannot be compared to other assets without a fresh settlement asset price.");
+  }
+
+  let readiness: ClaimFundingReadinessState;
+  if (requestedAmount <= immediatelySettleableAmount) {
+    readiness = "settle_now";
+  } else if (requestedAmount <= immediatelySettleableAmount + availableLpAllocationCapacityAmount) {
+    readiness = "reserve_then_settle";
+  } else if (otherReserveHaircutValueUsd1e8 > 0n && (shortfallUsd1e8 === null || otherReserveHaircutValueUsd1e8 >= shortfallUsd1e8)) {
+    readiness = "operator_action_required";
+  } else {
+    readiness = "queue_or_refund";
+  }
+
+  return {
+    reserveDomain,
+    settlementMint,
+    requestedAmount,
+    directSettlementAssetCapacityAmount,
+    fundingLineAvailableAmount,
+    immediatelySettleableAmount,
+    reservedOrPayableAmount,
+    pendingObligationsAmount,
+    queuedRedemptionsAmount,
+    availableLpAllocationCapacityAmount,
+    otherReserveAssets,
+    readiness,
+    warnings,
   };
 }
 

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -15852,6 +15852,21 @@
       "code": 6106,
       "name": "CommitmentPaymentRailInactive",
       "msg": "Commitment payment rail is inactive"
+    },
+    {
+      "code": 6107,
+      "name": "PartialObligationTransitionUnsupported",
+      "msg": "Partial obligation lifecycle transitions are not supported"
+    },
+    {
+      "code": 6108,
+      "name": "InvalidObligationDeliveryMode",
+      "msg": "Invalid obligation delivery mode"
+    },
+    {
+      "code": 6109,
+      "name": "ClaimAdjudicationLocked",
+      "msg": "Claim adjudication is locked after payout or terminal state"
     }
   ],
   "types": [

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-cb89cecec5597e42d9dc2f958705aa10f83b8508237cd344177774154dbda762
+18e706864b7fb32783c27a380107c3ebff786a5cbac4b341867d990b1e10c61c
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/args.rs

--- a/programs/omegax_protocol/src/claims.rs
+++ b/programs/omegax_protocol/src/claims.rs
@@ -116,6 +116,11 @@ pub(crate) fn adjudicate_claim_case(
     );
 
     let claim_case = &mut ctx.accounts.claim_case;
+    let adjudication_obligation = ctx.accounts.obligation.as_ref().map(|obligation| {
+        let obligation: &Obligation = obligation;
+        obligation
+    });
+    require_claim_adjudication_mutable(claim_case, adjudication_obligation)?;
     let claim_case_key = claim_case.key();
     claim_case.adjudicator = ctx.accounts.authority.key();
     claim_case.review_state = args.review_state;

--- a/programs/omegax_protocol/src/errors.rs
+++ b/programs/omegax_protocol/src/errors.rs
@@ -220,4 +220,10 @@ pub enum OmegaXProtocolError {
     CommitmentPaymentRailMismatch,
     #[msg("Commitment payment rail is inactive")]
     CommitmentPaymentRailInactive,
+    #[msg("Partial obligation lifecycle transitions are not supported")]
+    PartialObligationTransitionUnsupported,
+    #[msg("Invalid obligation delivery mode")]
+    InvalidObligationDeliveryMode,
+    #[msg("Claim adjudication is locked after payout or terminal state")]
+    ClaimAdjudicationLocked,
 }

--- a/programs/omegax_protocol/src/funding_obligations/obligations.rs
+++ b/programs/omegax_protocol/src/funding_obligations/obligations.rs
@@ -39,6 +39,7 @@ pub(crate) fn create_obligation(
         args.allocation_position,
         args.asset_mint,
     )?;
+    require_supported_obligation_delivery_mode(args.delivery_mode)?;
 
     let obligation = &mut ctx.accounts.obligation;
     obligation.reserve_domain = ctx.accounts.health_plan.reserve_domain;

--- a/programs/omegax_protocol/src/funding_obligations/settlement.rs
+++ b/programs/omegax_protocol/src/funding_obligations/settlement.rs
@@ -24,6 +24,7 @@ pub(crate) fn settle_obligation(
         amount <= obligation.outstanding_amount,
         OmegaXProtocolError::AmountExceedsOutstandingObligation
     );
+    require_full_obligation_transition_amount(args.next_status, amount, obligation)?;
     validate_treasury_mutation_bindings(
         ctx.accounts.series_reserve_ledger.as_deref(),
         ctx.accounts.pool_class_ledger.as_deref(),

--- a/programs/omegax_protocol/src/kernel/reserve_accounting.rs
+++ b/programs/omegax_protocol/src/kernel/reserve_accounting.rs
@@ -205,6 +205,49 @@ pub(crate) fn sync_adjudicated_claim_liability(
     Ok(())
 }
 
+pub(crate) fn require_claim_adjudication_mutable(
+    claim_case: &ClaimCase,
+    obligation: Option<&Obligation>,
+) -> Result<()> {
+    require!(
+        claim_case.paid_amount == 0 && claim_case.intake_status < CLAIM_INTAKE_SETTLED,
+        OmegaXProtocolError::ClaimAdjudicationLocked
+    );
+    if let Some(obligation) = obligation {
+        require!(
+            obligation.status < OBLIGATION_STATUS_SETTLED && obligation.settled_amount == 0,
+            OmegaXProtocolError::ClaimAdjudicationLocked
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn require_supported_obligation_delivery_mode(delivery_mode: u8) -> Result<()> {
+    match delivery_mode {
+        OBLIGATION_DELIVERY_MODE_CLAIMABLE | OBLIGATION_DELIVERY_MODE_PAYABLE => Ok(()),
+        _ => err!(OmegaXProtocolError::InvalidObligationDeliveryMode),
+    }
+}
+
+pub(crate) fn require_full_obligation_transition_amount(
+    next_status: u8,
+    amount: u64,
+    obligation: &Obligation,
+) -> Result<()> {
+    match next_status {
+        OBLIGATION_STATUS_CLAIMABLE_PAYABLE
+        | OBLIGATION_STATUS_SETTLED
+        | OBLIGATION_STATUS_CANCELED => {
+            require!(
+                amount == obligation.outstanding_amount,
+                OmegaXProtocolError::PartialObligationTransitionUnsupported
+            );
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 pub(crate) fn sync_linked_claim_case_reserve(
     claim_case: &mut ClaimCase,
     claim_case_key: Pubkey,

--- a/programs/omegax_protocol/src/tests.rs
+++ b/programs/omegax_protocol/src/tests.rs
@@ -211,6 +211,199 @@ fn sponsor_budget_reserve_and_settlement_walks_the_kernel() {
 }
 
 #[test]
+fn partial_claimable_transition_rejects_without_mutating_obligation() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let obligation = sample_obligation(health_plan, policy_series, funding_line, asset_mint);
+
+    let status = obligation.status;
+    let outstanding_amount = obligation.outstanding_amount;
+    let reserved_amount = obligation.reserved_amount;
+    let result = require_full_obligation_transition_amount(
+        OBLIGATION_STATUS_CLAIMABLE_PAYABLE,
+        outstanding_amount - 1,
+        &obligation,
+    );
+
+    let error = result.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Partial obligation lifecycle transitions are not supported"));
+    assert_eq!(obligation.status, status);
+    assert_eq!(obligation.outstanding_amount, outstanding_amount);
+    assert_eq!(obligation.reserved_amount, reserved_amount);
+}
+
+#[test]
+fn partial_settled_transition_rejects_from_reserved_and_delivery_states() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let mut obligation = sample_obligation(health_plan, policy_series, funding_line, asset_mint);
+
+    for status in [
+        OBLIGATION_STATUS_RESERVED,
+        OBLIGATION_STATUS_CLAIMABLE_PAYABLE,
+    ] {
+        obligation.status = status;
+        let result = require_full_obligation_transition_amount(
+            OBLIGATION_STATUS_SETTLED,
+            obligation.outstanding_amount - 1,
+            &obligation,
+        );
+        let error = result.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Partial obligation lifecycle transitions are not supported"));
+    }
+}
+
+#[test]
+fn partial_canceled_transition_rejects() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let obligation = sample_obligation(health_plan, policy_series, funding_line, asset_mint);
+
+    let result = require_full_obligation_transition_amount(
+        OBLIGATION_STATUS_CANCELED,
+        obligation.outstanding_amount - 1,
+        &obligation,
+    );
+
+    let error = result.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Partial obligation lifecycle transitions are not supported"));
+}
+
+#[test]
+fn full_settlement_and_cancellation_amounts_remain_supported() {
+    let reserve_domain = Pubkey::new_unique();
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let funding_line_key = Pubkey::new_unique();
+
+    let mut settlement_line = sample_funding_line(
+        reserve_domain,
+        health_plan,
+        policy_series,
+        asset_mint,
+        FUNDING_LINE_TYPE_SPONSOR_BUDGET,
+    );
+    settlement_line.reserved_amount = 60;
+    let mut settlement_obligation =
+        sample_obligation(health_plan, policy_series, funding_line_key, asset_mint);
+    let mut domain_assets = 60;
+    let mut domain_sheet = ReserveBalanceSheet {
+        funded: 60,
+        reserved: 60,
+        owed: 60,
+        free: 0,
+        redeemable: 0,
+        ..ReserveBalanceSheet::default()
+    };
+    let mut plan_sheet = domain_sheet;
+    let mut line_sheet = domain_sheet;
+
+    require_full_obligation_transition_amount(
+        OBLIGATION_STATUS_SETTLED,
+        settlement_obligation.outstanding_amount,
+        &settlement_obligation,
+    )
+    .unwrap();
+    settle_delivery(
+        &mut domain_assets,
+        &mut domain_sheet,
+        &mut plan_sheet,
+        &mut line_sheet,
+        None,
+        None,
+        None,
+        None,
+        &mut settlement_line,
+        60,
+        &mut settlement_obligation,
+    )
+    .unwrap();
+
+    assert_eq!(domain_assets, 0);
+    assert_eq!(settlement_obligation.outstanding_amount, 0);
+    assert_eq!(settlement_obligation.settled_amount, 100);
+    assert_eq!(domain_sheet.settled, 60);
+
+    let mut cancellation_line = sample_funding_line(
+        reserve_domain,
+        health_plan,
+        policy_series,
+        asset_mint,
+        FUNDING_LINE_TYPE_SPONSOR_BUDGET,
+    );
+    cancellation_line.reserved_amount = 60;
+    let mut cancellation_obligation =
+        sample_obligation(health_plan, policy_series, funding_line_key, asset_mint);
+    let mut cancel_domain_sheet = ReserveBalanceSheet {
+        funded: 60,
+        reserved: 60,
+        owed: 60,
+        free: 0,
+        redeemable: 0,
+        ..ReserveBalanceSheet::default()
+    };
+    let mut cancel_plan_sheet = cancel_domain_sheet;
+    let mut cancel_line_sheet = cancel_domain_sheet;
+
+    require_full_obligation_transition_amount(
+        OBLIGATION_STATUS_CANCELED,
+        cancellation_obligation.outstanding_amount,
+        &cancellation_obligation,
+    )
+    .unwrap();
+    cancel_outstanding(
+        &mut cancel_domain_sheet,
+        &mut cancel_plan_sheet,
+        &mut cancel_line_sheet,
+        None,
+        None,
+        None,
+        None,
+        &mut cancellation_line,
+        60,
+        &mut cancellation_obligation,
+    )
+    .unwrap();
+
+    assert_eq!(cancellation_obligation.outstanding_amount, 0);
+    assert_eq!(cancellation_obligation.reserved_amount, 0);
+    assert_eq!(cancellation_line.released_amount, 60);
+    assert_eq!(cancel_domain_sheet.owed, 0);
+}
+
+#[test]
+fn invalid_obligation_delivery_mode_rejects() {
+    let mut sheet = ReserveBalanceSheet::default();
+    book_inflow_sheet(&mut sheet, 500).unwrap();
+    let funded_before = sheet.funded;
+    let free_before = sheet.free;
+
+    let result = require_supported_obligation_delivery_mode(99);
+
+    let error = result.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Invalid obligation delivery mode"));
+    assert_eq!(sheet.funded, funded_before);
+    assert_eq!(sheet.free, free_before);
+    assert!(require_supported_obligation_delivery_mode(OBLIGATION_DELIVERY_MODE_CLAIMABLE).is_ok());
+    assert!(require_supported_obligation_delivery_mode(OBLIGATION_DELIVERY_MODE_PAYABLE).is_ok());
+}
+
+#[test]
 fn reserve_capacity_rejects_unfunded_non_allocation_obligations() {
     let mut sheet = ReserveBalanceSheet::default();
     book_inflow_sheet(&mut sheet, 100).unwrap();
@@ -805,6 +998,89 @@ fn adjudication_rejects_linked_obligation_reserve_above_approved_amount() {
 
     let error = result.unwrap_err();
     assert!(error.to_string().contains("Amount exceeds approved claim"));
+}
+
+#[test]
+fn post_payout_claim_adjudication_rejects() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let mut claim_case = sample_claim_case(health_plan, policy_series, funding_line, asset_mint);
+    claim_case.paid_amount = 1;
+
+    let result = require_claim_adjudication_mutable(&claim_case, None);
+
+    let error = result.unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Claim adjudication is locked after payout or terminal state"));
+}
+
+#[test]
+fn settled_or_closed_claim_adjudication_rejects() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let mut claim_case = sample_claim_case(health_plan, policy_series, funding_line, asset_mint);
+    claim_case.paid_amount = 0;
+
+    for intake_status in [CLAIM_INTAKE_SETTLED, CLAIM_INTAKE_CLOSED] {
+        claim_case.intake_status = intake_status;
+        let result = require_claim_adjudication_mutable(&claim_case, None);
+        let error = result.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("Claim adjudication is locked after payout or terminal state"));
+    }
+}
+
+#[test]
+fn pre_payout_claim_adjudication_remains_mutable() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let mut claim_case = sample_claim_case(health_plan, policy_series, funding_line, asset_mint);
+    claim_case.paid_amount = 0;
+
+    for intake_status in [
+        CLAIM_INTAKE_OPEN,
+        CLAIM_INTAKE_UNDER_REVIEW,
+        CLAIM_INTAKE_APPROVED,
+        CLAIM_INTAKE_DENIED,
+    ] {
+        claim_case.intake_status = intake_status;
+        require_claim_adjudication_mutable(&claim_case, None).unwrap();
+    }
+}
+
+#[test]
+fn terminal_or_settled_obligation_locks_adjudication() {
+    let health_plan = Pubkey::new_unique();
+    let policy_series = Pubkey::new_unique();
+    let funding_line = Pubkey::new_unique();
+    let asset_mint = Pubkey::new_unique();
+    let mut claim_case = sample_claim_case(health_plan, policy_series, funding_line, asset_mint);
+    let mut obligation = sample_obligation(health_plan, policy_series, funding_line, asset_mint);
+    claim_case.paid_amount = 0;
+    claim_case.intake_status = CLAIM_INTAKE_APPROVED;
+
+    obligation.status = OBLIGATION_STATUS_SETTLED;
+    let terminal_result = require_claim_adjudication_mutable(&claim_case, Some(&obligation));
+    let terminal_error = terminal_result.unwrap_err();
+    assert!(terminal_error
+        .to_string()
+        .contains("Claim adjudication is locked after payout or terminal state"));
+
+    obligation.status = OBLIGATION_STATUS_RESERVED;
+    obligation.settled_amount = 1;
+    let settled_result = require_claim_adjudication_mutable(&claim_case, Some(&obligation));
+    let settled_error = settled_result.unwrap_err();
+    assert!(settled_error
+        .to_string()
+        .contains("Claim adjudication is locked after payout or terminal state"));
 }
 
 fn membership_proof_input(membership_mode: u8, proof_mode: u8) -> MembershipProofValidationInput {

--- a/scripts/bootstrap_genesis_live_protocol.ts
+++ b/scripts/bootstrap_genesis_live_protocol.ts
@@ -161,6 +161,19 @@ function stringifyJson(value: unknown): string {
   );
 }
 
+function loadAndValidateOracleKeypair(config: ReturnType<typeof loadGenesisLiveBootstrapConfig>): Keypair {
+  if (!existsSync(config.roles.oracleKeypairPath)) {
+    throw new Error("Genesis live oracle keypair file was not found.");
+  }
+  const oracle = keypairFromFile(config.roles.oracleKeypairPath);
+  if (oracle.publicKey.toBase58() !== config.roles.oracleAuthority) {
+    throw new Error(
+      `OMEGAX_LIVE_ORACLE_WALLET (${config.roles.oracleAuthority}) does not match the configured oracle keypair.`,
+    );
+  }
+  return oracle;
+}
+
 async function main() {
   const { planOnly } = parseArgs(process.argv.slice(2));
   loadEnvFile(FRONTEND_ENV_PATH);
@@ -173,6 +186,7 @@ async function main() {
   });
 
   if (planOnly) {
+    loadAndValidateOracleKeypair(config);
     console.log(stringifyJson(planSummary(protocol, config)));
     return;
   }
@@ -181,12 +195,7 @@ async function main() {
     throw new Error(`Genesis schema metadata file not found: ${config.schema.metadataLocalPath}`);
   }
 
-  const oracle = keypairFromFile(config.roles.oracleKeypairPath);
-  if (oracle.publicKey.toBase58() !== config.roles.oracleAuthority) {
-    throw new Error(
-      `OMEGAX_LIVE_ORACLE_WALLET (${config.roles.oracleAuthority}) does not match ${config.roles.oracleKeypairPath} (${oracle.publicKey.toBase58()}).`,
-    );
-  }
+  const oracle = loadAndValidateOracleKeypair(config);
 
   const seniorLp = config.capitalClasses.senior.lpKeypairPath
     ? keypairFromFile(config.capitalClasses.senior.lpKeypairPath)

--- a/tests/claim_funding_readiness.test.ts
+++ b/tests/claim_funding_readiness.test.ts
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Keypair } from "@solana/web3.js";
+
+import protocolModule from "../frontend/lib/protocol.ts";
+
+const protocol = protocolModule as typeof import("../frontend/lib/protocol.ts");
+type DomainAssetVaultSnapshot = import("../frontend/lib/protocol.ts").DomainAssetVaultSnapshot;
+type ProtocolConsoleSnapshot = import("../frontend/lib/protocol.ts").ProtocolConsoleSnapshot;
+type ReserveAssetRailSnapshot = import("../frontend/lib/protocol.ts").ReserveAssetRailSnapshot;
+
+const nowTs = 1_777_777_777;
+const reserveDomain = pk();
+const settlementMint = pk();
+const wbtcMint = pk();
+const wethMint = pk();
+const healthPlan = pk();
+const policySeries = pk();
+const fundingLine = pk();
+const pool = pk();
+const capitalClass = pk();
+
+function pk(): string {
+  return Keypair.generate().publicKey.toBase58();
+}
+
+function emptySnapshot(overrides: Partial<ProtocolConsoleSnapshot> = {}): ProtocolConsoleSnapshot {
+  return {
+    protocolGovernance: null,
+    reserveDomains: [],
+    domainAssetVaults: [],
+    reserveAssetRails: [],
+    domainAssetLedgers: [],
+    healthPlans: [],
+    policySeries: [],
+    memberPositions: [],
+    commitmentCampaigns: [],
+    commitmentPaymentRails: [],
+    commitmentLedgers: [],
+    commitmentPositions: [],
+    fundingLines: [],
+    claimCases: [],
+    obligations: [],
+    liquidityPools: [],
+    capitalClasses: [],
+    lpPositions: [],
+    allocationPositions: [],
+    planReserveLedgers: [],
+    seriesReserveLedgers: [],
+    fundingLineLedgers: [],
+    poolClassLedgers: [],
+    allocationLedgers: [],
+    outcomesBySeries: {},
+    oracleProfiles: [],
+    poolOracleApprovals: [],
+    poolOraclePolicies: [],
+    poolOraclePermissionSets: [],
+    outcomeSchemas: [],
+    schemaDependencyLedgers: [],
+    claimAttestations: [],
+    protocolFeeVaults: [],
+    poolTreasuryVaults: [],
+    poolOracleFeeVaults: [],
+    ...overrides,
+  };
+}
+
+function vault(assetMint: string, totalAssets: bigint): DomainAssetVaultSnapshot {
+  return {
+    address: pk(),
+    reserveDomain,
+    assetMint,
+    vaultTokenAccount: pk(),
+    totalAssets,
+    bump: 255,
+  };
+}
+
+function rail(params: {
+  assetMint: string;
+  symbol: string;
+  priceUsd1e8?: bigint;
+  haircutBps?: number;
+  publishedAtTs?: number;
+}): ReserveAssetRailSnapshot {
+  return {
+    address: pk(),
+    reserveDomain,
+    assetMint: params.assetMint,
+    oracleAuthority: pk(),
+    assetSymbol: params.symbol,
+    role: 0,
+    payoutPriority: 0,
+    oracleSource: 0,
+    oracleFeedIdHex: "11".repeat(32),
+    maxStalenessSeconds: 3_600,
+    haircutBps: params.haircutBps ?? 0,
+    maxExposureBps: 10_000,
+    depositEnabled: true,
+    payoutEnabled: true,
+    capacityEnabled: true,
+    active: true,
+    lastPriceUsd1e8: params.priceUsd1e8 ?? 100_000_000n,
+    lastPriceConfidenceBps: 25,
+    lastPricePublishedAtTs: params.publishedAtTs ?? nowTs,
+    lastPriceSlot: 1n,
+    lastPriceProofHashHex: "22".repeat(32),
+    auditNonce: 0n,
+    bump: 254,
+  };
+}
+
+test("claim funding readiness settles now when settlement-mint reserve capacity is enough", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      domainAssetLedgers: [{ address: pk(), reserveDomain, assetMint: settlementMint, sheet: { funded: 1_000n } }],
+      reserveAssetRails: [rail({ assetMint: settlementMint, symbol: "USDC" })],
+    }),
+    reserveDomainAddress: reserveDomain,
+    settlementMint,
+    requestedAmount: 600n,
+    assetDecimalsByMint: { [settlementMint]: 0 },
+    nowTs,
+  });
+
+  assert.equal(model.readiness, "settle_now");
+  assert.equal(model.immediatelySettleableAmount, 1_000n);
+  assert.equal(model.otherReserveAssets.length, 0);
+});
+
+test("claim funding readiness shows other priced assets without treating them as settlement capacity", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      domainAssetLedgers: [
+        { address: pk(), reserveDomain, assetMint: settlementMint, sheet: { funded: 250n } },
+        { address: pk(), reserveDomain, assetMint: wbtcMint, sheet: { funded: 1n } },
+      ],
+      reserveAssetRails: [
+        rail({ assetMint: settlementMint, symbol: "USDC" }),
+        rail({ assetMint: wbtcMint, symbol: "WBTC", priceUsd1e8: 5_000_000_000_000n, haircutBps: 5_000 }),
+      ],
+    }),
+    reserveDomainAddress: reserveDomain,
+    settlementMint,
+    requestedAmount: 1_000n,
+    assetDecimalsByMint: { [settlementMint]: 0, [wbtcMint]: 0 },
+    nowTs,
+  });
+
+  assert.equal(model.immediatelySettleableAmount, 250n);
+  assert.equal(model.readiness, "operator_action_required");
+  assert.equal(model.otherReserveAssets.length, 1);
+  assert.equal(model.otherReserveAssets[0]!.assetMint, wbtcMint);
+  assert.equal(model.otherReserveAssets[0]!.immediatelySettleable, false);
+  assert(model.warnings.some((warning) => warning.includes("valuation context only")));
+});
+
+test("claim funding readiness refuses to count non-settlement assets without a fresh price", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      domainAssetLedgers: [
+        { address: pk(), reserveDomain, assetMint: settlementMint, sheet: { funded: 100n } },
+        { address: pk(), reserveDomain, assetMint: wethMint, sheet: { funded: 10n } },
+      ],
+      reserveAssetRails: [
+        rail({ assetMint: settlementMint, symbol: "USDC" }),
+        rail({ assetMint: wethMint, symbol: "WETH", priceUsd1e8: 0n }),
+      ],
+    }),
+    reserveDomainAddress: reserveDomain,
+    settlementMint,
+    requestedAmount: 500n,
+    assetDecimalsByMint: { [settlementMint]: 0, [wethMint]: 0 },
+    nowTs,
+  });
+
+  assert.equal(model.readiness, "queue_or_refund");
+  assert.equal(model.otherReserveAssets[0]!.haircutAdjustedValueUsd1e8, null);
+  assert(model.otherReserveAssets[0]!.warnings.some((warning) => warning.includes("No fresh published price")));
+});
+
+test("claim funding readiness reduces fallback vault capacity by pending obligations", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      domainAssetVaults: [vault(settlementMint, 1_000n)],
+      reserveAssetRails: [rail({ assetMint: settlementMint, symbol: "USDC" })],
+      obligations: [{
+        address: pk(),
+        reserveDomain,
+        assetMint: settlementMint,
+        healthPlan,
+        policySeries,
+        fundingLine,
+        obligationId: "pending-claim",
+        status: protocol.OBLIGATION_STATUS_RESERVED,
+        deliveryMode: protocol.OBLIGATION_DELIVERY_MODE_PAYABLE,
+        principalAmount: 600n,
+        reservedAmount: 600n,
+      }],
+    }),
+    reserveDomainAddress: reserveDomain,
+    healthPlanAddress: healthPlan,
+    policySeriesAddress: policySeries,
+    fundingLineAddress: fundingLine,
+    settlementMint,
+    requestedAmount: 500n,
+    nowTs,
+  });
+
+  assert.equal(model.pendingObligationsAmount, 600n);
+  assert.equal(model.reservedOrPayableAmount, 600n);
+  assert.equal(model.directSettlementAssetCapacityAmount, 400n);
+  assert.equal(model.readiness, "queue_or_refund");
+});
+
+test("claim funding readiness reduces fallback vault capacity by queued LP redemptions", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      domainAssetVaults: [vault(settlementMint, 1_000n)],
+      reserveAssetRails: [rail({ assetMint: settlementMint, symbol: "USDC" })],
+      liquidityPools: [{
+        address: pool,
+        reserveDomain,
+        poolId: "income",
+        displayName: "Income",
+        depositAssetMint: settlementMint,
+        strategyThesis: "test",
+        redemptionPolicy: protocol.REDEMPTION_POLICY_QUEUE_ONLY,
+        totalValueLocked: 1_000n,
+        active: true,
+      }],
+      capitalClasses: [{
+        address: capitalClass,
+        liquidityPool: pool,
+        classId: "senior",
+        displayName: "Senior",
+        priority: 0,
+        restrictionMode: protocol.CAPITAL_CLASS_RESTRICTION_OPEN,
+        totalShares: 1_000n,
+        navAssets: 1_000n,
+        pendingRedemptions: 300n,
+        active: true,
+      }],
+      lpPositions: [{
+        address: pk(),
+        owner: pk(),
+        capitalClass,
+        shares: 1_000n,
+        subscriptionBasis: 1_000n,
+        pendingRedemptionAssets: 300n,
+        queueStatus: protocol.LP_QUEUE_STATUS_PENDING,
+      }],
+    }),
+    reserveDomainAddress: reserveDomain,
+    settlementMint,
+    requestedAmount: 800n,
+    nowTs,
+  });
+
+  assert.equal(model.queuedRedemptionsAmount, 300n);
+  assert.equal(model.directSettlementAssetCapacityAmount, 700n);
+  assert.equal(model.readiness, "queue_or_refund");
+});
+
+test("claim approval evidence stays separate from settlement funding readiness", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      claimCases: [{
+        address: pk(),
+        reserveDomain,
+        healthPlan,
+        policySeries,
+        fundingLine,
+        memberPosition: pk(),
+        claimant: pk(),
+        claimId: "approved-but-unfunded",
+        intakeStatus: protocol.CLAIM_INTAKE_APPROVED,
+        approvedAmount: 10_000n,
+      }],
+      domainAssetVaults: [vault(settlementMint, 100n)],
+      reserveAssetRails: [rail({ assetMint: settlementMint, symbol: "USDC" })],
+    }),
+    reserveDomainAddress: reserveDomain,
+    healthPlanAddress: healthPlan,
+    policySeriesAddress: policySeries,
+    fundingLineAddress: fundingLine,
+    settlementMint,
+    requestedAmount: 1_000n,
+    nowTs,
+  });
+
+  assert.equal(model.requestedAmount, 1_000n);
+  assert.equal(model.immediatelySettleableAmount, 100n);
+  assert.notEqual(model.readiness, "settle_now");
+});

--- a/tests/genesis_live_bootstrap_plan_cli.test.ts
+++ b/tests/genesis_live_bootstrap_plan_cli.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+import { Keypair } from "@solana/web3.js";
+
+const MAINNET_USDC = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function writeKeypair(path: string): Keypair {
+  const keypair = Keypair.generate();
+  writeFileSync(path, JSON.stringify(Array.from(keypair.secretKey)));
+  return keypair;
+}
+
+function role(): string {
+  return Keypair.generate().publicKey.toBase58();
+}
+
+function runPlan(overrides: Record<string, string | undefined>) {
+  const dir = mkdtempSync(join(tmpdir(), "omegax-genesis-plan-test-"));
+  const governancePath = join(dir, "governance.json");
+  const oraclePath = join(dir, "oracle.json");
+  const governance = writeKeypair(governancePath);
+  const oracle = writeKeypair(oraclePath);
+  const env = {
+    ...process.env,
+    SOLANA_KEYPAIR: governancePath,
+    SOLANA_RPC_URL: "https://api.mainnet-beta.solana.com",
+    OMEGAX_LIVE_CLUSTER_OVERRIDE: "mainnet",
+    OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS: "1",
+    OMEGAX_LIVE_SETTLEMENT_MINT: MAINNET_USDC,
+    OMEGAX_LIVE_RESERVE_DOMAIN_ADMIN: role(),
+    OMEGAX_LIVE_SPONSOR_WALLET: role(),
+    OMEGAX_LIVE_SPONSOR_OPERATOR_WALLET: role(),
+    OMEGAX_LIVE_CLAIMS_OPERATOR_WALLET: role(),
+    OMEGAX_LIVE_ORACLE_WALLET: oracle.publicKey.toBase58(),
+    OMEGAX_LIVE_ORACLE_KEYPAIR_PATH: oraclePath,
+    OMEGAX_LIVE_POOL_CURATOR_WALLET: role(),
+    OMEGAX_LIVE_POOL_ALLOCATOR_WALLET: role(),
+    OMEGAX_LIVE_POOL_SENTINEL_WALLET: role(),
+    ...overrides,
+  };
+  return {
+    governance,
+    oracle,
+    oraclePath,
+    result: spawnSync(
+      process.execPath,
+      ["--import", "tsx", "scripts/bootstrap_genesis_live_protocol.ts", "--plan"],
+      {
+        cwd: process.cwd(),
+        env,
+        encoding: "utf8",
+      },
+    ),
+  };
+}
+
+test("Genesis live plan mode validates oracle keypair before no-send output", () => {
+  const { result, oracle } = runPlan({});
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.roles.oracleAuthority, oracle.publicKey.toBase58());
+  assert.equal(parsed.settlementMint, MAINNET_USDC);
+});
+
+test("Genesis live plan mode rejects a missing oracle keypair before any send path", () => {
+  const { result } = runPlan({
+    OMEGAX_LIVE_ORACLE_KEYPAIR_PATH: "/tmp/omegax-missing-oracle-keypair.json",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /oracle keypair file was not found/);
+});
+
+test("Genesis live plan mode rejects an oracle wallet/keypair mismatch before any send path", () => {
+  const { result } = runPlan({
+    OMEGAX_LIVE_ORACLE_WALLET: role(),
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /OMEGAX_LIVE_ORACLE_WALLET .* does not match the configured oracle keypair/);
+});

--- a/tests/security/cybersecurity_plan_regression.test.ts
+++ b/tests/security/cybersecurity_plan_regression.test.ts
@@ -10,6 +10,9 @@ const frontendProtocolSource = readFileSync(
   new URL("../../frontend/lib/protocol.ts", import.meta.url),
   "utf8",
 );
+const idl = JSON.parse(
+  readFileSync(new URL("../../idl/omegax_protocol.json", import.meta.url), "utf8"),
+) as { errors?: Array<{ name: string }> };
 
 test("[CSO-2026-05-04] claim recipients lock after approval or payout", () => {
   const body = extractRustFunctionBody("authorize_claim_recipient");
@@ -67,4 +70,51 @@ test("[CSO-2026-05-04] broad pool authority helper is removed from mutation path
   assert.match(extractRustFunctionBody("set_pool_oracle_permissions"), /require_curator_control\(/);
   assert.match(extractRustFunctionBody("set_pool_oracle_policy"), /require_curator_control\(/);
   assert.match(extractRustFunctionBody("update_allocation_caps"), /require_allocator\(/);
+});
+
+test("[CSO-2026-05-05] obligation lifecycle transitions reject partial amounts before mutation", () => {
+  const body = extractRustFunctionBody("settle_obligation");
+  const guardIndex = body.indexOf("require_full_obligation_transition_amount");
+  assert.notEqual(guardIndex, -1);
+  for (const mutation of [
+    "release_reserved_to_delivery",
+    "settle_delivery",
+    "cancel_outstanding",
+  ]) {
+    const mutationIndex = body.indexOf(mutation);
+    assert.notEqual(mutationIndex, -1);
+    assert.ok(guardIndex < mutationIndex, `${mutation} must be after the full-transition guard`);
+  }
+  assert.match(programSource, /PartialObligationTransitionUnsupported/);
+});
+
+test("[CSO-2026-05-05] obligation delivery mode is validated before ledger booking", () => {
+  const body = extractRustFunctionBody("create_obligation");
+  const guardIndex = body.indexOf("require_supported_obligation_delivery_mode");
+  const bookIndex = body.indexOf("book_owed");
+  assert.notEqual(guardIndex, -1);
+  assert.notEqual(bookIndex, -1);
+  assert.ok(guardIndex < bookIndex, "delivery mode must be checked before owed ledger mutation");
+  assert.match(programSource, /InvalidObligationDeliveryMode/);
+});
+
+test("[CSO-2026-05-05] claim adjudication locks after payout or terminal state before rewrites", () => {
+  const body = extractRustFunctionBody("adjudicate_claim_case");
+  const guardIndex = body.indexOf("require_claim_adjudication_mutable");
+  const rewriteIndex = body.indexOf("claim_case.adjudicator");
+  assert.notEqual(guardIndex, -1);
+  assert.notEqual(rewriteIndex, -1);
+  assert.ok(guardIndex < rewriteIndex, "adjudication lock must run before claim fields are rewritten");
+  assert.match(programSource, /ClaimAdjudicationLocked/);
+});
+
+test("[CSO-2026-05-05] IDL exposes pre-mainnet liability-state error codes", () => {
+  const errorNames = new Set((idl.errors ?? []).map((error) => error.name));
+  for (const expected of [
+    "PartialObligationTransitionUnsupported",
+    "InvalidObligationDeliveryMode",
+    "ClaimAdjudicationLocked",
+  ]) {
+    assert.ok(errorNames.has(expected), `IDL must expose ${expected}`);
+  }
 });


### PR DESCRIPTION
## Summary
- harden obligation lifecycle transitions so partial claimable/payable, settled, and canceled transitions reject before mutation
- lock claim adjudication after payout, settled/closed claim state, or terminal/settled linked obligations
- reject invalid obligation delivery modes before owed ledger booking
- regenerate IDL/source hash and update v0.3.2 release evidence
- refresh release evidence after review-and-iterate rerun

## Validation
Local:
- npm run rust:test
- npm run test:node
- npm run anchor:idl
- npm run protocol:contract
- npm run verify:public
- OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet
- SOLANA_KEYPAIR=<devnet governance keypair> npm run devnet:operator:drawer:sim
- npm run public:hygiene:check

Remote on current head ace6317a37997ab148f78a0f817565ed323197f1:
- CodeQL: pass https://github.com/OmegaX-Health/omegax-protocol/runs/74269517022
- Public CI verify: pass https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475611/job/74269330889
- Localnet E2E: pass https://github.com/OmegaX-Health/omegax-protocol/actions/runs/25332475638/job/74269331451

## Release posture
No mainnet sends or real reserve funding in this PR. The latest review-and-iterate rerun says this is code-green for pre-mainnet review but not ready for paid mainnet funding until the PR is reviewed/merged, governance and upgrade authority multisig posture is proven, the hardened binary is redeployed/rehearsed on devnet, branch review enforcement is fixed or explicitly accepted, and an independent money/control review is recorded.