### PR TITLE
Harden negative rehearsal simulation RPC handling

### DIFF
--- a/scripts/devnet_founder_rehearsal.ts
+++ b/scripts/devnet_founder_rehearsal.ts
@@ -2352,7 +2352,12 @@ async function simulateExpectedFailure(
     encodedTransaction,
     { commitment: "confirmed", encoding: "base64", sigVerify: true },
   ]);
-  const err = response.error ?? response.result?.value?.err;
+  if (response.error) {
+    throw new Error(
+      `simulateTransaction RPC error for negative simulation ${label}: ${JSON.stringify(response.error)}`,
+    );
+  }
+  const err = response.result?.value?.err;
   if (!err) {
     throw new Error(`Negative simulation unexpectedly passed: ${label}`);
   }


### PR DESCRIPTION
### Motivation
- The negative-simulation helper treated top-level JSON-RPC `simulateTransaction` errors (`response.error`) as equivalent to a program/runtime simulation failure, which could record transient RPC/transport failures as expected negative outcomes.

### Description
- Change the `simulateExpectedFailure` helper in `scripts/devnet_founder_rehearsal.ts` to throw when `response.error` is present and only accept `response.result?.value?.err` as the intended negative simulation result.
- Keep collected `logs` and the existing `ctx.negativeSimulations` shape intact and make the change narrowly scoped to the RPC-response handling.

### Testing
- Ran the node tests with `npm run test:node`, and the suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e82f1df8832fb6d057dff4bcd95d)