### PR TITLE
Harden founder rehearsal keypair file permissions

### DIFF
--- a/scripts/devnet_founder_rehearsal.ts
+++ b/scripts/devnet_founder_rehearsal.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Buffer } from "node:buffer";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -167,12 +167,17 @@ function keypairPath(label: string): string {
 function ensureLocalKeypair(label: string, mode: "plan" | "execute"): Keypair {
   assertMaySend(mode);
   const path = keypairPath(label);
-  mkdirSync(dirname(path), { recursive: true });
+  const dir = dirname(path);
+  mkdirSync(dir, { mode: 0o700, recursive: true });
+  chmodSync(dir, 0o700);
   if (existsSync(path)) {
+    chmodSync(path, 0o600);
     return keypairFromFile(path);
   }
   const keypair = Keypair.generate();
-  writeFileSync(path, `${JSON.stringify([...keypair.secretKey])}\n`);
+  writeFileSync(path, `${JSON.stringify([...keypair.secretKey])}\n`, {
+    mode: 0o600,
+  });
   return keypair;
 }
 


### PR DESCRIPTION
### Motivation
- A devnet rehearsal script persisted generated Solana secret-key JSON under the user home directory using default filesystem permissions, allowing other local users to read private keys on multi-user systems.
- The intent is to prevent accidental exposure of rehearsal/operator private keys while preserving the script's functionality for local devnet rehearsals.

### Description
- Updated `ensureLocalKeypair` in `scripts/devnet_founder_rehearsal.ts` to create the parent directory with restrictive permissions using `mkdirSync(dir, { mode: 0o700, recursive: true })` and to enforce `0700` with `chmodSync(dir, 0o700)`.
- Ensure existing key files are force-corrected to `0600` via `chmodSync(path, 0o600)` before loading them with `keypairFromFile`.
- Write newly generated key files with explicit mode `0o600` by passing `{ mode: 0o600 }` to `writeFileSync`.
- Added `chmodSync` to the Node FS imports to support the permission hardening logic and otherwise preserved existing behavior.

### Testing
- Ran `npm run devnet:founder:rehearsal` and observed the script complete its planned output without exposing key files with world-readable permissions; the run succeeded.
- Verified the edited `ensureLocalKeypair` function writes directories and files with the intended `0700` and `0600` modes respectively by inspecting the modified source and executing the script in the workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e9c02ae0832f97994822812ced1a)