### PR TITLE
fix(security): redact RPC path/hash in treasury canary logs

### DIFF
--- a/scripts/seed_devnet_treasury_canaries.ts
+++ b/scripts/seed_devnet_treasury_canaries.ts
@@ -142,7 +142,9 @@ function stableHash(label: string): string {
 function redactRpcUrl(value: string): string {
   try {
     const url = new URL(value);
+    if (url.pathname && url.pathname !== "/") url.pathname = "/...";
     if (url.search) url.search = "?...";
+    if (url.hash) url.hash = "#...";
     if (url.username || url.password) {
       url.username = "...";
       url.password = "";


### PR DESCRIPTION
### Motivation
- Prevent leakage of RPC credentials because `scripts/seed_devnet_treasury_canaries.ts` logged the full RPC URL while `redactRpcUrl` only masked query and basic-auth, allowing path-embedded API tokens to appear in logs.

### Description
- Change `redactRpcUrl` in `scripts/seed_devnet_treasury_canaries.ts` to also redact non-root `pathname` to `"/..."` and `hash` to `"#..."` while preserving existing masking of `search` and `username`/`password`, keeping the script flow unchanged.

### Testing
- Ran `npm run test:node` and the test suite completed successfully with all tests passing (234 passed, 0 failed), and the patched lines in `scripts/seed_devnet_treasury_canaries.ts` were inspected to confirm the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e9c10d64832f844394067d47b4c3)