### PR TITLE
fix(frontend): align claim readiness LP capacity with on-chain accounting

### DIFF
--- a/frontend/lib/protocol.ts
+++ b/frontend/lib/protocol.ts
@@ -1999,12 +1999,9 @@ export function buildClaimFundingReadiness(params: ClaimFundingReadinessInput): 
       && params.snapshot.fundingLines.some((line) => line.address === allocation.fundingLine && line.assetMint === settlementMint),
     )
     .reduce((sum, allocation) => {
-      const capAmount = toBigIntAmount(allocation.capAmount);
-      const encumbered =
-        toBigIntAmount(allocation.allocatedAmount)
-        + toBigIntAmount(allocation.reservedCapacity)
-        + toBigIntAmount(allocation.utilizedAmount);
-      return sum + (capAmount > encumbered ? capAmount - encumbered : 0n);
+      const allocatedAmount = toBigIntAmount(allocation.allocatedAmount);
+      const reservedCapacity = toBigIntAmount(allocation.reservedCapacity);
+      return sum + (allocatedAmount > reservedCapacity ? allocatedAmount - reservedCapacity : 0n);
     }, 0n);
 
   const railsByMint = new Map(

--- a/tests/claim_funding_readiness.test.ts
+++ b/tests/claim_funding_readiness.test.ts
@@ -296,3 +296,46 @@ test("claim approval evidence stays separate from settlement funding readiness",
   assert.equal(model.immediatelySettleableAmount, 100n);
   assert.notEqual(model.readiness, "settle_now");
 });
+
+test("claim funding readiness does not treat allocation cap headroom as reserve capacity", () => {
+  const model = protocol.buildClaimFundingReadiness({
+    snapshot: emptySnapshot({
+      allocationPositions: [{
+        address: pk(),
+        reserveDomain,
+        healthPlan,
+        policySeries,
+        fundingLine,
+        liquidityPool: pool,
+        capitalClass,
+        capAmount: 1_000n,
+        allocatedAmount: 0n,
+        reservedCapacity: 0n,
+        utilizedAmount: 0n,
+        active: true,
+      }],
+      fundingLines: [{
+        address: fundingLine,
+        reserveDomain,
+        healthPlan,
+        policySeries,
+        lineId: "line-1",
+        assetMint: settlementMint,
+        lpPolicyId: "policy",
+        maxNotional: 1_000n,
+        utilizedNotional: 0n,
+        status: protocol.FUNDING_LINE_STATUS_OPEN,
+      }],
+    }),
+    reserveDomainAddress: reserveDomain,
+    healthPlanAddress: healthPlan,
+    policySeriesAddress: policySeries,
+    fundingLineAddress: fundingLine,
+    settlementMint,
+    requestedAmount: 500n,
+    nowTs,
+  });
+
+  assert.equal(model.availableLpAllocationCapacityAmount, 0n);
+  assert.equal(model.readiness, "queue_or_refund");
+});


### PR DESCRIPTION
### Motivation
- The frontend `buildClaimFundingReadiness` incorrectly treated unused allocation `capAmount` headroom as immediately-available LP capacity, which can make the UI report `reserve_then_settle` even when on-chain reserves would reject a reservation.  
- On-chain logic only permits reserves against actual allocated capacity (`allocated_amount - reserved_capacity`), so the frontend needed to match that accounting to avoid misleading operators or workflows.

### Description
- Change frontend readiness math in `buildClaimFundingReadiness` to compute LP allocation capacity from free allocated capital (`allocatedAmount - reservedCapacity`) instead of cap headroom.  
- Replace the previous reduction that used `capAmount - (allocated + reserved + utilized)` with `max(allocatedAmount - reservedCapacity, 0)`.  
- Add a regression test `tests/claim_funding_readiness.test.ts` that reproduces the reported scenario (`capAmount>0` with `allocatedAmount=0`) and asserts `availableLpAllocationCapacityAmount === 0n` and `readiness === 'queue_or_refund'`.

### Testing
- Ran `node --import tsx --test tests/claim_funding_readiness.test.ts` and observed the new and existing claim readiness tests pass.  
- Ran the repo test wrapper `npm run test:node -- tests/claim_funding_readiness.test.ts` and confirmed all exercised tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e94b42ec832f865f5f820e1b1aa5)