### PR TITLE
chore(dependabot): pause version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    # Version-update PRs are paused during the mainnet security/redeploy window.
+    # Dependabot security alerts remain handled through the advisory gate.
     schedule:
       interval: monthly
       day: monday
       time: "04:00"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     groups:
       npm-minor-patch:
         patterns:
@@ -24,7 +26,7 @@ updates:
       interval: monthly
       day: monday
       time: "04:15"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     groups:
       frontend-minor-patch:
         patterns:
@@ -42,7 +44,7 @@ updates:
       interval: monthly
       day: monday
       time: "04:30"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     groups:
       cargo-minor-patch:
         patterns:
@@ -60,7 +62,7 @@ updates:
       interval: monthly
       day: monday
       time: "04:45"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     groups:
       github-actions-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot immediately reopened grouped version-update PRs after the security consolidation merged. This pauses Dependabot version-update PR creation during the mainnet security/redeploy window by setting each configured ecosystem to `open-pull-requests-limit: 0`.

Security/advisory review remains covered by the repo advisory gate and dependency risk acceptance docs.

## Validation

- `git diff --check`

Signed-off-by: Marino Sabijan, MD <marinosabijan@gmail.com>