### PR TITLE
Gate Phase 0 mainnet surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,14 @@ Public repository. Keep instructions and changes public-safe.
 - Do not hand-edit generated outputs in `idl/`, `shared/`, or `frontend/lib/generated/` unless a documented maintenance workflow explicitly requires it.
 - If you change the protocol surface or shared protocol builders, regenerate artifacts with `npm run anchor:idl` and `npm run protocol:contract`.
 
+## Cross-Repo Protect Buyer Surface
+
+- The `$99` Founder commitment buyer flow belongs in the OmegaX website Protect funnel and the OmegaX Health `protocol-oracle-service`, not in this protocol console as a duplicate purchase UI.
+- The protocol console should treat Founder commitments as a transparency/operator/auditor surface: show campaign status, accepted rails, pending/activated/refunded counts, terms hash, linked coverage lane, and reserve impact, then link out to the consumer Protect flow when a user wants to commit.
+- Keep these states semantically separate in labels, models, and docs: Founder commitment is a refundable pending hold; Protect quote is eligibility/pricing for activating cover; claims-paying reserve only increases after the relevant activation/posting rules are satisfied.
+- Do not present pending commitments as active cover or available claims-paying reserve. Pending custody, treasury inventory, and reserve impact must remain distinct.
+- If the external consumer/oracle commitment campaign cannot be read in production, fail closed in protocol-facing copy instead of implying the campaign is actively accepting deposits.
+
 ## Genesis Protect Launch Keys
 
 - The prepared public vanity operator wallet is `oxhocTdPyENqy9RS13iaq2upoNAovMJHu9PMaBxrK8h`.

--- a/docs/operations/phase0-mainnet-surface-gating.md
+++ b/docs/operations/phase0-mainnet-surface-gating.md
@@ -1,0 +1,89 @@
+# Phase 0 Mainnet Surface Gating
+
+Phase 0 keeps the on-chain OmegaX program broad and permissioned, but narrows the public mainnet console and bootstrap paths to the conservative live surface.
+
+There is no on-chain `phase0` switch, no deleted instruction set, and no duplicated Founder checkout in this repository. The public console is the reserve, liability, LP, operator, and auditor surface. The consumer Founder commitment flow remains outside this repository in the OmegaX website and OmegaX Health protocol oracle service.
+
+## Mainnet Profile
+
+The frontend and bootstrap scripts share `GenesisPhase0LaunchProfile` from `frontend/lib/genesis-phase0-launch-profile.ts`.
+
+Mainnet defaults:
+
+- LP deposit actions are live.
+- LP redemption requests are live.
+- Capital, reserve, claims, oracle, and commitment dashboards are read-only.
+- Operator settlement visibility is read-only.
+- Rewards, RWA policy launch, hybrid launch, DAO fallback, and future launch choices render as disabled previews.
+- Capital admin and policy admin actions are hidden unless operator execution is explicitly enabled.
+
+The on-chain program still enforces the actual security boundary: signer authority, PDA/account binding, custody mint/program validation, Token-2022 rejection, no mixed-asset settlement, claim and obligation locks, and role-specific permissions.
+
+## Devnet Profile
+
+Devnet exposes the same code paths, but preview and rehearsal surfaces can become live behind explicit flags. This keeps the public branch identical while allowing devnet rehearsal without a staging-only fork.
+
+Frontend flags:
+
+| Flag | Effect |
+|------|--------|
+| `NEXT_PUBLIC_ENABLE_REWARD_LAUNCH=1` | Makes reward launch preview actionable on devnet. |
+| `NEXT_PUBLIC_ENABLE_RWA_POLICY=1` | Makes RWA policy preview actionable on devnet. |
+| `NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH=1` | Makes hybrid launch preview actionable on devnet. |
+| `NEXT_PUBLIC_ENABLE_DAO_FALLBACK=1` | Makes DAO fallback preview actionable on devnet. |
+| `NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS=1` | Shows operator/admin execution surfaces. |
+| `NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES=1` | Required in addition to the specific product flag before a future surface can become actionable on mainnet. |
+
+## Bootstrap Guards
+
+The Genesis live bootstrap maps operator environment variables into the same launch profile and refuses accidental mainnet creation of future or admin surfaces before any send path.
+
+Mainnet product/admin allowlist variables:
+
+| Attempted surface | Required product flag | Required mainnet allow flag |
+|-------------------|-----------------------|-----------------------------|
+| Reward launch | `OMEGAX_LIVE_ENABLE_REWARD_LAUNCH=1` | `OMEGAX_ALLOW_MAINNET_REWARD_LAUNCH=1` |
+| RWA policy launch | `OMEGAX_LIVE_ENABLE_RWA_POLICY=1` | `OMEGAX_ALLOW_MAINNET_RWA_LAUNCH=1` |
+| Hybrid launch | `OMEGAX_LIVE_ENABLE_HYBRID_LAUNCH=1` | `OMEGAX_ALLOW_MAINNET_HYBRID_LAUNCH=1` |
+| Extra admin bootstrap | `OMEGAX_LIVE_ENABLE_ADMIN_BOOTSTRAP=1` | `OMEGAX_ALLOW_MAINNET_ADMIN_BOOTSTRAP=1` |
+
+`npm run protocol:bootstrap:genesis-live -- --plan` must print:
+
+- launch profile id, network, disabled surfaces, and hidden surfaces;
+- LP class posture: open classes, 30-day lockup, queue-only redemption, classic SPL-only;
+- redemption posture: public request surface and operator-processed queue;
+- settlement mint, role map, and no-send status.
+
+## Commitment Visibility
+
+The protocol dapp shows Founder commitments as plan and policy-series state. It must not become the consumer purchase flow.
+
+The Genesis setup dashboard separates:
+
+- campaign status;
+- accepted rails;
+- pending, activated, and refunded counts;
+- terms hash;
+- linked policy series;
+- linked funding line;
+- pending custody;
+- pending coverage;
+- treasury inventory;
+- claims-paying reserve impact.
+
+Copy must stay explicit: pending commitments are refundable holds. They are not active cover, not LP deposits, and not claims-paying reserve until activation and posting rules are satisfied.
+
+Production website and oracle-service fallbacks must fail closed if the Founder campaign cannot be read. They should show a paused or unavailable campaign instead of implying deposits are open.
+
+## Validation
+
+Minimum checks for Phase 0 surface work:
+
+```bash
+npm run test:node
+npm run verify:public
+OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet
+npm run protocol:bootstrap:genesis-live -- --plan
+```
+
+Strict devnet treasury pen-test is required after program or treasury-flow changes. For frontend/bootstrap-only Phase 0 gating changes, document why it was not rerun.

--- a/docs/operations/runbooks.md
+++ b/docs/operations/runbooks.md
@@ -16,6 +16,7 @@ This page does not replace the individual runbooks — they remain the canonical
 | Devnet operator | Drawer simulation (no state mutation) | `npm run devnet:operator:drawer:sim` | [devnet-beta-runbook.md](./devnet-beta-runbook.md#operator-drawer-simulation) |
 | Mainnet operator | Genesis live bootstrap (preview) | `npm run protocol:bootstrap:genesis-live -- --plan` | [genesis-live-bootstrap.md](./genesis-live-bootstrap.md) |
 | Mainnet operator | Genesis live bootstrap (apply) | `npm run protocol:bootstrap:genesis-live` (with `OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS=1`) | [genesis-live-bootstrap.md](./genesis-live-bootstrap.md) |
+| Mainnet operator / frontend reviewer | Phase 0 surface gating | confirm launch profile, disabled previews, and commitment visibility | [phase0-mainnet-surface-gating.md](./phase0-mainnet-surface-gating.md) |
 | Launch operator | Founder Travel30 commitment mode | create campaign, route public CTAs, monitor pending commitments | [founder-commitment-runbook.md](./founder-commitment-runbook.md) |
 | Hosting operator | Firebase App Hosting cutover | follow the cutover checklist | [firebase-app-hosting-cutover.md](./firebase-app-hosting-cutover.md) |
 | Release manager | Public-tag promotion | walk the gate, then publish notes | [public-release-gate.md](./public-release-gate.md) + [release-v0.3.1.md](./release-v0.3.1.md) |

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4917,6 +4917,12 @@
     padding-top: 0.2rem;
   }
 
+  .plans-action-disabled {
+    opacity: 0.64;
+    cursor: default;
+    pointer-events: none;
+  }
+
   .plans-context-bar {
     --plans-context-control-height: 3.8rem;
     display: flex;
@@ -7386,6 +7392,21 @@
     transform: translateY(-1px);
     border-color: color-mix(in oklab, var(--border-strong) 34%, var(--border));
     color: var(--cyan-ink);
+  }
+
+  .plans-wizard-chip-disabled,
+  .plans-wizard-chip:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+    transform: none;
+    border-style: dashed;
+  }
+
+  .plans-wizard-chip-disabled:hover,
+  .plans-wizard-chip:disabled:hover {
+    transform: none;
+    color: var(--muted-foreground);
+    border-color: color-mix(in oklab, var(--border-strong) 16%, var(--border));
   }
 
   .plans-wizard-chip:focus-visible {

--- a/frontend/components/capital-lp-self-service-panel.tsx
+++ b/frontend/components/capital-lp-self-service-panel.tsx
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { PublicKey, type Transaction } from "@solana/web3.js";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+
+import { useProtocolTransactionReviewPrompt } from "@/components/protocol-transaction-review";
+import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
+import {
+  buildDepositIntoCapitalClassTx,
+  buildRequestRedemptionTx,
+  type CapitalClassSnapshot,
+  type DomainAssetVaultSnapshot,
+  type LiquidityPoolSnapshot,
+  type LPPositionSnapshot,
+} from "@/lib/protocol";
+import { formatAmount } from "@/lib/canonical-ui";
+
+type Status = {
+  tone: "ok" | "error";
+  message: string;
+} | null;
+
+type CapitalLpSelfServicePanelProps = {
+  selectedPool: LiquidityPoolSnapshot | null;
+  selectedClass: CapitalClassSnapshot | null;
+  domainAssetVaults: DomainAssetVaultSnapshot[];
+  lpPositions: LPPositionSnapshot[];
+  onRefresh?: () => Promise<void> | void;
+};
+
+function parseBigIntInput(value: string): bigint {
+  const normalized = value.trim().replace(/[_ ,]/g, "");
+  if (!normalized) return 0n;
+  try {
+    return BigInt(normalized);
+  } catch {
+    return 0n;
+  }
+}
+
+function deriveOwnerAta(owner: PublicKey | null, mint: string | null): string {
+  if (!owner || !mint) return "";
+  try {
+    return getAssociatedTokenAddressSync(new PublicKey(mint), owner, false).toBase58();
+  } catch {
+    return "";
+  }
+}
+
+export function CapitalLpSelfServicePanel(props: CapitalLpSelfServicePanelProps) {
+  const { connection } = useConnection();
+  const { publicKey, sendTransaction } = useWallet();
+  const { confirmReview, reviewPrompt } = useProtocolTransactionReviewPrompt();
+  const [depositAmount, setDepositAmount] = useState("");
+  const [minimumShares, setMinimumShares] = useState("0");
+  const [sourceTokenAccount, setSourceTokenAccount] = useState("");
+  const [redemptionShares, setRedemptionShares] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>(null);
+
+  const selectedVault = useMemo(
+    () =>
+      props.domainAssetVaults.find(
+        (vault) =>
+          vault.reserveDomain === props.selectedPool?.reserveDomain &&
+          vault.assetMint === props.selectedPool?.depositAssetMint,
+      ) ?? null,
+    [props.domainAssetVaults, props.selectedPool?.depositAssetMint, props.selectedPool?.reserveDomain],
+  );
+  const ownerPosition = useMemo(
+    () =>
+      props.lpPositions.find(
+        (position) =>
+          position.capitalClass === props.selectedClass?.address &&
+          position.owner === publicKey?.toBase58(),
+      ) ?? null,
+    [props.lpPositions, props.selectedClass?.address, publicKey],
+  );
+
+  useEffect(() => {
+    const derived = deriveOwnerAta(publicKey ?? null, props.selectedPool?.depositAssetMint ?? null);
+    if (derived) setSourceTokenAccount(derived);
+  }, [props.selectedPool?.depositAssetMint, publicKey]);
+
+  async function run(label: string, factory: () => Promise<Transaction>) {
+    if (!publicKey || !sendTransaction) return;
+    setBusy(label);
+    setStatus(null);
+    try {
+      const tx = await factory();
+      const result = await executeProtocolTransactionWithToast({
+        connection,
+        sendTransaction,
+        tx,
+        label,
+        confirmReview,
+        review: {
+          authority: publicKey.toBase58(),
+          feePayer: publicKey.toBase58(),
+          affectedObject: props.selectedClass
+            ? `${props.selectedClass.displayName} (${props.selectedClass.address})`
+            : "LP self-service",
+          economicEffect:
+            label === "Deposit LP capital"
+              ? "Deposits SPL assets into the selected capital class and mints LP shares under the pool accounting rules."
+              : "Queues LP shares for operator-processed redemption; it does not withdraw assets immediately.",
+          warnings: [
+            "Phase 0 LP exits are queue-only; redemption processing remains operator-reviewed.",
+            "Use the token account for the pool deposit mint only.",
+          ],
+        },
+        onConfirmed: async () => {
+          await props.onRefresh?.();
+        },
+        onRetry: () => {
+          void run(label, factory);
+        },
+      });
+      setStatus({
+        tone: result.ok ? "ok" : "error",
+        message: result.ok ? result.message : result.error,
+      });
+    } catch (cause) {
+      setStatus({
+        tone: "error",
+        message: cause instanceof Error ? cause.message : `${label} failed.`,
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const canSubmit =
+    Boolean(publicKey)
+    && Boolean(props.selectedPool)
+    && Boolean(props.selectedClass)
+    && Boolean(selectedVault?.vaultTokenAccount);
+
+  return (
+    <article className="plans-card heavy-glass">
+      {reviewPrompt}
+      <div className="plans-card-head">
+        <div>
+          <p className="plans-card-eyebrow">LP self-service</p>
+          <h2 className="plans-card-title plans-card-title-display">
+            Deposit or queue <em>redemption</em>
+          </h2>
+        </div>
+        <span className="plans-card-meta">Queue-only exit</span>
+      </div>
+
+      <div className="plans-notice liquid-glass" role="status">
+        <span className="material-symbols-outlined plans-notice-icon" aria-hidden="true">info</span>
+        <p>
+          Public LP deposits and redemption requests are live. Redemption processing stays operator-reviewed and pays the LP owner route enforced on-chain.
+        </p>
+      </div>
+
+      {status ? (
+        <div className="plans-notice liquid-glass" role="status">
+          <span className="material-symbols-outlined plans-notice-icon" aria-hidden="true">
+            {status.tone === "ok" ? "verified" : "error"}
+          </span>
+          <p>{status.message}</p>
+        </div>
+      ) : null}
+
+      <div className="plans-settings-grid">
+        <div className="plans-settings-row">
+          <div>
+            <span className="plans-settings-label">Selected class</span>
+            <span className="plans-settings-lane">Choose the pool and class in the context bar above</span>
+          </div>
+          <span className="plans-settings-address">{props.selectedClass?.displayName ?? "None"}</span>
+        </div>
+        <div className="plans-settings-row">
+          <div>
+            <span className="plans-settings-label">Your LP shares</span>
+            <span className="plans-settings-lane">Connected wallet position in this class</span>
+          </div>
+          <span className="plans-settings-address">{formatAmount(ownerPosition?.shares ?? 0n)}</span>
+        </div>
+      </div>
+
+      <div className="plans-wizard-row">
+        <label className="plans-wizard-field-group">
+          <span className="plans-wizard-field-label">Deposit amount (base units)</span>
+          <span className="plans-wizard-field-bar">
+            <input
+              type="text"
+              inputMode="numeric"
+              className="plans-wizard-input"
+              value={depositAmount}
+              onChange={(event) => setDepositAmount(event.target.value)}
+              placeholder="0"
+            />
+          </span>
+        </label>
+        <label className="plans-wizard-field-group">
+          <span className="plans-wizard-field-label">Minimum shares</span>
+          <span className="plans-wizard-field-bar">
+            <input
+              type="text"
+              inputMode="numeric"
+              className="plans-wizard-input"
+              value={minimumShares}
+              onChange={(event) => setMinimumShares(event.target.value)}
+              placeholder="0"
+            />
+          </span>
+        </label>
+      </div>
+
+      <label className="plans-wizard-field-group">
+        <span className="plans-wizard-field-label">Source token account</span>
+        <span className="plans-wizard-field-bar">
+          <input
+            type="text"
+            className="plans-wizard-input"
+            value={sourceTokenAccount}
+            onChange={(event) => setSourceTokenAccount(event.target.value)}
+            placeholder="Associated token account for the pool mint"
+          />
+        </span>
+      </label>
+
+      <div className="operator-drawer-actions">
+        <button
+          type="button"
+          className="plans-primary-cta"
+          disabled={!canSubmit || !sourceTokenAccount.trim() || !depositAmount.trim() || busy === "Deposit LP capital"}
+          onClick={() =>
+            run("Deposit LP capital", async () => {
+              const { blockhash } = await connection.getLatestBlockhash("confirmed");
+              return buildDepositIntoCapitalClassTx({
+                owner: publicKey!,
+                reserveDomainAddress: props.selectedPool!.reserveDomain,
+                poolAddress: props.selectedPool!.address,
+                poolDepositAssetMint: props.selectedPool!.depositAssetMint,
+                capitalClassAddress: props.selectedClass!.address,
+                sourceTokenAccountAddress: sourceTokenAccount.trim(),
+                vaultTokenAccountAddress: selectedVault!.vaultTokenAccount,
+                recentBlockhash: blockhash,
+                amount: parseBigIntInput(depositAmount),
+                shares: parseBigIntInput(minimumShares),
+              });
+            })
+          }
+        >
+          Deposit
+        </button>
+      </div>
+
+      <div className="plans-wizard-divider" aria-hidden="true" />
+
+      <label className="plans-wizard-field-group">
+        <span className="plans-wizard-field-label">Shares to queue for redemption</span>
+        <span className="plans-wizard-field-bar">
+          <input
+            type="text"
+            inputMode="numeric"
+            className="plans-wizard-input"
+            value={redemptionShares}
+            onChange={(event) => setRedemptionShares(event.target.value)}
+            placeholder="0"
+          />
+        </span>
+      </label>
+      <div className="operator-drawer-actions">
+        <button
+          type="button"
+          className="plans-secondary-cta"
+          disabled={!canSubmit || !redemptionShares.trim() || busy === "Request LP redemption"}
+          onClick={() =>
+            run("Request LP redemption", async () => {
+              const { blockhash } = await connection.getLatestBlockhash("confirmed");
+              return buildRequestRedemptionTx({
+                owner: publicKey!,
+                reserveDomainAddress: props.selectedPool!.reserveDomain,
+                poolAddress: props.selectedPool!.address,
+                poolDepositAssetMint: props.selectedPool!.depositAssetMint,
+                capitalClassAddress: props.selectedClass!.address,
+                recentBlockhash: blockhash,
+                shares: parseBigIntInput(redemptionShares),
+              });
+            })
+          }
+        >
+          Request redemption
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/capital-workbench.tsx
+++ b/frontend/components/capital-workbench.tsx
@@ -11,6 +11,8 @@ import {
   CapitalOperatorDrawer,
   type CapitalOperatorSection,
 } from "@/components/capital-operator-drawer";
+import { CapitalLpSelfServicePanel } from "@/components/capital-lp-self-service-panel";
+import { useNetworkContext } from "@/components/network-context";
 import { PoolTreasuryPanel } from "@/components/pool-treasury-panel";
 import { PoolWorkspaceProvider } from "@/components/pool-workspace-context";
 import { useWorkspacePersona } from "@/components/workspace-persona";
@@ -19,6 +21,10 @@ import { buildCanonicalConsoleStateFromSnapshot } from "@/lib/console-model";
 import { formatAmount } from "@/lib/canonical-ui";
 import { firstSearchParamValue, type RouteSearchParams, toURLSearchParams } from "@/lib/search-params";
 import { useProtocolConsoleSnapshot } from "@/lib/use-protocol-console-snapshot";
+import {
+  isGenesisPhase0SurfaceActionable,
+  resolveGenesisPhase0LaunchProfile,
+} from "@/lib/genesis-phase0-launch-profile";
 import {
   buildAuditTrail,
   CAPITAL_TABS,
@@ -192,7 +198,12 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { effectivePersona } = useWorkspacePersona();
+  const { selectedNetwork } = useNetworkContext();
   const { snapshot, loading, error, refresh } = useProtocolConsoleSnapshot();
+  const phase0Profile = useMemo(
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
+    [selectedNetwork],
+  );
   const consoleState = useMemo(() => buildCanonicalConsoleStateFromSnapshot(snapshot), [snapshot]);
   const wallet = useWallet();
 
@@ -243,12 +254,13 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
       ),
     [selectedPool, snapshot.allocationPositions],
   );
-  const queueRows = useMemo(() => {
+  const poolLpPositions = useMemo(() => {
     const classAddresses = new Set(poolClasses.map((capitalClass) => capitalClass.address));
-    return snapshot.lpPositions.filter(
-      (position) => classAddresses.has(position.capitalClass) && hasPendingRedemptionQueue(position),
-    );
+    return snapshot.lpPositions.filter((position) => classAddresses.has(position.capitalClass));
   }, [poolClasses, snapshot.lpPositions]);
+  const queueRows = useMemo(() => {
+    return poolLpPositions.filter((position) => hasPendingRedemptionQueue(position));
+  }, [poolLpPositions]);
   const linkedPlanContext = useMemo(() => {
     const planAddresses = [...new Set(poolAllocations.map((allocation) => allocation.healthPlan).filter(Boolean))];
     const seriesAddresses = [...new Set(
@@ -419,7 +431,9 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
 
   /* ── Operator drawer ── */
 
-  const canOperate = OPERATOR_PERSONAS.has(effectivePersona);
+  const canOperate =
+    OPERATOR_PERSONAS.has(effectivePersona)
+    && isGenesisPhase0SurfaceActionable(phase0Profile, "capitalAdminActions");
   const [operatorOpen, setOperatorOpen] = useState(false);
   const [operatorSection, setOperatorSection] = useState<CapitalOperatorSection>("provision");
 
@@ -709,6 +723,14 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
                       </p>
                     )}
                   </article>
+
+                  <CapitalLpSelfServicePanel
+                    selectedPool={selectedPool}
+                    selectedClass={selectedClass ?? poolClasses[0] ?? null}
+                    domainAssetVaults={snapshot.domainAssetVaults}
+                    lpPositions={poolLpPositions}
+                    onRefresh={refresh}
+                  />
                 </div>
               ) : null}
 

--- a/frontend/components/genesis-protect-acute-setup-panel.tsx
+++ b/frontend/components/genesis-protect-acute-setup-panel.tsx
@@ -22,6 +22,8 @@ type GenesisProtectAcuteSetupPanelProps = {
   bootstrapHref: string;
   oracleBindingsHref: string;
   claimsHref: string;
+  adminActionsEnabled?: boolean;
+  founderCommitmentHref?: string;
   skuConsoleHrefs: Record<GenesisProtectAcuteSkuKey, {
     claims: string;
     treasury: string;
@@ -66,6 +68,13 @@ function commitmentModeLabel(mode: number): string {
     default:
       return `MODE_${mode}`;
   }
+}
+
+function shortHash(value: string | null | undefined): string {
+  const normalized = value?.trim() ?? "";
+  if (!normalized) return "None";
+  if (normalized.length <= 16) return normalized;
+  return `${normalized.slice(0, 8)}…${normalized.slice(-8)}`;
 }
 
 function checklistRows(props: GenesisProtectAcuteSetupPanelProps) {
@@ -258,16 +267,24 @@ export function GenesisProtectAcuteSetupPanel(props: GenesisProtectAcuteSetupPan
         <div className="plans-notice liquid-glass" role="status">
           <span className="material-symbols-outlined plans-notice-icon" aria-hidden="true">lock</span>
           <p>
-            <strong>Founder Travel30 commitment mode.</strong>{" "}
-            Pending deposits are shown as custody or rail inventory here and stay out of claims-paying reserve until activation.
+            <strong>Founder commitments are read-only here.</strong>{" "}
+            Pending deposits are refundable holds, not active cover, not LP deposits, and not claims-paying reserve until activation or posting rules are satisfied.
           </p>
         </div>
+
+        {props.founderCommitmentHref ? (
+          <div className="plans-wizard-support-actions">
+            <Link href={props.founderCommitmentHref} className="secondary-button inline-flex w-fit" target="_blank" rel="noreferrer">
+              Open consumer Founder flow
+            </Link>
+          </div>
+        ) : null}
 
         <div className="plans-settings-grid">
           <div className="plans-settings-row">
             <div>
-              <span className="plans-settings-label">Commitment campaign</span>
-              <span className="plans-settings-lane">Founder Travel30 campaign visibility in the protocol console</span>
+              <span className="plans-settings-label">Founder campaigns</span>
+              <span className="plans-settings-lane">Read-only campaign status linked to this plan and policy series</span>
             </div>
             <span className="plans-settings-address">
               {props.model.founderCommitments.activeCampaignCount}/{props.model.founderCommitments.campaignCount} active
@@ -338,6 +355,18 @@ export function GenesisProtectAcuteSetupPanel(props: GenesisProtectAcuteSetupPan
                   <div className="plans-settings-row">
                     <span className="plans-settings-label">Pending</span>
                     <span className="plans-settings-address">{formatAmount(row.pendingAmount)}</span>
+                  </div>
+                  <div className="plans-settings-row">
+                    <span className="plans-settings-label">Policy series</span>
+                    <span className="plans-settings-address">{row.policySeries ? shortHash(row.policySeries) : "Unlinked"}</span>
+                  </div>
+                  <div className="plans-settings-row">
+                    <span className="plans-settings-label">Funding line</span>
+                    <span className="plans-settings-address">{shortHash(row.coverageFundingLine)}</span>
+                  </div>
+                  <div className="plans-settings-row">
+                    <span className="plans-settings-label">Terms hash</span>
+                    <span className="plans-settings-address">{shortHash(row.termsHashHex)}</span>
                   </div>
                   <div className="plans-settings-row">
                     <span className="plans-settings-label">Activated</span>
@@ -453,9 +482,11 @@ export function GenesisProtectAcuteSetupPanel(props: GenesisProtectAcuteSetupPan
         </div>
 
         <div className="plans-wizard-support-actions">
-          <Link href={props.bootstrapHref} className="secondary-button inline-flex w-fit">
-            Rerun Genesis template
-          </Link>
+          {props.adminActionsEnabled ? (
+            <Link href={props.bootstrapHref} className="secondary-button inline-flex w-fit">
+              Rerun Genesis template
+            </Link>
+          ) : null}
           {props.planAddress ? (
             <Link href={props.claimsHref} className="secondary-button inline-flex w-fit">
               Open claim console
@@ -489,13 +520,15 @@ export function GenesisProtectAcuteSetupPanel(props: GenesisProtectAcuteSetupPan
                   <p className="text-sm font-semibold text-[var(--foreground)]">{row.title}</p>
                   <p className="field-help">{row.detail}</p>
                 </div>
-                <span className={`status-pill ${row.ready ? "status-ok" : "status-off"}`}>
-                  {row.ready ? "Ready" : "Action needed"}
-                </span>
-              </div>
-              <Link href={row.href} className="secondary-button inline-flex w-fit">
-                {row.action}
-              </Link>
+              <span className={`status-pill ${row.ready ? "status-ok" : "status-off"}`}>
+                {row.ready ? "Ready" : "Action needed"}
+              </span>
+            </div>
+              {props.adminActionsEnabled ? (
+                <Link href={row.href} className="secondary-button inline-flex w-fit">
+                  {row.action}
+                </Link>
+              ) : null}
             </article>
           ))}
         </div>

--- a/frontend/components/plan-creation-wizard.tsx
+++ b/frontend/components/plan-creation-wizard.tsx
@@ -11,6 +11,7 @@ import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 
 import { DocumentLinkRow } from "@/components/document-link-row";
 import { MultiOraclePicker, type MultiOracleOption } from "@/components/multi-oracle-picker";
+import { useNetworkContext } from "@/components/network-context";
 import { useProtocolTransactionReviewPrompt } from "@/components/protocol-transaction-review";
 import { WizardDetailSheet, WizardDetailTriggerRow, type WizardDetailMetaItem } from "@/components/wizard-detail-sheet";
 import { cn } from "@/lib/cn";
@@ -64,6 +65,10 @@ import {
   fetchProtectionMetadataDocument,
   validateProtectionMetadataAgainstPosture,
 } from "@/lib/protection-metadata";
+import {
+  isGenesisPhase0SurfaceActionable,
+  resolveGenesisPhase0LaunchProfile,
+} from "@/lib/genesis-phase0-launch-profile";
 import { executeProtocolTransactionWithToast } from "@/lib/protocol-action-toast";
 import {
   buildCreateAllocationPositionTx,
@@ -378,12 +383,20 @@ export function PlanCreationWizard() {
   const searchParams = useSearchParams();
   const { connection } = useConnection();
   const { connected, publicKey, sendTransaction } = useWallet();
+  const { selectedNetwork } = useNetworkContext();
   const { snapshot } = useProtocolConsoleSnapshot();
   const genesisTemplateMode = isGenesisProtectAcuteTemplate(searchParams.get("template"));
-  const rwaPolicyLaunchEnabled = isRwaPolicyLaunchEnabled();
+  const phase0Profile = useMemo(
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
+    [selectedNetwork],
+  );
+  const rewardLaunchEnabled = isGenesisPhase0SurfaceActionable(phase0Profile, "rewardLaunch");
+  const hybridLaunchEnabled = isGenesisPhase0SurfaceActionable(phase0Profile, "hybridLaunch");
+  const rwaPolicyLaunchEnabled = isGenesisPhase0SurfaceActionable(phase0Profile, "rwaPolicyLaunch")
+    && isRwaPolicyLaunchEnabled();
   const { confirmReview, reviewPrompt } = useProtocolTransactionReviewPrompt();
 
-  const [launchIntent, setLaunchIntent] = useState<LaunchIntent>("hybrid");
+  const [launchIntent, setLaunchIntent] = useState<LaunchIntent>("insurance");
   const [stepIndex, setStepIndex] = useState(0);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [statusTone, setStatusTone] = useState<"ok" | "error" | null>(null);
@@ -491,6 +504,24 @@ export function PlanCreationWizard() {
   const copy = STEP_COPY[activeStep.id];
   const rewardLaneRequired = !genesisTemplateMode && requiresRewardLane(launchIntent);
   const protectionLaneRequired = !genesisTemplateMode && requiresProtectionLane(launchIntent);
+  const launchIntentOptions = useMemo(
+    () => (["rewards", "insurance", "hybrid"] as const).map((intent) => {
+      const enabled =
+        intent === "insurance"
+          ? true
+          : intent === "rewards"
+            ? rewardLaunchEnabled
+            : hybridLaunchEnabled;
+      return {
+        intent,
+        enabled,
+        reason: enabled
+          ? ""
+          : `${intent === "rewards" ? "Reward" : "Hybrid"} launch creation is a Phase 0 preview surface on ${selectedNetwork === "mainnet-beta" ? "mainnet" : "this network"}.`,
+      };
+    }),
+    [hybridLaunchEnabled, rewardLaunchEnabled, selectedNetwork],
+  );
   const payoutAssetAddress = payoutAssetMode === "spl" ? payoutMint : ZERO_PUBKEY;
   const reserveDomainPk = toAssetPublicKey(reserveDomainAddress);
   const payoutMintPk = toAssetPublicKey(payoutAssetAddress);
@@ -549,6 +580,18 @@ export function PlanCreationWizard() {
     if (rwaPolicyLaunchEnabled || coveragePathway !== "rwa_policy") return;
     handleCoveragePathwayChange("defi_native");
   }, [coveragePathway, handleCoveragePathwayChange, rwaPolicyLaunchEnabled]);
+
+  useEffect(() => {
+    if (launchIntent === "insurance") return;
+    if (launchIntent === "rewards" && rewardLaunchEnabled) return;
+    if (launchIntent === "hybrid" && hybridLaunchEnabled) return;
+    setLaunchIntent("insurance");
+  }, [hybridLaunchEnabled, launchIntent, rewardLaunchEnabled]);
+
+  useEffect(() => {
+    if (hybridLaunchEnabled || defiSettlementMode !== "hybrid_rails") return;
+    setDefiSettlementMode("onchain_programmatic");
+  }, [defiSettlementMode, hybridLaunchEnabled]);
 
   const closeActiveDetail = useCallback(() => {
     if (!activeDetail) return;
@@ -2269,18 +2312,34 @@ export function PlanCreationWizard() {
                 ) : null}
                 <FieldGroup label="Launch Intent">
                   <div className="flex flex-wrap gap-2">
-                    {(["rewards", "insurance", "hybrid"] as const).map((intent) => (
-                      <button
-                        key={intent}
-                        type="button"
-                        className={cn("plans-wizard-chip", launchIntent === intent && "plans-wizard-chip-active")}
-                        onClick={() => setLaunchIntent(intent)}
-                        disabled={genesisTemplateMode}
-                      >
-                        {intent.toUpperCase()}
-                      </button>
-                    ))}
+                    {launchIntentOptions.map(({ intent, enabled, reason }) => {
+                      const disabled = genesisTemplateMode || !enabled;
+                      return (
+                        <button
+                          key={intent}
+                          type="button"
+                          className={cn(
+                            "plans-wizard-chip",
+                            launchIntent === intent && "plans-wizard-chip-active",
+                            disabled && "plans-wizard-chip-disabled",
+                          )}
+                          onClick={() => {
+                            if (!enabled) return;
+                            setLaunchIntent(intent);
+                          }}
+                          disabled={disabled}
+                          title={reason || undefined}
+                        >
+                          {intent.toUpperCase()}
+                        </button>
+                      );
+                    })}
                   </div>
+                  {phase0Profile.disabledSurfaces.length > 0 ? (
+                    <p className="field-help">
+                      Phase 0 keeps {phase0Profile.disabledSurfaces.join(", ")} preview-only on this network.
+                    </p>
+                  ) : null}
                 </FieldGroup>
 
                 <div className="plans-wizard-row">
@@ -2406,15 +2465,22 @@ export function PlanCreationWizard() {
                         >
                           DEFI_NATIVE
                         </button>
-                        {rwaPolicyLaunchEnabled ? (
-                          <button
-                            type="button"
-                            className={cn("plans-wizard-chip", coveragePathway === "rwa_policy" && "plans-wizard-chip-active")}
-                            onClick={() => handleCoveragePathwayChange("rwa_policy")}
-                          >
-                            RWA_POLICY
-                          </button>
-                        ) : null}
+                        <button
+                          type="button"
+                          className={cn(
+                            "plans-wizard-chip",
+                            coveragePathway === "rwa_policy" && "plans-wizard-chip-active",
+                            !rwaPolicyLaunchEnabled && "plans-wizard-chip-disabled",
+                          )}
+                          onClick={() => {
+                            if (!rwaPolicyLaunchEnabled) return;
+                            handleCoveragePathwayChange("rwa_policy");
+                          }}
+                          disabled={!rwaPolicyLaunchEnabled}
+                          title={rwaPolicyLaunchEnabled ? undefined : "RWA policy launch is preview-only in Phase 0."}
+                        >
+                          RWA_POLICY
+                        </button>
                       </div>
                     </FieldGroup>
 
@@ -2431,8 +2497,17 @@ export function PlanCreationWizard() {
                             </button>
                             <button
                               type="button"
-                              className={cn("plans-wizard-chip", defiSettlementMode === "hybrid_rails" && "plans-wizard-chip-active")}
-                              onClick={() => setDefiSettlementMode("hybrid_rails")}
+                              className={cn(
+                                "plans-wizard-chip",
+                                defiSettlementMode === "hybrid_rails" && "plans-wizard-chip-active",
+                                !hybridLaunchEnabled && "plans-wizard-chip-disabled",
+                              )}
+                              onClick={() => {
+                                if (!hybridLaunchEnabled) return;
+                                setDefiSettlementMode("hybrid_rails");
+                              }}
+                              disabled={!hybridLaunchEnabled}
+                              title={hybridLaunchEnabled ? undefined : "Hybrid rails are preview-only in Phase 0."}
                             >
                               HYBRID_RAILS
                             </button>

--- a/frontend/components/plans-workbench.tsx
+++ b/frontend/components/plans-workbench.tsx
@@ -14,6 +14,7 @@ import {
 import { GenesisProtectAcuteClaimsConsolePanel } from "@/components/genesis-protect-acute-claims-console";
 import { GenesisProtectAcuteReserveConsolePanel } from "@/components/genesis-protect-acute-reserve-console";
 import { GenesisProtectAcuteSetupPanel } from "@/components/genesis-protect-acute-setup-panel";
+import { useNetworkContext } from "@/components/network-context";
 import { useWorkspacePersona } from "@/components/workspace-persona";
 import { buildCanonicalConsoleStateFromSnapshot } from "@/lib/console-model";
 import { formatAmount, plansForPool, seriesOutcomeCount } from "@/lib/canonical-ui";
@@ -37,6 +38,10 @@ import {
   normalizeGenesisProtectAcuteClaimQueueFilter,
   normalizeGenesisProtectAcuteReserveLaneFilter,
 } from "@/lib/genesis-protect-acute-console";
+import {
+  isGenesisPhase0SurfaceActionable,
+  resolveGenesisPhase0LaunchProfile,
+} from "@/lib/genesis-phase0-launch-profile";
 import {
   buildAuditTrail,
   defaultTabForPersona,
@@ -314,7 +319,12 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { effectivePersona } = useWorkspacePersona();
+  const { selectedNetwork } = useNetworkContext();
   const { snapshot, loading, error, refresh } = useProtocolConsoleSnapshot();
+  const phase0Profile = useMemo(
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
+    [selectedNetwork],
+  );
   const consoleState = useMemo(() => buildCanonicalConsoleStateFromSnapshot(snapshot), [snapshot]);
   const routeMode: PlansRouteMode = pathname === "/claims" ? "claims" : "plans";
   const forcedTab: PlanTabId | null = routeMode === "claims" ? "claims" : null;
@@ -611,7 +621,9 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
 
   /* ── Operator drawer ── */
 
-  const canOperate = OPERATOR_PERSONAS.has(effectivePersona);
+  const canOperate =
+    OPERATOR_PERSONAS.has(effectivePersona)
+    && isGenesisPhase0SurfaceActionable(phase0Profile, "policyAdminActions");
   const [operatorOpen, setOperatorOpen] = useState(false);
   const [operatorSection, setOperatorSection] = useState<PlanOperatorSection>("funding");
 
@@ -712,15 +724,27 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
                   Operator actions
                 </button>
               ) : null}
-              <Link
-                href={routeMode === "plans" ? (genesisSetupMode ? genesisBootstrapHref : "/plans/new") : planWorkspaceHref}
-                className={canOperate ? "plans-secondary-cta" : "plans-hero-cta"}
-              >
-                <span className="material-symbols-outlined" aria-hidden="true">
-                  {routeMode === "plans" ? "add" : "arrow_back"}
-                </span>
-                {routeMode === "plans" ? (genesisSetupMode ? "Genesis template" : "New plan") : "Back to plan"}
-              </Link>
+              {routeMode === "plans" ? (
+                canOperate ? (
+                  <Link
+                    href={genesisSetupMode ? genesisBootstrapHref : "/plans/new"}
+                    className="plans-secondary-cta"
+                  >
+                    <span className="material-symbols-outlined" aria-hidden="true">add</span>
+                    {genesisSetupMode ? "Genesis template" : "New plan"}
+                  </Link>
+                ) : (
+                  <span className="plans-secondary-cta plans-action-disabled" aria-disabled="true">
+                    <span className="material-symbols-outlined" aria-hidden="true">visibility</span>
+                    Read-only Phase 0
+                  </span>
+                )
+              ) : (
+                <Link href={planWorkspaceHref} className={canOperate ? "plans-secondary-cta" : "plans-hero-cta"}>
+                  <span className="material-symbols-outlined" aria-hidden="true">arrow_back</span>
+                  Back to plan
+                </Link>
+              )}
             </div>
           </div>
         </header>
@@ -827,6 +851,8 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
                     oracleBindingsHref={`/oracles${genesisPoolAddress ? `?${new URLSearchParams({ pool: genesisPoolAddress, tab: "bindings" }).toString()}` : "?tab=bindings"}`}
                     claimsHref={genesisClaimsHref}
                     skuConsoleHrefs={genesisSkuConsoleHrefs}
+                    adminActionsEnabled={canOperate}
+                    founderCommitmentHref={process.env.NEXT_PUBLIC_PROTECT_FOUNDER_COMMITMENT_URL ?? "https://omegax.health/protect/founder"}
                   />
                 ) : (
                   <div className="plans-stack">

--- a/frontend/lib/genesis-phase0-launch-profile.ts
+++ b/frontend/lib/genesis-phase0-launch-profile.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { NetworkMode } from "@/lib/network-config";
+
+export type GenesisPhase0SurfaceState = "live" | "disabled_preview" | "hidden";
+export type GenesisPhase0ReadSurfaceState = "read_only";
+
+export type GenesisPhase0LaunchProfile = {
+  id: "genesis-phase0";
+  network: NetworkMode;
+  description: string;
+  lpDeposits: GenesisPhase0SurfaceState;
+  lpRedemptionRequests: GenesisPhase0SurfaceState;
+  capitalDashboard: GenesisPhase0ReadSurfaceState;
+  reserveDashboard: GenesisPhase0ReadSurfaceState;
+  claimsDashboard: GenesisPhase0ReadSurfaceState;
+  oracleDashboard: GenesisPhase0ReadSurfaceState;
+  commitmentsDashboard: GenesisPhase0ReadSurfaceState;
+  operatorSettlementVisibility: GenesisPhase0ReadSurfaceState;
+  rewardLaunch: GenesisPhase0SurfaceState;
+  rwaPolicyLaunch: GenesisPhase0SurfaceState;
+  hybridLaunch: GenesisPhase0SurfaceState;
+  daoFallback: GenesisPhase0SurfaceState;
+  capitalAdminActions: GenesisPhase0SurfaceState;
+  policyAdminActions: GenesisPhase0SurfaceState;
+  futureLaunchChoices: GenesisPhase0SurfaceState;
+  disabledSurfaces: string[];
+  hiddenSurfaces: string[];
+  mainnetPlanAssertions: string[];
+};
+
+type EnvLike = Partial<Record<string, string | undefined>>;
+
+export const GENESIS_PHASE0_ADMIN_FLAG = "NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS";
+export const GENESIS_PHASE0_MAINNET_FUTURE_SURFACES_FLAG = "NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES";
+export const GENESIS_PHASE0_REWARD_FLAG = "NEXT_PUBLIC_ENABLE_REWARD_LAUNCH";
+export const GENESIS_PHASE0_RWA_FLAG = "NEXT_PUBLIC_ENABLE_RWA_POLICY";
+export const GENESIS_PHASE0_HYBRID_FLAG = "NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH";
+export const GENESIS_PHASE0_DAO_FLAG = "NEXT_PUBLIC_ENABLE_DAO_FALLBACK";
+
+export const GENESIS_PHASE0_CLIENT_ENV: EnvLike = {
+  NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES: process.env.NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES,
+  NEXT_PUBLIC_ENABLE_DAO_FALLBACK: process.env.NEXT_PUBLIC_ENABLE_DAO_FALLBACK,
+  NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: process.env.NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH,
+  NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS: process.env.NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS,
+  NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: process.env.NEXT_PUBLIC_ENABLE_REWARD_LAUNCH,
+  NEXT_PUBLIC_ENABLE_RWA_POLICY: process.env.NEXT_PUBLIC_ENABLE_RWA_POLICY,
+};
+
+export function phase0FlagEnabled(env: EnvLike, name: string): boolean {
+  const value = String(env[name] ?? "").trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+function normalizeNetwork(network?: NetworkMode | string | null): NetworkMode {
+  const normalized = String(network ?? "devnet").trim().toLowerCase();
+  return normalized.includes("mainnet") ? "mainnet-beta" : "devnet";
+}
+
+function productSurfaceState(params: {
+  enabledFlag: string;
+  env: EnvLike;
+  mainnet: boolean;
+}): GenesisPhase0SurfaceState {
+  const enabled = phase0FlagEnabled(params.env, params.enabledFlag);
+  if (!enabled) return "disabled_preview";
+  if (!params.mainnet) return "live";
+  return phase0FlagEnabled(params.env, GENESIS_PHASE0_MAINNET_FUTURE_SURFACES_FLAG)
+    ? "live"
+    : "disabled_preview";
+}
+
+function adminSurfaceState(params: {
+  env: EnvLike;
+  mainnet: boolean;
+}): GenesisPhase0SurfaceState {
+  const enabled = phase0FlagEnabled(params.env, GENESIS_PHASE0_ADMIN_FLAG);
+  if (!enabled) return "hidden";
+  if (!params.mainnet) return "live";
+  return enabled ? "live" : "hidden";
+}
+
+function disabledLabels(profile: Omit<
+  GenesisPhase0LaunchProfile,
+  "disabledSurfaces" | "hiddenSurfaces" | "mainnetPlanAssertions"
+>): string[] {
+  const entries: Array<[GenesisPhase0SurfaceState, string]> = [
+    [profile.rewardLaunch, "reward launch"],
+    [profile.rwaPolicyLaunch, "RWA policy launch"],
+    [profile.hybridLaunch, "hybrid launch"],
+    [profile.daoFallback, "DAO fallback"],
+    [profile.futureLaunchChoices, "future launch choices"],
+  ];
+  return entries.flatMap(([state, label]) => state === "disabled_preview" ? [label] : []);
+}
+
+function hiddenLabels(profile: Omit<
+  GenesisPhase0LaunchProfile,
+  "disabledSurfaces" | "hiddenSurfaces" | "mainnetPlanAssertions"
+>): string[] {
+  const entries: Array<[GenesisPhase0SurfaceState, string]> = [
+    [profile.capitalAdminActions, "capital admin actions"],
+    [profile.policyAdminActions, "policy admin actions"],
+  ];
+  return entries.flatMap(([state, label]) => state === "hidden" ? [label] : []);
+}
+
+export function resolveGenesisPhase0LaunchProfile(params: {
+  network?: NetworkMode | string | null;
+  env?: EnvLike;
+} = {}): GenesisPhase0LaunchProfile {
+  const env = params.env ?? GENESIS_PHASE0_CLIENT_ENV;
+  const network = normalizeNetwork(params.network);
+  const mainnet = network === "mainnet-beta";
+  const capitalAdminActions = adminSurfaceState({ env, mainnet });
+  const policyAdminActions = adminSurfaceState({ env, mainnet });
+  const base = {
+    id: "genesis-phase0" as const,
+    network,
+    description: mainnet
+      ? "Phase 0 mainnet profile: LP self-service, read-only reserve/liability visibility, and hidden admin execution by default."
+      : "Phase 0 devnet profile: live LP self-service plus explicit rehearsal flags for preview surfaces.",
+    lpDeposits: "live" as const,
+    lpRedemptionRequests: "live" as const,
+    capitalDashboard: "read_only" as const,
+    reserveDashboard: "read_only" as const,
+    claimsDashboard: "read_only" as const,
+    oracleDashboard: "read_only" as const,
+    commitmentsDashboard: "read_only" as const,
+    operatorSettlementVisibility: "read_only" as const,
+    rewardLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_REWARD_FLAG, env, mainnet }),
+    rwaPolicyLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_RWA_FLAG, env, mainnet }),
+    hybridLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_HYBRID_FLAG, env, mainnet }),
+    daoFallback: productSurfaceState({ enabledFlag: GENESIS_PHASE0_DAO_FLAG, env, mainnet }),
+    capitalAdminActions,
+    policyAdminActions,
+    futureLaunchChoices: mainnet ? "disabled_preview" as const : "disabled_preview" as const,
+  };
+
+  return {
+    ...base,
+    disabledSurfaces: disabledLabels(base),
+    hiddenSurfaces: hiddenLabels(base),
+    mainnetPlanAssertions: [
+      "LP classes are open.",
+      "LP lockup is 30 days.",
+      "LP redemption is queue-only.",
+      "Classic SPL Token custody only; Token-2022 remains unsupported.",
+      "No reward, RWA, hybrid, DAO, or external yield execution is bootstrapped by default.",
+      "No transactions are sent in --plan mode.",
+    ],
+  };
+}
+
+export function isGenesisPhase0SurfaceLive(state: GenesisPhase0SurfaceState): boolean {
+  return state === "live";
+}
+
+export function isGenesisPhase0SurfaceActionable(
+  profile: GenesisPhase0LaunchProfile,
+  surface: keyof Pick<
+    GenesisPhase0LaunchProfile,
+    | "lpDeposits"
+    | "lpRedemptionRequests"
+    | "rewardLaunch"
+    | "rwaPolicyLaunch"
+    | "hybridLaunch"
+    | "daoFallback"
+    | "capitalAdminActions"
+    | "policyAdminActions"
+    | "futureLaunchChoices"
+  >,
+): boolean {
+  return isGenesisPhase0SurfaceLive(profile[surface]);
+}
+
+const genesisPhase0LaunchProfileModule = {
+  GENESIS_PHASE0_ADMIN_FLAG,
+  GENESIS_PHASE0_DAO_FLAG,
+  GENESIS_PHASE0_HYBRID_FLAG,
+  GENESIS_PHASE0_MAINNET_FUTURE_SURFACES_FLAG,
+  GENESIS_PHASE0_REWARD_FLAG,
+  GENESIS_PHASE0_RWA_FLAG,
+  isGenesisPhase0SurfaceActionable,
+  isGenesisPhase0SurfaceLive,
+  phase0FlagEnabled,
+  resolveGenesisPhase0LaunchProfile,
+};
+
+export default genesisPhase0LaunchProfileModule;

--- a/frontend/lib/genesis-protect-acute-operator.ts
+++ b/frontend/lib/genesis-protect-acute-operator.ts
@@ -163,8 +163,11 @@ export type GenesisProtectAcuteCommitmentCampaignRow = {
   displayName: string;
   mode: number;
   status: number;
+  policySeries: string | null;
+  coverageFundingLine: string;
   paymentAssetMint: string;
   coverageAssetMint: string;
+  termsHashHex: string;
   paymentRailCount: number;
   paymentAssetMints: string[];
   waterfallRailCount: number;
@@ -516,8 +519,11 @@ function buildGenesisProtectAcuteCommitmentPosture(params: {
       displayName: campaign.displayName || campaign.campaignId,
       mode: campaign.mode,
       status: campaign.status,
+      policySeries: campaign.policySeries ?? null,
+      coverageFundingLine: campaign.coverageFundingLine,
       paymentAssetMint: campaign.paymentAssetMint,
       coverageAssetMint: campaign.coverageAssetMint,
+      termsHashHex: campaign.termsHashHex,
       paymentRailCount: paymentAssetMints.length,
       paymentAssetMints,
       waterfallRailCount,

--- a/frontend/lib/plan-launch.ts
+++ b/frontend/lib/plan-launch.ts
@@ -3,6 +3,10 @@
 import { PublicKey } from "@solana/web3.js";
 
 import { DEVNET_PROTOCOL_FIXTURE_STATE } from "@/lib/devnet-fixtures";
+import {
+  GENESIS_PHASE0_RWA_FLAG,
+  phase0FlagEnabled,
+} from "@/lib/genesis-phase0-launch-profile";
 import { deriveLaunchLedgerAddresses } from "@/lib/plan-launch-tx";
 import {
   deriveFundingLinePda,
@@ -27,8 +31,7 @@ export type DefiSettlementMode = "" | "onchain_programmatic" | "hybrid_rails";
 export function isRwaPolicyLaunchEnabled(
   env: { [key: string]: string | undefined } = process.env as { [key: string]: string | undefined },
 ): boolean {
-  const value = String(env.NEXT_PUBLIC_ENABLE_RWA_POLICY ?? "").trim().toLowerCase();
-  return value === "1" || value === "true" || value === "yes";
+  return phase0FlagEnabled(env, GENESIS_PHASE0_RWA_FLAG);
 }
 
 export type LaunchLaneBlueprint = {

--- a/scripts/bootstrap_genesis_live_protocol.ts
+++ b/scripts/bootstrap_genesis_live_protocol.ts
@@ -121,8 +121,26 @@ function planSummary(
   config: ReturnType<typeof loadGenesisLiveBootstrapConfig>,
 ) {
   return {
+    noTransactionsSent: true,
     rpcUrl: config.rpcUrl,
     programId: protocol.getProgramId().toBase58(),
+    launchProfile: {
+      id: config.launchProfile.id,
+      network: config.launchProfile.network,
+      description: config.launchProfile.description,
+      lpDeposits: config.launchProfile.lpDeposits,
+      lpRedemptionRequests: config.launchProfile.lpRedemptionRequests,
+      dashboards: {
+        capital: config.launchProfile.capitalDashboard,
+        reserves: config.launchProfile.reserveDashboard,
+        claims: config.launchProfile.claimsDashboard,
+        oracle: config.launchProfile.oracleDashboard,
+        commitments: config.launchProfile.commitmentsDashboard,
+      },
+      disabledSurfaces: config.launchProfile.disabledSurfaces,
+      hiddenSurfaces: config.launchProfile.hiddenSurfaces,
+      assertions: config.launchProfile.mainnetPlanAssertions,
+    },
     governanceAuthority: config.governanceAuthority,
     governanceConfigAddress: config.governanceConfigAddress,
     settlementMint: config.settlementMint,
@@ -148,6 +166,18 @@ function planSummary(
     fundingLines: config.fundingLines,
     pool: config.liquidityPool,
     capitalClasses: config.capitalClasses,
+    lpClassPosture: {
+      restrictionMode: "open",
+      minLockupSeconds: "2592000",
+      minLockupDays: 30,
+      redemptionPolicy: "queue_only",
+      tokenProgram: "classic_spl_only",
+    },
+    redemptionPosture: {
+      policy: "queue_only",
+      requestSurface: config.launchProfile.lpRedemptionRequests,
+      processingSurface: config.launchProfile.capitalAdminActions,
+    },
     allocations: config.allocations,
     fundingAmounts: config.fundingAmounts,
   };

--- a/scripts/support/genesis_live_bootstrap_config.ts
+++ b/scripts/support/genesis_live_bootstrap_config.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 
 import { PublicKey } from "@solana/web3.js";
 
+import phase0Module from "../../frontend/lib/genesis-phase0-launch-profile.ts";
 import genesisModule from "../../frontend/lib/genesis-protect-acute.ts";
 import protocolModule from "../../frontend/lib/protocol.ts";
 
@@ -43,10 +44,16 @@ const {
   deriveReserveDomainPda,
 } = protocolModule as typeof import("../../frontend/lib/protocol.ts");
 
+const {
+  resolveGenesisPhase0LaunchProfile,
+  phase0FlagEnabled,
+} = phase0Module as typeof import("../../frontend/lib/genesis-phase0-launch-profile.ts");
+
 type GenesisLiveBootstrapEnv = NodeJS.ProcessEnv;
 
 export type GenesisLiveBootstrapConfig = {
   rpcUrl: string;
+  launchProfile: ReturnType<typeof resolveGenesisPhase0LaunchProfile>;
   governanceAuthority: string;
   governanceConfigAddress: string | null;
   settlementMint: string;
@@ -276,6 +283,47 @@ function parseBigIntEnv(env: GenesisLiveBootstrapEnv, name: string, fallback: bi
   }
 }
 
+function assertPhase0MainnetBootstrapAttemptAllowed(params: {
+  env: GenesisLiveBootstrapEnv;
+  targetingMainnet: boolean;
+}): void {
+  if (!params.targetingMainnet) return;
+
+  const guardedAttempts: Array<{ attempt: string; allow: string; label: string }> = [
+    {
+      attempt: "OMEGAX_LIVE_ENABLE_REWARD_LAUNCH",
+      allow: "OMEGAX_ALLOW_MAINNET_REWARD_LAUNCH",
+      label: "reward launch creation",
+    },
+    {
+      attempt: "OMEGAX_LIVE_ENABLE_RWA_POLICY",
+      allow: "OMEGAX_ALLOW_MAINNET_RWA_LAUNCH",
+      label: "RWA policy creation",
+    },
+    {
+      attempt: "OMEGAX_LIVE_ENABLE_HYBRID_LAUNCH",
+      allow: "OMEGAX_ALLOW_MAINNET_HYBRID_LAUNCH",
+      label: "hybrid launch creation",
+    },
+    {
+      attempt: "OMEGAX_LIVE_ENABLE_ADMIN_BOOTSTRAP",
+      allow: "OMEGAX_ALLOW_MAINNET_ADMIN_BOOTSTRAP",
+      label: "extra admin bootstrap",
+    },
+  ];
+
+  const blocked = guardedAttempts.filter((entry) =>
+    phase0FlagEnabled(params.env, entry.attempt) && !phase0FlagEnabled(params.env, entry.allow),
+  );
+  if (blocked.length === 0) return;
+
+  throw new Error(
+    "Mainnet Phase 0 bootstrap blocked: "
+      + blocked.map((entry) => `${entry.label} set by ${entry.attempt} without ${entry.allow}=1`).join("; ")
+      + ". Genesis Phase 0 bootstraps LP classes, protection policy series, funding lines, and reserve visibility only by default.",
+  );
+}
+
 function absolutePublicUri(pathOrUrl: string): string {
   if (pathOrUrl.startsWith("http://") || pathOrUrl.startsWith("https://")) {
     return pathOrUrl;
@@ -394,6 +442,19 @@ export function loadGenesisLiveBootstrapConfig(params: {
     clusterOverride === "mainnet"
     || (clusterOverride !== "devnet" && clusterOverride !== "localnet" && isMainnetCluster(rpcUrlForGuard));
   const breakGlass = env.OMEGAX_ALLOW_LOCAL_SIGNER_FOR_MAINNET === "1";
+  const launchProfile = resolveGenesisPhase0LaunchProfile({
+    network: targetingMainnet ? "mainnet-beta" : "devnet",
+    env: {
+      NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: env.OMEGAX_LIVE_ENABLE_REWARD_LAUNCH,
+      NEXT_PUBLIC_ENABLE_RWA_POLICY: env.OMEGAX_LIVE_ENABLE_RWA_POLICY,
+      NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: env.OMEGAX_LIVE_ENABLE_HYBRID_LAUNCH,
+      NEXT_PUBLIC_ENABLE_DAO_FALLBACK: env.OMEGAX_LIVE_ENABLE_DAO_FALLBACK,
+      NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS: env.OMEGAX_LIVE_ENABLE_ADMIN_BOOTSTRAP,
+      NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES: env.OMEGAX_ALLOW_MAINNET_FUTURE_SURFACES,
+    },
+  });
+
+  assertPhase0MainnetBootstrapAttemptAllowed({ env, targetingMainnet });
 
   if (targetingMainnet && !breakGlass) {
     if (env.OMEGAX_REQUIRE_DISTINCT_OPERATOR_KEYS !== "1") {
@@ -548,6 +609,7 @@ export function loadGenesisLiveBootstrapConfig(params: {
       ?? optionalEnv(env, "NEXT_PUBLIC_SOLANA_MAINNET_RPC_URL")
       ?? optionalEnv(env, "NEXT_PUBLIC_SOLANA_RPC_URL")
       ?? "https://api.mainnet-beta.solana.com",
+    launchProfile,
     governanceAuthority,
     governanceConfigAddress: optionalPubkey(
       env,

--- a/tests/genesis_live_bootstrap_config.test.ts
+++ b/tests/genesis_live_bootstrap_config.test.ts
@@ -27,11 +27,33 @@ test("Genesis live bootstrap config derives canonical Genesis addresses and defa
   assert.equal(config.policySeries.travel30.seriesId, "genesis-travel-30-v1");
   assert.equal(config.fundingLines.event7Sponsor.lineId, "genesis-event7-sponsor");
   assert.equal(config.fundingLines.travel30Liquidity.lineId, "genesis-travel30-liquidity");
+  assert.equal(config.launchProfile.network, "devnet");
+  assert.equal(config.launchProfile.lpDeposits, "live");
+  assert.equal(config.launchProfile.lpRedemptionRequests, "live");
   assert.equal(config.schema.keyHashHex, schemaKeyHashHex("genesis-protect-acute-claim", 1));
   assert.equal(
     config.schema.metadataUri,
     "https://protocol.omegax.health/schemas/genesis-protect-acute-claim-v1.json",
   );
+});
+
+test("Genesis live bootstrap defaults to open LP classes and queue-only redemptions", () => {
+  const config = loadGenesisLiveBootstrapConfig({
+    governanceAuthority: GOVERNANCE,
+    env: {
+      OMEGAX_LIVE_SETTLEMENT_MINT: "So11111111111111111111111111111111111111112",
+      OMEGAX_LIVE_ORACLE_WALLET: ORACLE,
+      OMEGAX_LIVE_ORACLE_KEYPAIR_PATH: "/tmp/genesis-oracle.json",
+      OMEGAX_LIVE_CLUSTER_OVERRIDE: "devnet",
+    },
+  });
+
+  assert.equal(config.capitalClasses.senior.restrictionMode, 0);
+  assert.equal(config.capitalClasses.junior.restrictionMode, 0);
+  assert.equal(config.capitalClasses.senior.minLockupSeconds, 30n * 86_400n);
+  assert.equal(config.capitalClasses.junior.minLockupSeconds, 30n * 86_400n);
+  assert.equal(config.liquidityPool.redemptionPolicy, 1);
+  assert(config.launchProfile.mainnetPlanAssertions.some((row) => /Classic SPL Token custody only/i.test(row)));
 });
 
 test("Genesis live bootstrap config requires LP keypair paths when deposit amounts are set", () => {
@@ -161,6 +183,26 @@ test("Mainnet bootstrap blocked when role wallets default to governance signer",
     }),
     /Mainnet bootstrap blocked.*privileged role\(s\) would default to the governance signer.*OMEGAX_LIVE_RESERVE_DOMAIN_ADMIN/,
   );
+});
+
+test("Mainnet Phase 0 bootstrap blocks accidental reward, RWA, hybrid, or extra admin attempts", () => {
+  for (const flag of [
+    "OMEGAX_LIVE_ENABLE_REWARD_LAUNCH",
+    "OMEGAX_LIVE_ENABLE_RWA_POLICY",
+    "OMEGAX_LIVE_ENABLE_HYBRID_LAUNCH",
+    "OMEGAX_LIVE_ENABLE_ADMIN_BOOTSTRAP",
+  ]) {
+    assert.throws(
+      () => loadGenesisLiveBootstrapConfig({
+        governanceAuthority: GOVERNANCE,
+        env: {
+          ...baseMainnetEnv(),
+          [flag]: "1",
+        },
+      }),
+      /Mainnet Phase 0 bootstrap blocked/,
+    );
+  }
 });
 
 test("Mainnet bootstrap loads cleanly when every privileged role has a distinct wallet", () => {

--- a/tests/genesis_protect_acute_operator_console.test.ts
+++ b/tests/genesis_protect_acute_operator_console.test.ts
@@ -610,6 +610,9 @@ test("Genesis setup surfaces Founder commitments separately from claims-paying r
   assert.equal(model.founderCommitments.pendingCoverageAmount, 1_000n);
   assert.equal(model.founderCommitments.treasuryInventoryAmount, 0n);
   assert.equal(model.founderCommitments.claimsPayingReserveImpact, 0n);
+  assert.equal(model.founderCommitments.rows[0]?.policySeries, travel30Series.address);
+  assert.equal(model.founderCommitments.rows[0]?.coverageFundingLine, travel30PremiumLine.address);
+  assert.equal(model.founderCommitments.rows[0]?.termsHashHex, "11".repeat(32));
   assert.ok(
     model.founderCommitments.warnings.some((warning) => /do not count as claims-paying reserve/i.test(warning)),
   );

--- a/tests/plan_launch_model.test.ts
+++ b/tests/plan_launch_model.test.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { Keypair } from "@solana/web3.js";
 
 import planLaunchModule from "../frontend/lib/plan-launch.ts";
+import phase0Module from "../frontend/lib/genesis-phase0-launch-profile.ts";
 import type {
   LaunchBasicsValidationInput,
   LaunchMembershipValidationInput,
@@ -25,6 +27,93 @@ const {
   validateProtectionLane,
   validateRewardLane,
 } = planLaunchModule as typeof import("../frontend/lib/plan-launch.ts");
+
+const {
+  isGenesisPhase0SurfaceActionable,
+  resolveGenesisPhase0LaunchProfile,
+} = phase0Module as typeof import("../frontend/lib/genesis-phase0-launch-profile.ts");
+
+test("Genesis Phase 0 launch profile keeps mainnet conservative by default", () => {
+  const profile = resolveGenesisPhase0LaunchProfile({
+    network: "mainnet-beta",
+    env: {},
+  });
+
+  assert.equal(profile.lpDeposits, "live");
+  assert.equal(profile.lpRedemptionRequests, "live");
+  assert.equal(profile.commitmentsDashboard, "read_only");
+  assert.equal(profile.rewardLaunch, "disabled_preview");
+  assert.equal(profile.rwaPolicyLaunch, "disabled_preview");
+  assert.equal(profile.hybridLaunch, "disabled_preview");
+  assert.equal(profile.capitalAdminActions, "hidden");
+  assert.equal(profile.policyAdminActions, "hidden");
+  assert(profile.disabledSurfaces.includes("reward launch"));
+  assert(profile.hiddenSurfaces.includes("capital admin actions"));
+  assert.equal(isGenesisPhase0SurfaceActionable(profile, "policyAdminActions"), false);
+});
+
+test("Genesis Phase 0 launch profile only makes devnet preview surfaces live behind explicit flags", () => {
+  const defaultDevnet = resolveGenesisPhase0LaunchProfile({
+    network: "devnet",
+    env: {},
+  });
+  assert.equal(defaultDevnet.rewardLaunch, "disabled_preview");
+  assert.equal(defaultDevnet.rwaPolicyLaunch, "disabled_preview");
+  assert.equal(defaultDevnet.hybridLaunch, "disabled_preview");
+
+  const flaggedDevnet = resolveGenesisPhase0LaunchProfile({
+    network: "devnet",
+    env: {
+      NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_RWA_POLICY: "1",
+      NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS: "1",
+    },
+  });
+  assert.equal(flaggedDevnet.rewardLaunch, "live");
+  assert.equal(flaggedDevnet.rwaPolicyLaunch, "live");
+  assert.equal(flaggedDevnet.hybridLaunch, "live");
+  assert.equal(flaggedDevnet.capitalAdminActions, "live");
+});
+
+test("Genesis Phase 0 mainnet future surfaces require a second explicit allow flag", () => {
+  const profile = resolveGenesisPhase0LaunchProfile({
+    network: "mainnet-beta",
+    env: {
+      NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_RWA_POLICY: "1",
+      NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: "1",
+    },
+  });
+
+  assert.equal(profile.rewardLaunch, "disabled_preview");
+  assert.equal(profile.rwaPolicyLaunch, "disabled_preview");
+  assert.equal(profile.hybridLaunch, "disabled_preview");
+
+  const allowed = resolveGenesisPhase0LaunchProfile({
+    network: "mainnet-beta",
+    env: {
+      NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_RWA_POLICY: "1",
+      NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: "1",
+      NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES: "1",
+    },
+  });
+  assert.equal(allowed.rewardLaunch, "live");
+  assert.equal(allowed.rwaPolicyLaunch, "live");
+  assert.equal(allowed.hybridLaunch, "live");
+});
+
+test("Phase 0 UI keeps public LP self-service separate from hidden admin drawers", () => {
+  const capitalWorkbench = readFileSync("frontend/components/capital-workbench.tsx", "utf8");
+  const lpPanel = readFileSync("frontend/components/capital-lp-self-service-panel.tsx", "utf8");
+
+  assert.match(capitalWorkbench, /CapitalLpSelfServicePanel/);
+  assert.match(capitalWorkbench, /capitalAdminActions/);
+  assert.match(lpPanel, /buildDepositIntoCapitalClassTx/);
+  assert.match(lpPanel, /buildRequestRedemptionTx/);
+  assert.doesNotMatch(lpPanel, /buildProcessRedemptionQueueTx/);
+});
 
 test("RWA policy launch controls stay future-gated by default", () => {
   assert.equal(isRwaPolicyLaunchEnabled({}), false);


### PR DESCRIPTION
## Summary
- add the shared Genesis Phase 0 launch profile for frontend and bootstrap gates
- keep LP deposit/request redemption live while hiding admin/operator mutation by default
- render reward/RWA/hybrid/DAO/future launch surfaces as disabled previews unless explicitly enabled
- surface Founder commitments as read-only plan/policy-series state without duplicating checkout
- add mainnet bootstrap guards and Phase 0 operations docs

## Validation
- npm run test:node
- npm --prefix frontend run build
- npm run verify:public
- OMEGAX_E2E_KEEP_ARTIFACTS=1 npm run test:e2e:localnet

## Mainnet notes
- no on-chain program changes; IDL regeneration was not required
- no mainnet transactions were sent
- mainnet --plan still safely blocks without OMEGAX_LIVE_ORACLE_KEYPAIR_PATH in local operator env