### PR TITLE
feat(protocol): add MagicBlock private claim room

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -6,11 +6,11 @@ members = ["programs/omegax_protocol", "programs/omegax_private_claim_review"]
 
 [programs.localnet]
 omegax_protocol = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
-omegax_private_claim_review = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU"
+omegax_private_claim_review = "FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn"
 
 [programs.devnet]
 omegax_protocol = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
-omegax_private_claim_review = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU"
+omegax_private_claim_review = "FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -2,13 +2,15 @@
 anchor_version = "0.32.1"
 
 [workspace]
-members = ["programs/omegax_protocol"]
+members = ["programs/omegax_protocol", "programs/omegax_private_claim_review"]
 
 [programs.localnet]
 omegax_protocol = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+omegax_private_claim_review = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU"
 
 [programs.devnet]
 omegax_protocol = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+omegax_private_claim_review = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +774,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ephemeral-rollups-sdk"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebb432c4e5f748d843cd368d3e2389ce682601b07261be41cda4180eb8c665f"
+dependencies = [
+ "anchor-lang",
+ "base64ct",
+ "borsh 1.6.0",
+ "ephemeral-rollups-sdk-attribute-action",
+ "ephemeral-rollups-sdk-attribute-commit",
+ "ephemeral-rollups-sdk-attribute-delegate",
+ "ephemeral-rollups-sdk-attribute-ephemeral",
+ "getrandom 0.2.17",
+ "magicblock-delegation-program",
+ "magicblock-magic-program-api",
+ "solana-program",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-action"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f0b983783d3e2fa9e921a1760b606a830acff5a2d17493dd97c50971653090"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-commit"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa12b48570efab341b925df215470cdb5bbd6edf09132cba0bf3608672e261"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-delegate"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868eb256937326dc1ee629477c1935a8a8fbdb6dabcc5b926e8534f7390c4387"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ephemeral-rollups-sdk-attribute-ephemeral"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3194e93f3c5265da16111b9b8a70bece5a191614f4e8209d056e06ddc2cbad8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1106,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "magicblock-delegation-program"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e25f9e37194cc27c0f1d3dbc00e83795f7f4012f1a99c20bc557bdeb62e13e"
+dependencies = [
+ "borsh 1.6.0",
+ "bytemuck",
+ "num_enum",
+ "solana-program",
+ "static_assertions",
+]
+
+[[package]]
+name = "magicblock-magic-program-api"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6ec80d63618a71bb4db324ec5fdca8f85552d0469a51aa063d290256d425f5"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-program",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1215,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "omegax_private_claim_review"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "ephemeral-rollups-sdk",
 ]
 
 [[package]]
@@ -2795,6 +2895,12 @@ dependencies = [
  "spl-pod",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/docs/architecture/magicblock-private-claim-room.md
+++ b/docs/architecture/magicblock-private-claim-room.md
@@ -1,0 +1,34 @@
+# MagicBlock Private Claim Room
+
+OmegaX Private Claim Room is a hackathon adjunct for private Genesis Protect Acute claim review. It uses MagicBlock Ephemeral Rollups for delegated review-session state while the main `omegax_protocol` program remains the Solana settlement and claim-attestation kernel.
+
+The adjunct program is `omegax_private_claim_review`. It stores only public-safe hashes and session state:
+
+- linked claim case
+- health plan and policy series
+- evidence and schema hashes
+- review result and artifact hashes
+- review binary and TEE attestation digests
+- reviewer/operator key
+- private payment reference hash
+- lifecycle status and timestamps
+
+Raw medical evidence, encrypted evidence payloads, OCR text, storage paths, and private payment details never belong in this program.
+
+## Demo Flow
+
+1. `omegax-health` prepares a redacted Genesis Protect Acute claim packet and hashes the private evidence bundle.
+2. `omegax_private_claim_review::open_review_session` creates a public review-session PDA on base Solana.
+3. `delegate_review_session` delegates that session PDA to MagicBlock ER.
+4. A TEE/private reviewer checks the private packet and emits a hash-bounded review artifact.
+5. `record_private_review` records only review hashes and status on the delegated session.
+6. The MagicBlock Private Payments API builds a devnet reimbursement preview; `record_private_payment_ref` stores only its reference hash.
+7. `commit_and_close_review_session` commits and undelegates the review session back to Solana.
+8. The existing `omegax_protocol::attest_claim_case` consumes the committed review artifact hash through the normal claim attestation path.
+
+## Boundaries
+
+- The main `omegax_protocol` program is not delegated to MagicBlock.
+- `ClaimCase`, reserves, vaults, funding lines, obligations, and payout accounts are not delegated.
+- The private reviewer may inspect plaintext inside the TEE path, but public Solana only receives hashes and status.
+- The hackathon reimbursement preview demonstrates MagicBlock private payments; it does not replace the production reserve kernel.

--- a/frontend/app/magicblock-claim-room/page.tsx
+++ b/frontend/app/magicblock-claim-room/page.tsx
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Fingerprint,
+  LockKeyhole,
+  Network,
+  ReceiptText,
+  ShieldCheck,
+} from "lucide-react";
+
+const REVIEW_PROGRAM_ID = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU";
+
+const proofSteps = [
+  {
+    label: "Prepare",
+    title: "Redacted medical packet",
+    detail:
+      "The claim room hashes the evidence bundle and shows only safe document metadata.",
+  },
+  {
+    label: "Open",
+    title: "Base Solana session",
+    detail:
+      "A public review-session PDA links the claim case, schema hash, and evidence hash.",
+  },
+  {
+    label: "Delegate",
+    title: "MagicBlock ER handoff",
+    detail:
+      "The review session moves into the low-latency MagicBlock execution lane.",
+  },
+  {
+    label: "Review",
+    title: "Private reviewer output",
+    detail:
+      "The TEE reviewer checks completeness and emits result and artifact hashes.",
+  },
+  {
+    label: "Pay",
+    title: "Private payment preview",
+    detail:
+      "A devnet reimbursement preview proves the private payment rail was invoked.",
+  },
+  {
+    label: "Commit",
+    title: "Public proof out",
+    detail:
+      "The session commits back to Solana and the existing claim attestation path consumes it.",
+  },
+] as const;
+
+export const metadata: Metadata = {
+  title: "MagicBlock Claim Room | OmegaX Protocol",
+  description:
+    "A MagicBlock-powered private claim review room for OmegaX Protect medical claims.",
+};
+
+export default function MagicBlockClaimRoomPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+      <section className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-stretch">
+        <div className="flex min-h-[28rem] flex-col justify-between rounded-[8px] border border-[color:var(--border)] bg-[color:var(--surface-elevated)] p-6 shadow-[var(--surface-shadow)]">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-strong)] bg-[color:var(--signal-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--accent-strong)]">
+              <LockKeyhole className="h-3.5 w-3.5" strokeWidth={1.9} />
+              MagicBlock privacy track
+            </span>
+            <span className="inline-flex rounded-full border border-[color:var(--border)] px-3 py-1 text-xs text-[color:var(--muted-foreground)]">
+              ER + PER + Private Payments
+            </span>
+          </div>
+
+          <div className="max-w-2xl">
+            <h1 className="mt-10 text-balance font-[var(--font-display)] text-4xl font-semibold leading-tight sm:text-5xl">
+              OmegaX Private Claim Room
+            </h1>
+            <p className="mt-4 max-w-xl text-base leading-7 text-[color:var(--muted-foreground)]">
+              Private medical evidence goes into a MagicBlock claim room; public
+              Solana only sees verifiable review and settlement proofs.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-3 sm:grid-cols-3">
+            <Signal
+              icon={<ShieldCheck className="h-4 w-4" strokeWidth={1.9} />}
+              label="Private evidence in"
+              value="Only hashes on-chain"
+            />
+            <Signal
+              icon={<Network className="h-4 w-4" strokeWidth={1.9} />}
+              label="MagicBlock review"
+              value="Delegated session PDA"
+            />
+            <Signal
+              icon={<CheckCircle2 className="h-4 w-4" strokeWidth={1.9} />}
+              label="Public proof out"
+              value="attest_claim_case"
+            />
+          </div>
+        </div>
+
+        <div className="rounded-[8px] border border-[color:var(--border)] bg-[color:var(--surface)] p-5 shadow-[var(--surface-shadow)]">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--muted-foreground)]">
+                Live demo surface
+              </p>
+              <h2 className="mt-1 text-xl font-semibold">
+                Claim-room proof trail
+              </h2>
+            </div>
+            <Fingerprint
+              className="h-5 w-5 text-[color:var(--accent)]"
+              strokeWidth={1.8}
+            />
+          </div>
+
+          <div className="mt-5 space-y-3">
+            <ProofRow label="Adjunct program" value={REVIEW_PROGRAM_ID} />
+            <ProofRow
+              label="Base route"
+              value="POST /v1/internal/magicblock/claim-room/open"
+            />
+            <ProofRow
+              label="ER route"
+              value="POST /v1/internal/magicblock/claim-room/review"
+            />
+            <ProofRow
+              label="Payment route"
+              value="POST /v1/internal/magicblock/claim-room/private-payment"
+            />
+            <ProofRow
+              label="Final route"
+              value="POST /v1/internal/magicblock/claim-room/commit"
+            />
+          </div>
+
+          <div className="mt-6 rounded-[8px] border border-[color:var(--border-strong)] bg-[color:var(--status-surface)] p-4">
+            <p className="text-sm font-semibold">Judging line</p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--muted-foreground)]">
+              Private evidence in. Public proof out. Settlement stays on Solana.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {proofSteps.map((step, index) => (
+          <div
+            key={step.label}
+            className="flex min-h-[10rem] flex-col justify-between rounded-[8px] border border-[color:var(--border)] bg-[color:var(--surface)] p-4"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="inline-flex h-8 min-w-8 items-center justify-center rounded-full bg-[color:var(--signal-soft)] px-2 text-xs font-semibold text-[color:var(--accent-strong)]">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              {index < proofSteps.length - 1 ? (
+                <ArrowRight
+                  className="h-4 w-4 text-[color:var(--muted-foreground)]"
+                  strokeWidth={1.8}
+                />
+              ) : (
+                <ReceiptText
+                  className="h-4 w-4 text-[color:var(--accent)]"
+                  strokeWidth={1.8}
+                />
+              )}
+            </div>
+            <div className="mt-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--muted-foreground)]">
+                {step.label}
+              </p>
+              <h3 className="mt-1 text-lg font-semibold">{step.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-[color:var(--muted-foreground)]">
+                {step.detail}
+              </p>
+            </div>
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+}
+
+function Signal({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-[8px] border border-[color:var(--border)] bg-[color:var(--surface)] p-3">
+      <div className="flex items-center gap-2 text-[color:var(--accent)]">
+        {icon}
+      </div>
+      <p className="mt-3 text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--muted-foreground)]">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function ProofRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 rounded-[8px] border border-[color:var(--border)] bg-[color:var(--surface-elevated)] p-3">
+      <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[color:var(--muted-foreground)]">
+        {label}
+      </span>
+      <span className="break-all font-mono text-xs text-[color:var(--foreground)]">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/frontend/app/magicblock-claim-room/page.tsx
+++ b/frontend/app/magicblock-claim-room/page.tsx
@@ -12,7 +12,7 @@ import {
   ShieldCheck,
 } from "lucide-react";
 
-const REVIEW_PROGRAM_ID = "5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU";
+const REVIEW_PROGRAM_ID = "FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn";
 
 const proofSteps = [
   {

--- a/programs/omegax_private_claim_review/Cargo.toml
+++ b/programs/omegax_private_claim_review/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "omegax_private_claim_review"
+version = "0.1.0"
+description = "OmegaX MagicBlock private claim review session adjunct program"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "omegax_private_claim_review"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+custom-heap = []
+custom-panic = []
+anchor-debug = []
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
+
+[dependencies]
+anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }
+ephemeral-rollups-sdk = { version = "0.6.5", features = ["anchor", "disable-realloc"] }

--- a/programs/omegax_private_claim_review/src/lib.rs
+++ b/programs/omegax_private_claim_review/src/lib.rs
@@ -11,10 +11,14 @@ use ephemeral_rollups_sdk::anchor::{commit, delegate, ephemeral};
 use ephemeral_rollups_sdk::cpi::DelegateConfig;
 use ephemeral_rollups_sdk::ephem::commit_and_undelegate_accounts;
 
-declare_id!("5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU");
+declare_id!("FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn");
 
 pub const SEED_REVIEW_SESSION: &[u8] = b"private_claim_review";
 pub const MAX_SESSION_ID_LEN: usize = 64;
+pub const MAGICBLOCK_DEVNET_TEE_VALIDATOR: Pubkey = Pubkey::new_from_array([
+    5, 61, 71, 26, 133, 158, 115, 46, 104, 11, 201, 88, 248, 65, 7, 43, 143, 63, 188, 25, 115, 155,
+    230, 151, 196, 198, 129, 18, 111, 140, 31, 116,
+]);
 
 pub const REVIEW_STATUS_OPENED: u8 = 0;
 pub const REVIEW_STATUS_DELEGATED: u8 = 1;
@@ -105,7 +109,10 @@ pub mod omegax_private_claim_review {
         ctx.accounts.delegate_review_session(
             &ctx.accounts.payer,
             &[SEED_REVIEW_SESSION, session_id.as_bytes()],
-            DelegateConfig::default(),
+            DelegateConfig {
+                validator: Some(MAGICBLOCK_DEVNET_TEE_VALIDATOR),
+                ..DelegateConfig::default()
+            },
         )?;
 
         emit!(ReviewSessionDelegated {

--- a/programs/omegax_private_claim_review/src/lib.rs
+++ b/programs/omegax_private_claim_review/src/lib.rs
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! MagicBlock adjunct program for private claim-review sessions.
+//!
+//! This program intentionally stores only public-safe hashes and session state.
+//! Raw medical evidence, encrypted evidence payloads, OCR text, storage paths,
+//! and payout details stay outside this program.
+
+use anchor_lang::prelude::*;
+use ephemeral_rollups_sdk::anchor::{commit, delegate, ephemeral};
+use ephemeral_rollups_sdk::cpi::DelegateConfig;
+use ephemeral_rollups_sdk::ephem::commit_and_undelegate_accounts;
+
+declare_id!("5eMhMgdweRhrucbxkFgw1FijRQEHqv8fxhriHBttf9xU");
+
+pub const SEED_REVIEW_SESSION: &[u8] = b"private_claim_review";
+pub const MAX_SESSION_ID_LEN: usize = 64;
+
+pub const REVIEW_STATUS_OPENED: u8 = 0;
+pub const REVIEW_STATUS_DELEGATED: u8 = 1;
+pub const REVIEW_STATUS_REVIEWED: u8 = 2;
+pub const REVIEW_STATUS_APPROVED: u8 = 3;
+pub const REVIEW_STATUS_NEEDS_MORE_INFO: u8 = 4;
+pub const REVIEW_STATUS_ESCALATED: u8 = 5;
+pub const REVIEW_STATUS_FAILED: u8 = 6;
+
+#[ephemeral]
+#[program]
+pub mod omegax_private_claim_review {
+    use super::*;
+
+    pub fn open_review_session(
+        ctx: Context<OpenReviewSession>,
+        args: OpenReviewSessionArgs,
+    ) -> Result<()> {
+        require!(
+            !args.session_id.trim().is_empty(),
+            PrivateClaimReviewError::EmptySessionId
+        );
+        require!(
+            args.session_id.len() <= MAX_SESSION_ID_LEN,
+            PrivateClaimReviewError::SessionIdTooLong
+        );
+        require!(
+            !is_zero_hash(&args.evidence_ref_hash),
+            PrivateClaimReviewError::ZeroEvidenceRefHash
+        );
+        require!(
+            !is_zero_hash(&args.schema_key_hash),
+            PrivateClaimReviewError::ZeroSchemaKeyHash
+        );
+        require!(
+            !is_zero_hash(&args.schema_hash),
+            PrivateClaimReviewError::ZeroSchemaHash
+        );
+
+        let now_ts = Clock::get()?.unix_timestamp;
+        let session = &mut ctx.accounts.review_session;
+        session.session_id = args.session_id;
+        session.claim_case = args.claim_case;
+        session.health_plan = args.health_plan;
+        session.policy_series = args.policy_series;
+        session.evidence_ref_hash = args.evidence_ref_hash;
+        session.decision_support_hash = args.decision_support_hash;
+        session.schema_key_hash = args.schema_key_hash;
+        session.schema_hash = args.schema_hash;
+        session.review_result_hash = [0; 32];
+        session.review_artifact_hash = [0; 32];
+        session.review_binary_hash = [0; 32];
+        session.tee_attestation_digest = [0; 32];
+        session.operator = Pubkey::default();
+        session.private_payment_ref_hash = [0; 32];
+        session.status = REVIEW_STATUS_OPENED;
+        session.opened_at = now_ts;
+        session.delegated_at = 0;
+        session.reviewed_at = 0;
+        session.payment_recorded_at = 0;
+        session.committed_at = 0;
+        session.failed_at = 0;
+        session.bump = ctx.bumps.review_session;
+
+        emit!(ReviewSessionOpened {
+            review_session: session.key(),
+            claim_case: session.claim_case,
+            evidence_ref_hash: session.evidence_ref_hash,
+            schema_key_hash: session.schema_key_hash,
+        });
+
+        Ok(())
+    }
+
+    pub fn delegate_review_session(
+        ctx: Context<DelegateReviewSession>,
+        session_id: String,
+    ) -> Result<()> {
+        require!(
+            !session_id.trim().is_empty(),
+            PrivateClaimReviewError::EmptySessionId
+        );
+        require!(
+            session_id.len() <= MAX_SESSION_ID_LEN,
+            PrivateClaimReviewError::SessionIdTooLong
+        );
+
+        ctx.accounts.delegate_review_session(
+            &ctx.accounts.payer,
+            &[SEED_REVIEW_SESSION, session_id.as_bytes()],
+            DelegateConfig::default(),
+        )?;
+
+        emit!(ReviewSessionDelegated {
+            review_session: ctx.accounts.review_session.key(),
+        });
+
+        Ok(())
+    }
+
+    pub fn record_private_review(
+        ctx: Context<RecordPrivateReview>,
+        args: RecordPrivateReviewArgs,
+    ) -> Result<()> {
+        require!(
+            is_terminal_review_status(args.status),
+            PrivateClaimReviewError::InvalidReviewStatus
+        );
+        require!(
+            !is_zero_hash(&args.review_result_hash),
+            PrivateClaimReviewError::ZeroReviewResultHash
+        );
+        require!(
+            !is_zero_hash(&args.review_artifact_hash),
+            PrivateClaimReviewError::ZeroReviewArtifactHash
+        );
+        require!(
+            !is_zero_hash(&args.review_binary_hash),
+            PrivateClaimReviewError::ZeroReviewBinaryHash
+        );
+        require!(
+            !is_zero_hash(&args.tee_attestation_digest),
+            PrivateClaimReviewError::ZeroTeeAttestationDigest
+        );
+
+        let session = &mut ctx.accounts.review_session;
+        require!(
+            session.status == REVIEW_STATUS_OPENED || session.status == REVIEW_STATUS_DELEGATED,
+            PrivateClaimReviewError::ReviewNotWritable
+        );
+        require!(
+            is_zero_hash(&session.review_result_hash),
+            PrivateClaimReviewError::ReviewAlreadyRecorded
+        );
+
+        let now_ts = Clock::get()?.unix_timestamp;
+        session.review_result_hash = args.review_result_hash;
+        session.review_artifact_hash = args.review_artifact_hash;
+        session.review_binary_hash = args.review_binary_hash;
+        session.tee_attestation_digest = args.tee_attestation_digest;
+        session.operator = ctx.accounts.reviewer.key();
+        session.status = args.status;
+        session.reviewed_at = now_ts;
+
+        emit!(PrivateReviewRecorded {
+            review_session: session.key(),
+            operator: session.operator,
+            status: session.status,
+            review_result_hash: session.review_result_hash,
+            review_artifact_hash: session.review_artifact_hash,
+        });
+
+        Ok(())
+    }
+
+    pub fn record_private_payment_ref(
+        ctx: Context<RecordPrivatePaymentRef>,
+        args: RecordPrivatePaymentRefArgs,
+    ) -> Result<()> {
+        require!(
+            !is_zero_hash(&args.private_payment_ref_hash),
+            PrivateClaimReviewError::ZeroPrivatePaymentRefHash
+        );
+
+        let session = &mut ctx.accounts.review_session;
+        require!(
+            session.status == REVIEW_STATUS_APPROVED || session.status == REVIEW_STATUS_REVIEWED,
+            PrivateClaimReviewError::PaymentRefNotAllowed
+        );
+        require!(
+            is_zero_hash(&session.private_payment_ref_hash),
+            PrivateClaimReviewError::PaymentRefAlreadyRecorded
+        );
+
+        session.private_payment_ref_hash = args.private_payment_ref_hash;
+        session.payment_recorded_at = Clock::get()?.unix_timestamp;
+
+        emit!(PrivatePaymentRefRecorded {
+            review_session: session.key(),
+            private_payment_ref_hash: session.private_payment_ref_hash,
+        });
+
+        Ok(())
+    }
+
+    pub fn commit_and_close_review_session(
+        ctx: Context<CommitAndCloseReviewSession>,
+    ) -> Result<()> {
+        let session = &mut ctx.accounts.review_session;
+        require!(
+            session.status == REVIEW_STATUS_REVIEWED
+                || session.status == REVIEW_STATUS_APPROVED
+                || session.status == REVIEW_STATUS_NEEDS_MORE_INFO
+                || session.status == REVIEW_STATUS_ESCALATED
+                || session.status == REVIEW_STATUS_FAILED,
+            PrivateClaimReviewError::ReviewNotReadyToCommit
+        );
+        session.committed_at = Clock::get()?.unix_timestamp;
+
+        emit!(ReviewSessionCommitted {
+            review_session: session.key(),
+            status: session.status,
+            review_artifact_hash: session.review_artifact_hash,
+            private_payment_ref_hash: session.private_payment_ref_hash,
+        });
+
+        commit_and_undelegate_accounts(
+            &ctx.accounts.payer,
+            vec![&ctx.accounts.review_session.to_account_info()],
+            &ctx.accounts.magic_context,
+            &ctx.accounts.magic_program,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn mark_review_failed(
+        ctx: Context<MarkReviewFailed>,
+        args: MarkReviewFailedArgs,
+    ) -> Result<()> {
+        require!(
+            !is_zero_hash(&args.failure_ref_hash),
+            PrivateClaimReviewError::ZeroFailureRefHash
+        );
+
+        let session = &mut ctx.accounts.review_session;
+        require!(
+            session.status != REVIEW_STATUS_APPROVED,
+            PrivateClaimReviewError::ApprovedReviewCannotFail
+        );
+        session.review_artifact_hash = args.failure_ref_hash;
+        session.status = REVIEW_STATUS_FAILED;
+        session.failed_at = Clock::get()?.unix_timestamp;
+
+        emit!(ReviewSessionFailed {
+            review_session: session.key(),
+            failure_ref_hash: session.review_artifact_hash,
+        });
+
+        Ok(())
+    }
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct PrivateClaimReviewSession {
+    #[max_len(MAX_SESSION_ID_LEN)]
+    pub session_id: String,
+    pub claim_case: Pubkey,
+    pub health_plan: Pubkey,
+    pub policy_series: Pubkey,
+    pub evidence_ref_hash: [u8; 32],
+    pub decision_support_hash: [u8; 32],
+    pub schema_key_hash: [u8; 32],
+    pub schema_hash: [u8; 32],
+    pub review_result_hash: [u8; 32],
+    pub review_artifact_hash: [u8; 32],
+    pub review_binary_hash: [u8; 32],
+    pub tee_attestation_digest: [u8; 32],
+    pub operator: Pubkey,
+    pub private_payment_ref_hash: [u8; 32],
+    pub status: u8,
+    pub opened_at: i64,
+    pub delegated_at: i64,
+    pub reviewed_at: i64,
+    pub payment_recorded_at: i64,
+    pub committed_at: i64,
+    pub failed_at: i64,
+    pub bump: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct OpenReviewSessionArgs {
+    #[max_len(MAX_SESSION_ID_LEN)]
+    pub session_id: String,
+    pub claim_case: Pubkey,
+    pub health_plan: Pubkey,
+    pub policy_series: Pubkey,
+    pub evidence_ref_hash: [u8; 32],
+    pub decision_support_hash: [u8; 32],
+    pub schema_key_hash: [u8; 32],
+    pub schema_hash: [u8; 32],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct RecordPrivateReviewArgs {
+    pub status: u8,
+    pub review_result_hash: [u8; 32],
+    pub review_artifact_hash: [u8; 32],
+    pub review_binary_hash: [u8; 32],
+    pub tee_attestation_digest: [u8; 32],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct RecordPrivatePaymentRefArgs {
+    pub private_payment_ref_hash: [u8; 32],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct MarkReviewFailedArgs {
+    pub failure_ref_hash: [u8; 32],
+}
+
+#[derive(Accounts)]
+#[instruction(args: OpenReviewSessionArgs)]
+pub struct OpenReviewSession<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + PrivateClaimReviewSession::INIT_SPACE,
+        seeds = [SEED_REVIEW_SESSION, args.session_id.as_bytes()],
+        bump,
+    )]
+    pub review_session: Account<'info, PrivateClaimReviewSession>,
+    pub system_program: Program<'info, System>,
+}
+
+#[delegate]
+#[derive(Accounts)]
+#[instruction(session_id: String)]
+pub struct DelegateReviewSession<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    /// CHECK: The delegation program validates ownership and delegated state.
+    #[account(
+        mut,
+        del,
+        seeds = [SEED_REVIEW_SESSION, session_id.as_bytes()],
+        bump,
+    )]
+    pub review_session: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+#[instruction(_args: RecordPrivateReviewArgs)]
+pub struct RecordPrivateReview<'info> {
+    #[account(mut)]
+    pub reviewer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [SEED_REVIEW_SESSION, review_session.session_id.as_bytes()],
+        bump = review_session.bump,
+    )]
+    pub review_session: Account<'info, PrivateClaimReviewSession>,
+}
+
+#[derive(Accounts)]
+#[instruction(_args: RecordPrivatePaymentRefArgs)]
+pub struct RecordPrivatePaymentRef<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [SEED_REVIEW_SESSION, review_session.session_id.as_bytes()],
+        bump = review_session.bump,
+    )]
+    pub review_session: Account<'info, PrivateClaimReviewSession>,
+}
+
+#[commit]
+#[derive(Accounts)]
+pub struct CommitAndCloseReviewSession<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [SEED_REVIEW_SESSION, review_session.session_id.as_bytes()],
+        bump = review_session.bump,
+    )]
+    pub review_session: Account<'info, PrivateClaimReviewSession>,
+}
+
+#[derive(Accounts)]
+#[instruction(_args: MarkReviewFailedArgs)]
+pub struct MarkReviewFailed<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [SEED_REVIEW_SESSION, review_session.session_id.as_bytes()],
+        bump = review_session.bump,
+    )]
+    pub review_session: Account<'info, PrivateClaimReviewSession>,
+}
+
+#[event]
+pub struct ReviewSessionOpened {
+    pub review_session: Pubkey,
+    pub claim_case: Pubkey,
+    pub evidence_ref_hash: [u8; 32],
+    pub schema_key_hash: [u8; 32],
+}
+
+#[event]
+pub struct ReviewSessionDelegated {
+    pub review_session: Pubkey,
+}
+
+#[event]
+pub struct PrivateReviewRecorded {
+    pub review_session: Pubkey,
+    pub operator: Pubkey,
+    pub status: u8,
+    pub review_result_hash: [u8; 32],
+    pub review_artifact_hash: [u8; 32],
+}
+
+#[event]
+pub struct PrivatePaymentRefRecorded {
+    pub review_session: Pubkey,
+    pub private_payment_ref_hash: [u8; 32],
+}
+
+#[event]
+pub struct ReviewSessionCommitted {
+    pub review_session: Pubkey,
+    pub status: u8,
+    pub review_artifact_hash: [u8; 32],
+    pub private_payment_ref_hash: [u8; 32],
+}
+
+#[event]
+pub struct ReviewSessionFailed {
+    pub review_session: Pubkey,
+    pub failure_ref_hash: [u8; 32],
+}
+
+#[error_code]
+pub enum PrivateClaimReviewError {
+    #[msg("review session id is required")]
+    EmptySessionId,
+    #[msg("review session id exceeds the maximum length")]
+    SessionIdTooLong,
+    #[msg("evidence reference hash cannot be zero")]
+    ZeroEvidenceRefHash,
+    #[msg("schema key hash cannot be zero")]
+    ZeroSchemaKeyHash,
+    #[msg("schema hash cannot be zero")]
+    ZeroSchemaHash,
+    #[msg("review result hash cannot be zero")]
+    ZeroReviewResultHash,
+    #[msg("review artifact hash cannot be zero")]
+    ZeroReviewArtifactHash,
+    #[msg("review binary hash cannot be zero")]
+    ZeroReviewBinaryHash,
+    #[msg("TEE attestation digest cannot be zero")]
+    ZeroTeeAttestationDigest,
+    #[msg("private payment reference hash cannot be zero")]
+    ZeroPrivatePaymentRefHash,
+    #[msg("failure reference hash cannot be zero")]
+    ZeroFailureRefHash,
+    #[msg("invalid private review status")]
+    InvalidReviewStatus,
+    #[msg("private review is not writable in its current state")]
+    ReviewNotWritable,
+    #[msg("private review result already recorded")]
+    ReviewAlreadyRecorded,
+    #[msg("private payment reference cannot be recorded in the current state")]
+    PaymentRefNotAllowed,
+    #[msg("private payment reference already recorded")]
+    PaymentRefAlreadyRecorded,
+    #[msg("private review session is not ready to commit")]
+    ReviewNotReadyToCommit,
+    #[msg("approved private review cannot be marked failed")]
+    ApprovedReviewCannotFail,
+}
+
+fn is_zero_hash(hash: &[u8; 32]) -> bool {
+    hash.iter().all(|byte| *byte == 0)
+}
+
+fn is_terminal_review_status(status: u8) -> bool {
+    status == REVIEW_STATUS_REVIEWED
+        || status == REVIEW_STATUS_APPROVED
+        || status == REVIEW_STATUS_NEEDS_MORE_INFO
+        || status == REVIEW_STATUS_ESCALATED
+        || status == REVIEW_STATUS_FAILED
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_hash_detection_is_exact() {
+        assert!(is_zero_hash(&[0; 32]));
+        let mut hash = [0; 32];
+        hash[31] = 1;
+        assert!(!is_zero_hash(&hash));
+    }
+
+    #[test]
+    fn only_review_terminal_statuses_can_be_recorded() {
+        assert!(!is_terminal_review_status(REVIEW_STATUS_OPENED));
+        assert!(!is_terminal_review_status(REVIEW_STATUS_DELEGATED));
+        assert!(is_terminal_review_status(REVIEW_STATUS_REVIEWED));
+        assert!(is_terminal_review_status(REVIEW_STATUS_APPROVED));
+        assert!(is_terminal_review_status(REVIEW_STATUS_NEEDS_MORE_INFO));
+        assert!(is_terminal_review_status(REVIEW_STATUS_ESCALATED));
+        assert!(is_terminal_review_status(REVIEW_STATUS_FAILED));
+    }
+}

--- a/tests/magicblock_private_claim_review.test.ts
+++ b/tests/magicblock_private_claim_review.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { PublicKey } from "@solana/web3.js";
+
+const anchorToml = readFileSync("Anchor.toml", "utf8");
+const cargoToml = readFileSync("programs/omegax_private_claim_review/Cargo.toml", "utf8");
+const programSource = readFileSync("programs/omegax_private_claim_review/src/lib.rs", "utf8");
+const architectureDoc = readFileSync(
+  "docs/architecture/magicblock-private-claim-room.md",
+  "utf8",
+);
+
+test("MagicBlock adjunct program is registered as a separate Anchor program", () => {
+  assert.match(anchorToml, /programs\/omegax_private_claim_review/);
+  assert.match(anchorToml, /omegax_private_claim_review = "[1-9A-HJ-NP-Za-km-z]+"/);
+  assert.match(cargoToml, /name = "omegax_private_claim_review"/);
+  assert.match(cargoToml, /ephemeral-rollups-sdk/);
+});
+
+test("MagicBlock adjunct uses ER delegation and commit macros", () => {
+  assert.match(programSource, /#\[ephemeral\]\s*#\[program\]/);
+  assert.match(programSource, /#\[delegate\]/);
+  assert.match(programSource, /#\[commit\]/);
+  assert.match(programSource, /commit_and_undelegate_accounts/);
+  assert.match(programSource, /DelegateConfig::default\(\)/);
+});
+
+test("PrivateClaimReviewSession stores only public-safe hashes and session state", () => {
+  const expectedFields = [
+    "evidence_ref_hash",
+    "decision_support_hash",
+    "schema_key_hash",
+    "schema_hash",
+    "review_result_hash",
+    "review_artifact_hash",
+    "review_binary_hash",
+    "tee_attestation_digest",
+    "private_payment_ref_hash",
+    "status",
+  ];
+
+  for (const field of expectedFields) {
+    assert.match(programSource, new RegExp(`pub ${field}:`));
+  }
+
+  assert.doesNotMatch(programSource, /storage_path|evidence_url|ocr_text|medical_narrative|firebase/i);
+});
+
+test("MagicBlock adjunct keeps the main settlement kernel out of delegation scope", () => {
+  assert.match(architectureDoc, /main `omegax_protocol` program remains/);
+  assert.match(architectureDoc, /ClaimCase`, reserves, vaults, funding lines, obligations, and payout accounts are not delegated/);
+  assert.doesNotMatch(programSource, /omegax_protocol::/);
+});
+
+test("MagicBlock private claim review program id is valid", () => {
+  const match = anchorToml.match(/omegax_private_claim_review = "([^"]+)"/);
+  assert.ok(match?.[1]);
+  assert.doesNotThrow(() => new PublicKey(match[1]));
+});


### PR DESCRIPTION
## Summary
- Adds the public MagicBlock adjunct Anchor program for private claim review sessions.
- Adds the protocol console MagicBlock Claim Room demo page.
- Aligns the adjunct program id with the deployed devnet program: FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn.

## Validation
- cargo test -p omegax_private_claim_review --lib
- npm --prefix frontend run build

## Notes
- Targets main via PR because direct main pushes are protected.
- Devnet deploy signature: 2QJUHwRRpMjBdjZbAbNhPFUPXCb1D9niMTJ4r6VbbywkQdzJG3NvbqKEqEYTv2nVoa7Cqe7384nuyiaNPpm7MLtC