### PR TITLE
fix: preserve modeled state in QEDGen guards

### DIFF
--- a/formal_verification/anchor_model/src/guards.rs
+++ b/formal_verification/anchor_model/src/guards.rs
@@ -10,14 +10,35 @@ use crate::errors::*;
 use crate::state::*;
 use crate::*;
 
+fn read_model_account(account_info: &AccountInfo) -> Result<OmegaxProtocolAccount> {
+    let data = account_info.try_borrow_data()?;
+    OmegaxProtocolAccount::try_deserialize(&mut data.as_ref())
+}
+
+fn account_emergency_pause(account_info: &AccountInfo) -> Result<bool> {
+    Ok(read_model_account(account_info)?.emergency_pause)
+}
+
+fn account_paid_amount(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.paid_amount)
+}
+
+fn account_approved_amount(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.approved_amount)
+}
+
+fn account_withdrawn_fees(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.withdrawn_fees)
+}
+
+fn account_accrued_fees(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.accrued_fees)
+}
+
+
 /// Guards for `initialize_protocol_governance`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn initialize_protocol_governance<'info>(ctx: &mut InitializeProtocolGovernance<'info>, args: InitializeProtocolGovernanceArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // requires: args.protocol_fee_bps ≤ 9999
     if !(args.protocol_fee_bps <= 9999) { return Err(OmegaxProtocolError::InvalidBps.into()); }
     // lifecycle: status := Live
@@ -28,11 +49,6 @@ pub fn initialize_protocol_governance<'info>(ctx: &mut InitializeProtocolGoverna
 /// Guards for `set_protocol_emergency_pause`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn set_protocol_emergency_pause<'info>(ctx: &mut SetProtocolEmergencyPause<'info>, args: SetProtocolEmergencyPauseArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.protocol_governance.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -41,11 +57,6 @@ pub fn set_protocol_emergency_pause<'info>(ctx: &mut SetProtocolEmergencyPause<'
 /// Guards for `rotate_protocol_governance_authority`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn rotate_protocol_governance_authority<'info>(ctx: &mut RotateProtocolGovernanceAuthority<'info>, args: RotateProtocolGovernanceAuthorityArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.protocol_governance.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -54,11 +65,6 @@ pub fn rotate_protocol_governance_authority<'info>(ctx: &mut RotateProtocolGover
 /// Guards for `create_reserve_domain`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_reserve_domain<'info>(ctx: &mut CreateReserveDomain<'info>, args: CreateReserveDomainArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.reserve_domain.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -67,11 +73,6 @@ pub fn create_reserve_domain<'info>(ctx: &mut CreateReserveDomain<'info>, args: 
 /// Guards for `update_reserve_domain_controls`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_reserve_domain_controls<'info>(ctx: &mut UpdateReserveDomainControls<'info>, args: UpdateReserveDomainControlsArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.reserve_domain.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -80,11 +81,6 @@ pub fn update_reserve_domain_controls<'info>(ctx: &mut UpdateReserveDomainContro
 /// Guards for `create_domain_asset_vault`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_domain_asset_vault<'info>(ctx: &mut CreateDomainAssetVault<'info>, args: CreateDomainAssetVaultArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -92,11 +88,7 @@ pub fn create_domain_asset_vault<'info>(ctx: &mut CreateDomainAssetVault<'info>,
 /// Guards for `configure_reserve_asset_rail`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn configure_reserve_asset_rail<'info>(ctx: &mut ConfigureReserveAssetRail<'info>, args: ConfigureReserveAssetRailArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.reserve_asset_rail.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -107,11 +99,7 @@ pub fn configure_reserve_asset_rail<'info>(ctx: &mut ConfigureReserveAssetRail<'
 /// Guards for `publish_reserve_asset_rail_price`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn publish_reserve_asset_rail_price<'info>(ctx: &mut PublishReserveAssetRailPrice<'info>, args: PublishReserveAssetRailPriceArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.reserve_asset_rail.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -124,11 +112,6 @@ pub fn publish_reserve_asset_rail_price<'info>(ctx: &mut PublishReserveAssetRail
 /// Guards for `init_protocol_fee_vault`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn init_protocol_fee_vault<'info>(ctx: &mut InitProtocolFeeVault<'info>, args: InitProtocolFeeVaultArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.protocol_fee_vault.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -137,11 +120,6 @@ pub fn init_protocol_fee_vault<'info>(ctx: &mut InitProtocolFeeVault<'info>, arg
 /// Guards for `init_pool_treasury_vault`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn init_pool_treasury_vault<'info>(ctx: &mut InitPoolTreasuryVault<'info>, args: InitPoolTreasuryVaultArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.pool_treasury_vault.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -150,11 +128,6 @@ pub fn init_pool_treasury_vault<'info>(ctx: &mut InitPoolTreasuryVault<'info>, a
 /// Guards for `init_pool_oracle_fee_vault`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn init_pool_oracle_fee_vault<'info>(ctx: &mut InitPoolOracleFeeVault<'info>, args: InitPoolOracleFeeVaultArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.pool_oracle_fee_vault.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -163,11 +136,6 @@ pub fn init_pool_oracle_fee_vault<'info>(ctx: &mut InitPoolOracleFeeVault<'info>
 /// Guards for `create_health_plan`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_health_plan<'info>(ctx: &mut CreateHealthPlan<'info>, args: CreateHealthPlanArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.health_plan.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -176,11 +144,6 @@ pub fn create_health_plan<'info>(ctx: &mut CreateHealthPlan<'info>, args: Create
 /// Guards for `update_health_plan_controls`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_health_plan_controls<'info>(ctx: &mut UpdateHealthPlanControls<'info>, args: UpdateHealthPlanControlsArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.health_plan.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -189,11 +152,6 @@ pub fn update_health_plan_controls<'info>(ctx: &mut UpdateHealthPlanControls<'in
 /// Guards for `create_policy_series`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_policy_series<'info>(ctx: &mut CreatePolicySeries<'info>, args: CreatePolicySeriesArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -201,11 +159,6 @@ pub fn create_policy_series<'info>(ctx: &mut CreatePolicySeries<'info>, args: Cr
 /// Guards for `initialize_series_reserve_ledger`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn initialize_series_reserve_ledger<'info>(ctx: &mut InitializeSeriesReserveLedger<'info>, args: InitializeSeriesReserveLedgerArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.series_reserve_ledger.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -214,11 +167,6 @@ pub fn initialize_series_reserve_ledger<'info>(ctx: &mut InitializeSeriesReserve
 /// Guards for `version_policy_series`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn version_policy_series<'info>(ctx: &mut VersionPolicySeries<'info>, args: VersionPolicySeriesArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -226,11 +174,6 @@ pub fn version_policy_series<'info>(ctx: &mut VersionPolicySeries<'info>, args: 
 /// Guards for `open_member_position`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn open_member_position<'info>(ctx: &mut OpenMemberPosition<'info>, args: OpenMemberPositionArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -238,11 +181,6 @@ pub fn open_member_position<'info>(ctx: &mut OpenMemberPosition<'info>, args: Op
 /// Guards for `update_member_eligibility`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_member_eligibility<'info>(ctx: &mut UpdateMemberEligibility<'info>, args: UpdateMemberEligibilityArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.member_position.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -251,11 +189,6 @@ pub fn update_member_eligibility<'info>(ctx: &mut UpdateMemberEligibility<'info>
 /// Guards for `open_funding_line`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn open_funding_line<'info>(ctx: &mut OpenFundingLine<'info>, args: OpenFundingLineArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -263,11 +196,7 @@ pub fn open_funding_line<'info>(ctx: &mut OpenFundingLine<'info>, args: OpenFund
 /// Guards for `fund_sponsor_budget`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn fund_sponsor_budget<'info>(ctx: &mut FundSponsorBudget<'info>, args: FundSponsorBudgetArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -278,11 +207,7 @@ pub fn fund_sponsor_budget<'info>(ctx: &mut FundSponsorBudget<'info>, args: Fund
 /// Guards for `record_premium_payment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn record_premium_payment<'info>(ctx: &mut RecordPremiumPayment<'info>, args: RecordPremiumPaymentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -293,11 +218,7 @@ pub fn record_premium_payment<'info>(ctx: &mut RecordPremiumPayment<'info>, args
 /// Guards for `create_commitment_campaign`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_commitment_campaign<'info>(ctx: &mut CreateCommitmentCampaign<'info>, args: CreateCommitmentCampaignArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.deposit_amount > 0
@@ -310,11 +231,7 @@ pub fn create_commitment_campaign<'info>(ctx: &mut CreateCommitmentCampaign<'inf
 /// Guards for `create_commitment_payment_rail`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_commitment_payment_rail<'info>(ctx: &mut CreateCommitmentPaymentRail<'info>, args: CreateCommitmentPaymentRailArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.deposit_amount > 0
@@ -327,11 +244,7 @@ pub fn create_commitment_payment_rail<'info>(ctx: &mut CreateCommitmentPaymentRa
 /// Guards for `deposit_commitment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn deposit_commitment<'info>(ctx: &mut DepositCommitment<'info>, args: DepositCommitmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     Ok(())
@@ -340,11 +253,7 @@ pub fn deposit_commitment<'info>(ctx: &mut DepositCommitment<'info>, args: Depos
 /// Guards for `activate_direct_premium_commitment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn activate_direct_premium_commitment<'info>(ctx: &mut ActivateDirectPremiumCommitment<'info>, args: ActivateCommitmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     Ok(())
@@ -353,11 +262,7 @@ pub fn activate_direct_premium_commitment<'info>(ctx: &mut ActivateDirectPremium
 /// Guards for `activate_treasury_credit_commitment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn activate_treasury_credit_commitment<'info>(ctx: &mut ActivateTreasuryCreditCommitment<'info>, args: ActivateCommitmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     Ok(())
@@ -366,11 +271,7 @@ pub fn activate_treasury_credit_commitment<'info>(ctx: &mut ActivateTreasuryCred
 /// Guards for `activate_waterfall_commitment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn activate_waterfall_commitment<'info>(ctx: &mut ActivateWaterfallCommitment<'info>, args: ActivateCommitmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     Ok(())
@@ -379,11 +280,6 @@ pub fn activate_waterfall_commitment<'info>(ctx: &mut ActivateWaterfallCommitmen
 /// Guards for `refund_commitment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn refund_commitment<'info>(ctx: &mut RefundCommitment<'info>, args: RefundCommitmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -391,11 +287,7 @@ pub fn refund_commitment<'info>(ctx: &mut RefundCommitment<'info>, args: RefundC
 /// Guards for `pause_commitment_campaign`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn pause_commitment_campaign<'info>(ctx: &mut PauseCommitmentCampaign<'info>, args: PauseCommitmentCampaignArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.campaign.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -406,11 +298,7 @@ pub fn pause_commitment_campaign<'info>(ctx: &mut PauseCommitmentCampaign<'info>
 /// Guards for `create_obligation`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_obligation<'info>(ctx: &mut CreateObligation<'info>, args: CreateObligationArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -421,11 +309,7 @@ pub fn create_obligation<'info>(ctx: &mut CreateObligation<'info>, args: CreateO
 /// Guards for `reserve_obligation`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn reserve_obligation<'info>(ctx: &mut ReserveObligation<'info>, args: ReserveObligationArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -436,11 +320,7 @@ pub fn reserve_obligation<'info>(ctx: &mut ReserveObligation<'info>, args: Reser
 /// Guards for `settle_obligation`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn settle_obligation<'info>(ctx: &mut SettleObligation<'info>, args: SettleObligationArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -451,11 +331,7 @@ pub fn settle_obligation<'info>(ctx: &mut SettleObligation<'info>, args: SettleO
 /// Guards for `release_reserve`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn release_reserve<'info>(ctx: &mut ReleaseReserve<'info>, args: ReleaseReserveArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -466,11 +342,7 @@ pub fn release_reserve<'info>(ctx: &mut ReleaseReserve<'info>, args: ReleaseRese
 /// Guards for `open_claim_case`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn open_claim_case<'info>(ctx: &mut OpenClaimCase<'info>, args: OpenClaimCaseArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.claim_case.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -481,11 +353,7 @@ pub fn open_claim_case<'info>(ctx: &mut OpenClaimCase<'info>, args: OpenClaimCas
 /// Guards for `authorize_claim_recipient`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn authorize_claim_recipient<'info>(ctx: &mut AuthorizeClaimRecipient<'info>, args: AuthorizeClaimRecipientArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.claim_case.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -496,11 +364,7 @@ pub fn authorize_claim_recipient<'info>(ctx: &mut AuthorizeClaimRecipient<'info>
 /// Guards for `attach_claim_evidence_ref`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn attach_claim_evidence_ref<'info>(ctx: &mut AttachClaimEvidenceRef<'info>, args: AttachClaimEvidenceRefArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // lifecycle: require status == Live
     if ctx.claim_case.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: emergency_pause = false
@@ -511,11 +375,8 @@ pub fn attach_claim_evidence_ref<'info>(ctx: &mut AttachClaimEvidenceRef<'info>,
 /// Guards for `adjudicate_claim_case`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn adjudicate_claim_case<'info>(ctx: &mut AdjudicateClaimCase<'info>, args: AdjudicateClaimCaseArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
+    let approved_amount = account_approved_amount(&ctx.claim_case)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.reserve_amount ≤ args.approved_amount
@@ -526,11 +387,9 @@ pub fn adjudicate_claim_case<'info>(ctx: &mut AdjudicateClaimCase<'info>, args: 
 /// Guards for `settle_claim_case`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn settle_claim_case<'info>(ctx: &mut SettleClaimCase<'info>, args: SettleClaimCaseArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
+    let paid_amount = account_paid_amount(&ctx.claim_case)?;
+    let approved_amount = account_approved_amount(&ctx.claim_case)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -543,11 +402,9 @@ pub fn settle_claim_case<'info>(ctx: &mut SettleClaimCase<'info>, args: SettleCl
 /// Guards for `settle_claim_case_selected_asset`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn settle_claim_case_selected_asset<'info>(ctx: &mut SettleClaimCaseSelectedAsset<'info>, args: SettleClaimCaseSelectedAssetArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
+    let paid_amount = account_paid_amount(&ctx.claim_case)?;
+    let approved_amount = account_approved_amount(&ctx.claim_case)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.claim_credit_amount > 0
@@ -564,11 +421,6 @@ pub fn settle_claim_case_selected_asset<'info>(ctx: &mut SettleClaimCaseSelected
 /// Guards for `create_liquidity_pool`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_liquidity_pool<'info>(ctx: &mut CreateLiquidityPool<'info>, args: CreateLiquidityPoolArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.liquidity_pool.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: args.fee_bps ≤ 9999
@@ -579,11 +431,6 @@ pub fn create_liquidity_pool<'info>(ctx: &mut CreateLiquidityPool<'info>, args: 
 /// Guards for `create_capital_class`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_capital_class<'info>(ctx: &mut CreateCapitalClass<'info>, args: CreateCapitalClassArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // requires: args.fee_bps ≤ 9999
     if !(args.fee_bps <= 9999) { return Err(OmegaxProtocolError::InvalidBps.into()); }
     Ok(())
@@ -592,11 +439,6 @@ pub fn create_capital_class<'info>(ctx: &mut CreateCapitalClass<'info>, args: Cr
 /// Guards for `update_capital_class_controls`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_capital_class_controls<'info>(ctx: &mut UpdateCapitalClassControls<'info>, args: UpdateCapitalClassControlsArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.capital_class.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -605,11 +447,6 @@ pub fn update_capital_class_controls<'info>(ctx: &mut UpdateCapitalClassControls
 /// Guards for `update_lp_position_credentialing`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_lp_position_credentialing<'info>(ctx: &mut UpdateLpPositionCredentialing<'info>, args: UpdateLpPositionCredentialingArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.lp_position.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -618,11 +455,7 @@ pub fn update_lp_position_credentialing<'info>(ctx: &mut UpdateLpPositionCredent
 /// Guards for `deposit_into_capital_class`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn deposit_into_capital_class<'info>(ctx: &mut DepositIntoCapitalClass<'info>, args: DepositIntoCapitalClassArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -633,11 +466,7 @@ pub fn deposit_into_capital_class<'info>(ctx: &mut DepositIntoCapitalClass<'info
 /// Guards for `request_redemption`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn request_redemption<'info>(ctx: &mut RequestRedemption<'info>, args: RequestRedemptionArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.shares > 0
@@ -648,11 +477,7 @@ pub fn request_redemption<'info>(ctx: &mut RequestRedemption<'info>, args: Reque
 /// Guards for `process_redemption_queue`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn process_redemption_queue<'info>(ctx: &mut ProcessRedemptionQueue<'info>, args: ProcessRedemptionQueueArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.shares > 0
@@ -663,11 +488,8 @@ pub fn process_redemption_queue<'info>(ctx: &mut ProcessRedemptionQueue<'info>, 
 /// Guards for `withdraw_protocol_fee_spl`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_protocol_fee_spl<'info>(ctx: &mut WithdrawProtocolFeeSpl<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.protocol_fee_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.protocol_fee_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -678,11 +500,8 @@ pub fn withdraw_protocol_fee_spl<'info>(ctx: &mut WithdrawProtocolFeeSpl<'info>,
 /// Guards for `withdraw_protocol_fee_sol`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_protocol_fee_sol<'info>(ctx: &mut WithdrawProtocolFeeSol<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.protocol_fee_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.protocol_fee_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -693,11 +512,8 @@ pub fn withdraw_protocol_fee_sol<'info>(ctx: &mut WithdrawProtocolFeeSol<'info>,
 /// Guards for `withdraw_pool_treasury_spl`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_pool_treasury_spl<'info>(ctx: &mut WithdrawPoolTreasurySpl<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.pool_treasury_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.pool_treasury_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -708,11 +524,8 @@ pub fn withdraw_pool_treasury_spl<'info>(ctx: &mut WithdrawPoolTreasurySpl<'info
 /// Guards for `withdraw_pool_treasury_sol`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_pool_treasury_sol<'info>(ctx: &mut WithdrawPoolTreasurySol<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.pool_treasury_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.pool_treasury_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -723,11 +536,8 @@ pub fn withdraw_pool_treasury_sol<'info>(ctx: &mut WithdrawPoolTreasurySol<'info
 /// Guards for `withdraw_pool_oracle_fee_spl`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_pool_oracle_fee_spl<'info>(ctx: &mut WithdrawPoolOracleFeeSpl<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.pool_oracle_fee_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.pool_oracle_fee_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -738,11 +548,8 @@ pub fn withdraw_pool_oracle_fee_spl<'info>(ctx: &mut WithdrawPoolOracleFeeSpl<'i
 /// Guards for `withdraw_pool_oracle_fee_sol`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn withdraw_pool_oracle_fee_sol<'info>(ctx: &mut WithdrawPoolOracleFeeSol<'info>, args: WithdrawArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let withdrawn_fees = account_withdrawn_fees(&ctx.pool_oracle_fee_vault)?;
+    let accrued_fees = account_accrued_fees(&ctx.pool_oracle_fee_vault)?;
     // requires: args.amount > 0
     if !(args.amount > 0) { return Err(OmegaxProtocolError::AmountMustBePositive.into()); }
     // requires: withdrawn_fees + args.amount ≤ accrued_fees
@@ -753,11 +560,6 @@ pub fn withdraw_pool_oracle_fee_sol<'info>(ctx: &mut WithdrawPoolOracleFeeSol<'i
 /// Guards for `create_allocation_position`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn create_allocation_position<'info>(ctx: &mut CreateAllocationPosition<'info>, args: CreateAllocationPositionArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -765,11 +567,6 @@ pub fn create_allocation_position<'info>(ctx: &mut CreateAllocationPosition<'inf
 /// Guards for `update_allocation_caps`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_allocation_caps<'info>(ctx: &mut UpdateAllocationCaps<'info>, args: UpdateAllocationCapsArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.allocation_position.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -778,11 +575,7 @@ pub fn update_allocation_caps<'info>(ctx: &mut UpdateAllocationCaps<'info>, args
 /// Guards for `allocate_capital`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn allocate_capital<'info>(ctx: &mut AllocateCapital<'info>, args: AllocateCapitalArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -793,11 +586,7 @@ pub fn allocate_capital<'info>(ctx: &mut AllocateCapital<'info>, args: AllocateC
 /// Guards for `deallocate_capital`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn deallocate_capital<'info>(ctx: &mut DeallocateCapital<'info>, args: DeallocateCapitalArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -808,11 +597,7 @@ pub fn deallocate_capital<'info>(ctx: &mut DeallocateCapital<'info>, args: Deall
 /// Guards for `mark_impairment`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn mark_impairment<'info>(ctx: &mut MarkImpairment<'info>, args: MarkImpairmentArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
+    let emergency_pause = account_emergency_pause(&ctx.protocol_governance)?;
     // requires: emergency_pause = false
     if !(emergency_pause == false) { return Err(OmegaxProtocolError::ProtocolEmergencyPaused.into()); }
     // requires: args.amount > 0
@@ -823,11 +608,6 @@ pub fn mark_impairment<'info>(ctx: &mut MarkImpairment<'info>, args: MarkImpairm
 /// Guards for `register_oracle`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn register_oracle<'info>(ctx: &mut RegisterOracle<'info>, args: RegisterOracleArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.oracle_profile.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -836,11 +616,6 @@ pub fn register_oracle<'info>(ctx: &mut RegisterOracle<'info>, args: RegisterOra
 /// Guards for `claim_oracle`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn claim_oracle<'info>(ctx: &mut ClaimOracle<'info>) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.oracle_profile.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -849,11 +624,6 @@ pub fn claim_oracle<'info>(ctx: &mut ClaimOracle<'info>) -> Result<()> {
 /// Guards for `update_oracle_profile`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn update_oracle_profile<'info>(ctx: &mut UpdateOracleProfile<'info>, args: UpdateOracleProfileArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.oracle_profile.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -862,11 +632,6 @@ pub fn update_oracle_profile<'info>(ctx: &mut UpdateOracleProfile<'info>, args: 
 /// Guards for `set_pool_oracle`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn set_pool_oracle<'info>(ctx: &mut SetPoolOracle<'info>, args: SetPoolOracleArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.pool_oracle_approval.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -875,11 +640,6 @@ pub fn set_pool_oracle<'info>(ctx: &mut SetPoolOracle<'info>, args: SetPoolOracl
 /// Guards for `set_pool_oracle_permissions`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn set_pool_oracle_permissions<'info>(ctx: &mut SetPoolOraclePermissions<'info>, args: SetPoolOraclePermissionsArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.pool_oracle_permission_set.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -888,11 +648,6 @@ pub fn set_pool_oracle_permissions<'info>(ctx: &mut SetPoolOraclePermissions<'in
 /// Guards for `set_pool_oracle_policy`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn set_pool_oracle_policy<'info>(ctx: &mut SetPoolOraclePolicy<'info>, args: SetPoolOraclePolicyArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.pool_oracle_policy.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     // requires: args.oracle_fee_bps ≤ 9999
@@ -903,11 +658,6 @@ pub fn set_pool_oracle_policy<'info>(ctx: &mut SetPoolOraclePolicy<'info>, args:
 /// Guards for `register_outcome_schema`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn register_outcome_schema<'info>(ctx: &mut RegisterOutcomeSchema<'info>, args: RegisterOutcomeSchemaArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -915,11 +665,6 @@ pub fn register_outcome_schema<'info>(ctx: &mut RegisterOutcomeSchema<'info>, ar
 /// Guards for `verify_outcome_schema`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn verify_outcome_schema<'info>(ctx: &mut VerifyOutcomeSchema<'info>, args: VerifyOutcomeSchemaArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.outcome_schema.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -928,11 +673,6 @@ pub fn verify_outcome_schema<'info>(ctx: &mut VerifyOutcomeSchema<'info>, args: 
 /// Guards for `backfill_schema_dependency_ledger`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn backfill_schema_dependency_ledger<'info>(ctx: &mut BackfillSchemaDependencyLedger<'info>, args: BackfillSchemaDependencyLedgerArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // lifecycle: require status == Live
     if ctx.schema_dependency_ledger.status != Status::Live as u8 { return Err(crate::errors::OmegaxProtocolError::InvalidLifecycle.into()); }
     Ok(())
@@ -941,11 +681,6 @@ pub fn backfill_schema_dependency_ledger<'info>(ctx: &mut BackfillSchemaDependen
 /// Guards for `close_outcome_schema`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn close_outcome_schema<'info>(ctx: &mut CloseOutcomeSchema<'info>) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }
@@ -953,11 +688,6 @@ pub fn close_outcome_schema<'info>(ctx: &mut CloseOutcomeSchema<'info>) -> Resul
 /// Guards for `attest_claim_case`.
 /// Generated from the `requires` clauses of the spec handler block.
 pub fn attest_claim_case<'info>(ctx: &mut AttestClaimCase<'info>, args: AttestClaimCaseArgs) -> Result<()> {
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
     // No guards declared in spec — nothing to check.
     Ok(())
 }

--- a/scripts/run_qedgen.mjs
+++ b/scripts/run_qedgen.mjs
@@ -328,6 +328,125 @@ function prefixStateFields(line, stateFields) {
   return line.replace(pattern, 's.$1');
 }
 
+const MODEL_STATE_HELPERS = `
+fn read_model_account(account_info: &AccountInfo) -> Result<OmegaxProtocolAccount> {
+    let data = account_info.try_borrow_data()?;
+    OmegaxProtocolAccount::try_deserialize(&mut data.as_ref())
+}
+
+fn account_emergency_pause(account_info: &AccountInfo) -> Result<bool> {
+    Ok(read_model_account(account_info)?.emergency_pause)
+}
+
+fn account_paid_amount(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.paid_amount)
+}
+
+fn account_approved_amount(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.approved_amount)
+}
+
+fn account_withdrawn_fees(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.withdrawn_fees)
+}
+
+fn account_accrued_fees(account_info: &AccountInfo) -> Result<u64> {
+    Ok(read_model_account(account_info)?.accrued_fees)
+}
+`;
+
+function parseContextFields() {
+  const libPath = `${MODEL_DIR}/src/lib.rs`;
+  if (!existsSync(libPath)) {
+    return new Map();
+  }
+
+  const lib = readFileSync(libPath, 'utf8');
+  const contexts = new Map();
+  for (const match of lib.matchAll(/pub struct (\w+)<'info> \{([\s\S]*?)\n\}/g)) {
+    contexts.set(
+      match[1],
+      [...match[2].matchAll(/pub (\w+):/g)].map((field) => field[1]),
+    );
+  }
+  return contexts;
+}
+
+function firstExistingField(fields, candidates) {
+  return candidates.find((candidate) => fields.includes(candidate));
+}
+
+function guardStatePrelude(ctxType, body, contexts) {
+  const fields = contexts.get(ctxType) ?? [];
+  const lines = [];
+  if (/\bemergency_pause\b/.test(body)) {
+    const source = firstExistingField(fields, ['protocol_governance']);
+    if (source) {
+      lines.push(`    let emergency_pause = account_emergency_pause(&ctx.${source})?;`);
+    }
+  }
+  if (/\bpaid_amount\b/.test(body)) {
+    const source = firstExistingField(fields, ['claim_case']);
+    if (source) {
+      lines.push(`    let paid_amount = account_paid_amount(&ctx.${source})?;`);
+    }
+  }
+  if (/\bapproved_amount\b/.test(body)) {
+    const source = firstExistingField(fields, ['claim_case']);
+    if (source) {
+      lines.push(`    let approved_amount = account_approved_amount(&ctx.${source})?;`);
+    }
+  }
+  if (/\bwithdrawn_fees\b/.test(body)) {
+    const source = firstExistingField(fields, [
+      'protocol_fee_vault',
+      'pool_treasury_vault',
+      'pool_oracle_fee_vault',
+    ]);
+    if (source) {
+      lines.push(`    let withdrawn_fees = account_withdrawn_fees(&ctx.${source})?;`);
+    }
+  }
+  if (/\baccrued_fees\b/.test(body)) {
+    const source = firstExistingField(fields, [
+      'protocol_fee_vault',
+      'pool_treasury_vault',
+      'pool_oracle_fee_vault',
+    ]);
+    if (source) {
+      lines.push(`    let accrued_fees = account_accrued_fees(&ctx.${source})?;`);
+    }
+  }
+
+  return lines.length === 0 ? '' : `${lines.join('\n')}\n`;
+}
+
+function postprocessGuards(guards) {
+  let text = guards.replace(
+    /\n    let emergency_pause[^\n]*;\n    let paid_amount[^\n]*;\n    let approved_amount[^\n]*;\n    let withdrawn_fees[^\n]*;\n    let accrued_fees[^\n]*;\n/g,
+    '\n',
+  );
+  if (!text.includes('fn read_model_account(')) {
+    text = text.replace('use crate::*;\n', `use crate::*;\n${MODEL_STATE_HELPERS}\n`);
+  }
+
+  const contexts = parseContextFields();
+  text = text.replace(
+    /(pub fn \w+<'info>\(ctx: &mut (\w+)<'info>, args: \w+\) -> Result<\(\)> \{)\n([\s\S]*?)(?=\n\}\n(?:\n\/\/\/ Guards for|$))/g,
+    (_match, header, ctxType, body) => {
+      const withoutExistingPrelude = body
+        .replace(/    let emergency_pause = account_emergency_pause\(&ctx\.\w+\)\?;\n/g, '')
+        .replace(/    let paid_amount = account_paid_amount\(&ctx\.\w+\)\?;\n/g, '')
+        .replace(/    let approved_amount = account_approved_amount\(&ctx\.\w+\)\?;\n/g, '')
+        .replace(/    let withdrawn_fees = account_withdrawn_fees\(&ctx\.\w+\)\?;\n/g, '')
+        .replace(/    let accrued_fees = account_accrued_fees\(&ctx\.\w+\)\?;\n/g, '');
+      return `${header}\n${guardStatePrelude(ctxType, withoutExistingPrelude, contexts)}${withoutExistingPrelude}`;
+    },
+  );
+
+  return text.replace(/[ \t]+$/gm, '');
+}
+
 function dedupeFunctions(text) {
   const seen = new Set();
   return text.replace(
@@ -657,15 +776,7 @@ function postprocessRustModel() {
 
   const guardsPath = `${MODEL_DIR}/src/guards.rs`;
   if (existsSync(guardsPath)) {
-    let guards = readFileSync(guardsPath, 'utf8');
-    guards = guards.replace(/(pub fn \w+<'info>\([^{]+ \{)\n/g, `$1
-    let emergency_pause = false;
-    let paid_amount: u64 = 0;
-    let approved_amount: u64 = u64::MAX;
-    let withdrawn_fees: u64 = 0;
-    let accrued_fees: u64 = u64::MAX;
-`);
-    guards = guards.replace(/[ \t]+$/gm, '');
+    const guards = postprocessGuards(readFileSync(guardsPath, 'utf8'));
     writeFileSync(guardsPath, guards);
   }
 


### PR DESCRIPTION
### Motivation
- QEDGen postprocessing previously injected hard-coded placeholder state (e.g. `emergency_pause = false`, `paid_amount = 0`, `accrued_fees = u64::MAX`) into every generated guard, which made formal guards vacuous or syntactically broken and detached them from the modeled account state.
- The postprocessor also applied a blunt field-prefix rewrite that produced invalid proptest code such as `s.protocol_fee_bps` in contexts that had no `s` variable.

### Description
- Reworked the QEDGen Rust postprocessor in `scripts/run_qedgen.mjs` to remove blanket constant stubs and instead inject small account-reading helpers plus context-aware preludes that read required modeled fields from the generated Anchor `ctx` accounts (e.g. use `account_emergency_pause(&ctx.protocol_governance)?`, `account_paid_amount(&ctx.claim_case)?`).
- Added `MODEL_STATE_HELPERS` helper functions for deserializing the generated `OmegaxProtocolAccount` and extracting `emergency_pause`, `paid_amount`, `approved_amount`, `withdrawn_fees`, and `accrued_fees` where required by a guard.
- Updated the guard postprocessing to introspect the generated `lib.rs` `#[derive(Accounts)]` context structs and only insert the appropriate account reads for guards that reference those fields, preserving spec intent and avoiding invalid rewrites.
- Regenerated/updated the checked-in model harness so guards in `formal_verification/anchor_model/src/guards.rs` now read modeled account state for pause, claim-payment bounds, and fee-withdrawal bounds instead of using hard-coded constants.

### Testing
- Ran a syntax check on the postprocessor with `node -c scripts/run_qedgen.mjs`, which succeeded.
- Ran the generated-model unit/test harness with `cargo test --manifest-path formal_verification/anchor_model/Cargo.toml --tests`, and the test run completed with the unit and proptest harness tests passing (all expected tests reported `ok`).
- Verified repository check output with `git diff --check` to ensure no leftover whitespace errors or parse-time diffs were introduced, which returned clean.
- Attempted `npm run qedgen:codegen` in this environment but it could not be executed because the QEDGen executable is not available here (the postprocessor changes are implemented and the checked-in guard artifact was updated, but full local QEDGen execution requires an installed `QEDGEN` tool).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7ae7c084832f91d6384eac21d9e0)