### PR TITLE
fix(formal): verify selected asset payout guard

### DIFF
--- a/programs/omegax_protocol/src/certora.rs
+++ b/programs/omegax_protocol/src/certora.rs
@@ -5,14 +5,15 @@
 use cvlr::prelude::*;
 
 use crate::constants::{BASIS_POINTS_DENOMINATOR, MAX_SELECTED_ASSET_PAYOUT_OVERPAY_BPS};
+use crate::reserve_waterfall::require_selected_asset_payout_value_bounds;
 
-const CERTORA_SCALE_1E6: u64 = 1_000_000;
+const CERTORA_SCALE_1E6: u128 = 1_000_000;
 const CERTORA_MAX_AMOUNT: u64 = 1_000_000_000;
 const CERTORA_MAX_PRICE_1E8: u64 = 1_000_000;
 const CERTORA_MAX_BALANCE_COMPONENT: u64 = 1_000_000_000_000;
 
-fn certora_value_1e8(amount: u64, price_1e8: u64) -> u64 {
-    (amount * price_1e8) / CERTORA_SCALE_1E6
+fn certora_value_1e8(amount: u64, price_1e8: u64) -> u128 {
+    ((amount as u128) * (price_1e8 as u128)) / CERTORA_SCALE_1E6
 }
 
 #[rule]
@@ -35,17 +36,19 @@ pub fn rule_selected_asset_payout_bounds() {
 
     let claim_value = certora_value_1e8(claim_credit_amount, claim_price_1e8);
     let payout_value = certora_value_1e8(payout_amount, payout_price_1e8);
-    let max_value = (claim_value * ((BASIS_POINTS_DENOMINATOR as u64) + (max_overpay_bps as u64)))
-        / (BASIS_POINTS_DENOMINATOR as u64);
+    let result =
+        require_selected_asset_payout_value_bounds(claim_value, payout_value, max_overpay_bps);
 
-    let accepted = payout_value >= claim_value && payout_value <= max_value;
+    if result.is_ok() {
+        let max_value = (claim_value
+            * ((BASIS_POINTS_DENOMINATOR as u128) + (max_overpay_bps as u128)))
+            / (BASIS_POINTS_DENOMINATOR as u128);
 
-    if accepted {
         cvlr_assert!(payout_value >= claim_value);
         cvlr_assert!(payout_value <= max_value);
     }
 
-    cvlr_satisfy!(accepted);
+    cvlr_satisfy!(result.is_ok());
 }
 
 #[rule]


### PR DESCRIPTION
### Motivation
- The Certora sanity rule for selected-asset payout bounds was computing a local `accepted` predicate rather than exercising the production guard, weakening the formal check.
- The rule must exercise the same runtime function and arithmetic width used on-chain so Certora proves the real implementation, not a duplicated local predicate.

### Description
- Reconnected the Certora rule to the runtime guard by importing and calling `require_selected_asset_payout_value_bounds` from `reserve_waterfall` and using its `Result` to drive the formal assertions.
- Aligned formal arithmetic width by changing `CERTORA_SCALE_1E6` to `u128` and making `certora_value_1e8` return `u128` with proper casts.
- Kept the postcondition assertions (`payout_value >= claim_value` and `payout_value <= max_value`) but now gate them on `result.is_ok()` and satisfy on `result.is_ok()` so the rule directly exercises the production logic.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo test -p omegax_protocol selected_asset_payout_value_bounds_are_enforced` and the unit test passed (`1 passed; 0 failed`).
- Ran `cargo check -p omegax_protocol --features certora` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7ae8815c832f8c84f24109eae5c2)