### PR TITLE
fix(frontend): fail closed Phase 0 custom RPC gates

### DIFF
--- a/frontend/components/capital-workbench.tsx
+++ b/frontend/components/capital-workbench.tsx
@@ -209,11 +209,11 @@ export function CapitalWorkbench({ searchParams = {} }: CapitalWorkbenchProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { effectivePersona } = useWorkspacePersona();
-  const { selectedNetwork } = useNetworkContext();
+  const { selectedNetwork, executionClusterVerified } = useNetworkContext();
   const { snapshot, loading, error, refresh } = useProtocolConsoleSnapshot();
   const phase0Profile = useMemo(
-    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
-    [selectedNetwork],
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork, executionClusterVerified }),
+    [executionClusterVerified, selectedNetwork],
   );
   const consoleState = useMemo(() => buildCanonicalConsoleStateFromSnapshot(snapshot), [snapshot]);
   const wallet = useWallet();

--- a/frontend/components/network-context.tsx
+++ b/frontend/components/network-context.tsx
@@ -27,6 +27,7 @@ export type NetworkContextValue = {
   canSelectRpcProfile: (profile: RpcProfile, network?: NetworkMode) => boolean;
   rpcProfileOptions: RpcProfileOption[];
   resolvedEndpoint: string;
+  executionClusterVerified: boolean;
   customRpcUrl: string;
   applyCustomRpcUrl: (value: string) => { ok: true } | { ok: false; error: string };
   resetConnectionSettings: () => void;
@@ -144,6 +145,10 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
     }));
   }
 
+  // Custom RPC URLs are syntactically validated, but this console does not verify
+  // their Solana genesis hash/cluster. Keep Phase 0 write gates fail-closed on them.
+  const executionClusterVerified = resolvedConnection.rpcProfile !== "custom";
+
   const value = useMemo(
     () => ({
       selectedNetwork,
@@ -155,6 +160,7 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
       canSelectRpcProfile,
       rpcProfileOptions,
       resolvedEndpoint: resolvedConnection.endpoint,
+      executionClusterVerified,
       customRpcUrl: customRpcEndpoints[selectedNetwork],
       applyCustomRpcUrl,
       resetConnectionSettings,
@@ -163,6 +169,7 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
       customRpcEndpoints,
       resolvedConnection.endpoint,
       resolvedConnection.rpcProfile,
+      executionClusterVerified,
       rpcProfileOptions,
       selectedNetwork,
       selectedRpcProfile,

--- a/frontend/components/plan-creation-wizard.tsx
+++ b/frontend/components/plan-creation-wizard.tsx
@@ -383,12 +383,12 @@ export function PlanCreationWizard() {
   const searchParams = useSearchParams();
   const { connection } = useConnection();
   const { connected, publicKey, sendTransaction } = useWallet();
-  const { selectedNetwork } = useNetworkContext();
+  const { selectedNetwork, executionClusterVerified } = useNetworkContext();
   const { snapshot } = useProtocolConsoleSnapshot();
   const genesisTemplateMode = isGenesisProtectAcuteTemplate(searchParams.get("template"));
   const phase0Profile = useMemo(
-    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
-    [selectedNetwork],
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork, executionClusterVerified }),
+    [executionClusterVerified, selectedNetwork],
   );
   const rewardLaunchEnabled = isGenesisPhase0SurfaceActionable(phase0Profile, "rewardLaunch");
   const hybridLaunchEnabled = isGenesisPhase0SurfaceActionable(phase0Profile, "hybridLaunch");

--- a/frontend/components/plans-workbench.tsx
+++ b/frontend/components/plans-workbench.tsx
@@ -332,11 +332,11 @@ export function PlansWorkbench({ searchParams = {} }: PlansWorkbenchProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { effectivePersona } = useWorkspacePersona();
-  const { selectedNetwork } = useNetworkContext();
+  const { selectedNetwork, executionClusterVerified } = useNetworkContext();
   const { snapshot, loading, error, refresh, lastUpdatedAt, hasCurrentSnapshot } = useProtocolConsoleSnapshot();
   const phase0Profile = useMemo(
-    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork }),
-    [selectedNetwork],
+    () => resolveGenesisPhase0LaunchProfile({ network: selectedNetwork, executionClusterVerified }),
+    [executionClusterVerified, selectedNetwork],
   );
   const consoleState = useMemo(() => buildCanonicalConsoleStateFromSnapshot(snapshot), [snapshot]);
   const routeMode: PlansRouteMode = pathname === "/claims" ? "claims" : "plans";

--- a/frontend/lib/genesis-phase0-launch-profile.ts
+++ b/frontend/lib/genesis-phase0-launch-profile.ts
@@ -108,12 +108,14 @@ function hiddenLabels(profile: Omit<
 export function resolveGenesisPhase0LaunchProfile(params: {
   network?: NetworkMode | string | null;
   env?: EnvLike;
+  executionClusterVerified?: boolean;
 } = {}): GenesisPhase0LaunchProfile {
   const env = params.env ?? GENESIS_PHASE0_CLIENT_ENV;
   const network = normalizeNetwork(params.network);
+  const executionClusterVerified = params.executionClusterVerified ?? true;
   const mainnet = network === "mainnet-beta";
-  const capitalAdminActions = adminSurfaceState({ env, mainnet });
-  const policyAdminActions = adminSurfaceState({ env, mainnet });
+  const capitalAdminActions = executionClusterVerified ? adminSurfaceState({ env, mainnet }) : "hidden";
+  const policyAdminActions = executionClusterVerified ? adminSurfaceState({ env, mainnet }) : "hidden";
   const base = {
     id: "genesis-phase0" as const,
     network,
@@ -128,10 +130,18 @@ export function resolveGenesisPhase0LaunchProfile(params: {
     oracleDashboard: "read_only" as const,
     commitmentsDashboard: "read_only" as const,
     operatorSettlementVisibility: "read_only" as const,
-    rewardLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_REWARD_FLAG, env, mainnet }),
-    rwaPolicyLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_RWA_FLAG, env, mainnet }),
-    hybridLaunch: productSurfaceState({ enabledFlag: GENESIS_PHASE0_HYBRID_FLAG, env, mainnet }),
-    daoFallback: productSurfaceState({ enabledFlag: GENESIS_PHASE0_DAO_FLAG, env, mainnet }),
+    rewardLaunch: executionClusterVerified
+      ? productSurfaceState({ enabledFlag: GENESIS_PHASE0_REWARD_FLAG, env, mainnet })
+      : "disabled_preview" as const,
+    rwaPolicyLaunch: executionClusterVerified
+      ? productSurfaceState({ enabledFlag: GENESIS_PHASE0_RWA_FLAG, env, mainnet })
+      : "disabled_preview" as const,
+    hybridLaunch: executionClusterVerified
+      ? productSurfaceState({ enabledFlag: GENESIS_PHASE0_HYBRID_FLAG, env, mainnet })
+      : "disabled_preview" as const,
+    daoFallback: executionClusterVerified
+      ? productSurfaceState({ enabledFlag: GENESIS_PHASE0_DAO_FLAG, env, mainnet })
+      : "disabled_preview" as const,
     capitalAdminActions,
     policyAdminActions,
     futureLaunchChoices: mainnet ? "disabled_preview" as const : "disabled_preview" as const,

--- a/tests/plan_launch_model.test.ts
+++ b/tests/plan_launch_model.test.ts
@@ -104,12 +104,38 @@ test("Genesis Phase 0 mainnet future surfaces require a second explicit allow fl
   assert.equal(allowed.hybridLaunch, "live");
 });
 
+test("Genesis Phase 0 launch profile fails closed when execution cluster is unverified", () => {
+  const profile = resolveGenesisPhase0LaunchProfile({
+    network: "devnet",
+    executionClusterVerified: false,
+    env: {
+      NEXT_PUBLIC_ENABLE_REWARD_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_RWA_POLICY: "1",
+      NEXT_PUBLIC_ENABLE_HYBRID_LAUNCH: "1",
+      NEXT_PUBLIC_ENABLE_PROTOCOL_OPERATOR_ACTIONS: "1",
+      NEXT_PUBLIC_ALLOW_MAINNET_FUTURE_SURFACES: "1",
+    },
+  });
+
+  assert.equal(profile.rewardLaunch, "disabled_preview");
+  assert.equal(profile.rwaPolicyLaunch, "disabled_preview");
+  assert.equal(profile.hybridLaunch, "disabled_preview");
+  assert.equal(profile.capitalAdminActions, "hidden");
+  assert.equal(profile.policyAdminActions, "hidden");
+  assert.equal(isGenesisPhase0SurfaceActionable(profile, "rewardLaunch"), false);
+});
+
 test("Phase 0 UI keeps public LP self-service separate from hidden admin drawers", () => {
   const capitalWorkbench = readFileSync("frontend/components/capital-workbench.tsx", "utf8");
+  const planCreationWizard = readFileSync("frontend/components/plan-creation-wizard.tsx", "utf8");
+  const plansWorkbench = readFileSync("frontend/components/plans-workbench.tsx", "utf8");
   const lpPanel = readFileSync("frontend/components/capital-lp-self-service-panel.tsx", "utf8");
 
   assert.match(capitalWorkbench, /CapitalLpSelfServicePanel/);
   assert.match(capitalWorkbench, /capitalAdminActions/);
+  assert.match(capitalWorkbench, /executionClusterVerified/);
+  assert.match(planCreationWizard, /executionClusterVerified/);
+  assert.match(plansWorkbench, /executionClusterVerified/);
   assert.match(lpPanel, /buildDepositIntoCapitalClassTx/);
   assert.match(lpPanel, /buildRequestRedemptionTx/);
   assert.doesNotMatch(lpPanel, /buildProcessRedemptionQueueTx/);


### PR DESCRIPTION
### Motivation
- The Phase 0 surface gating used only the UI `selectedNetwork` label so a Devnet label with a user-supplied custom RPC URL pointing at mainnet could enable preview/admin surfaces while transactions executed against mainnet. This diverges UI safety gates from the actual execution cluster. 
- The intent of the change is to prevent that cluster-label mismatch by failing Phase 0 write/preview gates closed when the console cannot verify the execution cluster for the configured RPC endpoint.

### Description
- Add an `executionClusterVerified` signal to `NetworkContext` and expose it via `useNetworkContext`, with custom RPC profiles treated as unverified (`executionClusterVerified = resolvedConnection.rpcProfile !== 'custom'`).
- Extend `resolveGenesisPhase0LaunchProfile` to accept `executionClusterVerified` and, when false, force product preview/future surfaces to `"disabled_preview"` and make admin surfaces `"hidden"`, so unverified clusters fail closed.
- Wire the verification signal into the UI by passing `executionClusterVerified` into `resolveGenesisPhase0LaunchProfile` where Phase 0 gating is used (`plan-creation-wizard`, `plans-workbench`, `capital-workbench`).
- Add a regression test in `tests/plan_launch_model.test.ts` asserting that an unverified execution cluster leaves product surfaces disabled and admin actions hidden, and update a UI test to assert the verification wiring exists.

### Testing
- Ran targeted unit tests: `node --import tsx --test tests/plan_launch_model.test.ts tests/network_connection_preferences.test.ts` and both passed (added regression test included). 
- Built the frontend: `npm run frontend:build` and the build completed successfully. 
- Verified repository hygiene: `git diff --check` and local changes committed with DCO sign-off. 
- Note: a full `npm run test:node` run was started but was interrupted after a long-running subprocess; the targeted tests and the frontend build for the changed code passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7aead6dc832f9ab77197441cbd86)