### PR TITLE
Add raw-account layout migrations for enlarged ProtocolGovernance, CapitalClass, and LPPosition

### DIFF
--- a/frontend/lib/generated/protocol-contract.js
+++ b/frontend/lib/generated/protocol-contract.js
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 5988efbe9e29ff7b6da5363223ed00a8085adf5278d766e03fad94f5318b940b
+// contract_sha256: e8e736a4834ba1ffe0ecb224f27539e693cd751f9df5830a1c2b6957b735a23d
 export const PROTOCOL_PROGRAM_ID = "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B";
 export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "accept_protocol_governance_authority": Uint8Array.from([202, 235, 28, 119, 167, 24, 81, 85]),
@@ -26,6 +26,9 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS = {
     "create_liquidity_pool": Uint8Array.from([175, 75, 181, 165, 224, 254, 6, 131]),
     "create_obligation": Uint8Array.from([216, 144, 172, 223, 19, 106, 220, 54]),
     "create_policy_series": Uint8Array.from([70, 162, 231, 218, 211, 136, 110, 176]),
+    "migrate_protocol_governance_layout": Uint8Array.from([142, 48, 202, 237, 234, 83, 239, 134]),
+    "migrate_capital_class_layout": Uint8Array.from([92, 167, 94, 232, 0, 194, 56, 209]),
+    "migrate_lp_position_layout": Uint8Array.from([113, 230, 184, 121, 86, 153, 219, 216]),
     "create_reserve_domain": Uint8Array.from([222, 2, 8, 218, 45, 157, 193, 246]),
     "deallocate_capital": Uint8Array.from([10, 97, 97, 189, 60, 170, 102, 29]),
     "deposit_commitment": Uint8Array.from([147, 105, 226, 224, 111, 39, 63, 78]),
@@ -143,6 +146,15 @@ export const PROTOCOL_INSTRUCTION_ARGS = {
     ],
     "create_policy_series": [
         { name: "args", type: {"defined":{"name":"CreatePolicySeriesArgs"}} },
+    ],
+    "migrate_protocol_governance_layout": [
+
+    ],
+    "migrate_capital_class_layout": [
+        { name: "args", type: {"defined":{"name":"MigrateCapitalClassLayoutArgs"}} },
+    ],
+    "migrate_lp_position_layout": [
+        { name: "args", type: {"defined":{"name":"MigrateLPPositionLayoutArgs"}} },
     ],
     "create_reserve_domain": [
         { name: "args", type: {"defined":{"name":"CreateReserveDomainArgs"}} },
@@ -501,6 +513,29 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS = {
         { name: "health_plan", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [104, 101, 97, 108, 116, 104, 95, 112, 108, 97, 110] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "health_plan.health_plan_id" }] },
         { name: "policy_series", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 108, 105, 99, 121, 95, 115, 101, 114, 105, 101, 115] }, { kind: "account", path: "health_plan" }, { kind: "arg", path: "args.series_id" }] },
         { name: "series_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [115, 101, 114, 105, 101, 115, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "policy_series" }, { kind: "arg", path: "args.asset_mint" }] },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "migrate_protocol_governance_layout": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "protocol_governance", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+        { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+        { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "migrate_capital_class_layout": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+        { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+    ],
+    "migrate_lp_position_layout": [
+        { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "capital_class", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+        { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+        { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
         { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
     ],
     "create_reserve_domain": [

--- a/frontend/lib/generated/protocol-contract.ts
+++ b/frontend/lib/generated/protocol-contract.ts
@@ -1,6 +1,6 @@
 // AUTO-GENERATED FILE. DO NOT EDIT MANUALLY.
 // source: shared/protocol_contract.json
-// contract_sha256: 5988efbe9e29ff7b6da5363223ed00a8085adf5278d766e03fad94f5318b940b
+// contract_sha256: e8e736a4834ba1ffe0ecb224f27539e693cd751f9df5830a1c2b6957b735a23d
 
 export type ProtocolInstructionName =
   | "accept_protocol_governance_authority"
@@ -26,6 +26,9 @@ export type ProtocolInstructionName =
   | "create_liquidity_pool"
   | "create_obligation"
   | "create_policy_series"
+  | "migrate_protocol_governance_layout"
+  | "migrate_capital_class_layout"
+  | "migrate_lp_position_layout"
   | "create_reserve_domain"
   | "deallocate_capital"
   | "deposit_commitment"
@@ -114,6 +117,9 @@ export const PROTOCOL_INSTRUCTION_DISCRIMINATORS: Record<ProtocolInstructionName
   "create_liquidity_pool": Uint8Array.from([175, 75, 181, 165, 224, 254, 6, 131]),
   "create_obligation": Uint8Array.from([216, 144, 172, 223, 19, 106, 220, 54]),
   "create_policy_series": Uint8Array.from([70, 162, 231, 218, 211, 136, 110, 176]),
+  "migrate_protocol_governance_layout": Uint8Array.from([142, 48, 202, 237, 234, 83, 239, 134]),
+  "migrate_capital_class_layout": Uint8Array.from([92, 167, 94, 232, 0, 194, 56, 209]),
+  "migrate_lp_position_layout": Uint8Array.from([113, 230, 184, 121, 86, 153, 219, 216]),
   "create_reserve_domain": Uint8Array.from([222, 2, 8, 218, 45, 157, 193, 246]),
   "deallocate_capital": Uint8Array.from([10, 97, 97, 189, 60, 170, 102, 29]),
   "deposit_commitment": Uint8Array.from([147, 105, 226, 224, 111, 39, 63, 78]),
@@ -232,6 +238,15 @@ export const PROTOCOL_INSTRUCTION_ARGS: Record<ProtocolInstructionName, Protocol
   ],
   "create_policy_series": [
       { name: "args", type: {"defined":{"name":"CreatePolicySeriesArgs"}} },
+  ],
+  "migrate_protocol_governance_layout": [
+
+  ],
+  "migrate_capital_class_layout": [
+      { name: "args", type: {"defined":{"name":"MigrateCapitalClassLayoutArgs"}} },
+  ],
+  "migrate_lp_position_layout": [
+      { name: "args", type: {"defined":{"name":"MigrateLPPositionLayoutArgs"}} },
   ],
   "create_reserve_domain": [
       { name: "args", type: {"defined":{"name":"CreateReserveDomainArgs"}} },
@@ -591,6 +606,29 @@ export const PROTOCOL_INSTRUCTION_ACCOUNTS: Record<ProtocolInstructionName, Prot
       { name: "health_plan", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [104, 101, 97, 108, 116, 104, 95, 112, 108, 97, 110] }, { kind: "account", path: "health_plan.reserve_domain" }, { kind: "account", path: "health_plan.health_plan_id" }] },
       { name: "policy_series", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 111, 108, 105, 99, 121, 95, 115, 101, 114, 105, 101, 115] }, { kind: "account", path: "health_plan" }, { kind: "arg", path: "args.series_id" }] },
       { name: "series_reserve_ledger", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [115, 101, 114, 105, 101, 115, 95, 114, 101, 115, 101, 114, 118, 101, 95, 108, 101, 100, 103, 101, 114] }, { kind: "account", path: "policy_series" }, { kind: "arg", path: "args.asset_mint" }] },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "migrate_protocol_governance_layout": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "protocol_governance", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108, 95, 103, 111, 118, 101, 114, 110, 97, 110, 99, 101] }] },
+      { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+      { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "migrate_capital_class_layout": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "liquidity_pool", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "capital_class", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+      { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
+  ],
+  "migrate_lp_position_layout": [
+      { name: "authority", writable: true, signer: true, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "capital_class", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "lp_position", writable: true, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
+      { name: "program", writable: false, signer: false, optional: false, address: "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B", pdaSeeds: undefined },
+      { name: "program_data", writable: false, signer: false, optional: false, address: undefined, pdaSeeds: undefined },
       { name: "system_program", writable: false, signer: false, optional: false, address: "11111111111111111111111111111111", pdaSeeds: undefined },
   ],
   "create_reserve_domain": [

--- a/idl/omegax_protocol.json
+++ b/idl/omegax_protocol.json
@@ -5079,6 +5079,166 @@
       ]
     },
     {
+      "name": "migrate_protocol_governance_layout",
+      "discriminator": [
+        142,
+        48,
+        202,
+        237,
+        234,
+        83,
+        239,
+        134
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "protocol_governance",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program",
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_capital_class_layout",
+      "discriminator": [
+        92,
+        167,
+        94,
+        232,
+        0,
+        194,
+        56,
+        209
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "liquidity_pool"
+        },
+        {
+          "name": "capital_class",
+          "writable": true
+        },
+        {
+          "name": "program",
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "MigrateCapitalClassLayoutArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "migrate_lp_position_layout",
+      "discriminator": [
+        113,
+        230,
+        184,
+        121,
+        86,
+        153,
+        219,
+        216
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "capital_class"
+        },
+        {
+          "name": "lp_position",
+          "writable": true
+        },
+        {
+          "name": "program",
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "MigrateLPPositionLayoutArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "create_reserve_domain",
       "discriminator": [
         222,
@@ -18434,6 +18594,30 @@
           {
             "name": "terms_version",
             "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateCapitalClassLayoutArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "class_id",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateLPPositionLayoutArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "pubkey"
           }
         ]
       }

--- a/idl/omegax_protocol.source-hash
+++ b/idl/omegax_protocol.source-hash
@@ -1,4 +1,4 @@
-2884eae040f84777fcc6f24ee71ec268b6c5e1f4935f718b304b6257ef4b9144
+3e2418b1b2ad18bcc0079c5fdd564e315d7cce07fb7f64ddb0e16be135d492d6
   Cargo.toml
   programs/omegax_protocol/Cargo.toml
   programs/omegax_protocol/src/args.rs
@@ -37,5 +37,6 @@
   programs/omegax_protocol/src/reserve_custody.rs
   programs/omegax_protocol/src/reserve_waterfall.rs
   programs/omegax_protocol/src/state.rs
+  programs/omegax_protocol/src/state_migrations.rs
   programs/omegax_protocol/src/tests.rs
   programs/omegax_protocol/src/types.rs

--- a/programs/omegax_protocol/README.md
+++ b/programs/omegax_protocol/README.md
@@ -73,6 +73,26 @@ current protocol surface.
 - [`../../docs/architecture/solana-instruction-map.md`](../../docs/architecture/solana-instruction-map.md)
 - [`../../docs/MIGRATION_MATRIX.md`](../../docs/MIGRATION_MATRIX.md)
 
+## Account layout migrations
+
+State-layout changes that enlarge an existing Anchor account must ship with a
+raw-account migration path before ordinary handlers deserialize the new layout.
+The current migration surface is intentionally upgrade-authority scoped and
+uses unchecked accounts for the account being resized so legacy deployments can
+recover before normal `Account<T>` validation runs:
+
+- `migrate_protocol_governance_layout` resizes the singleton
+  `ProtocolGovernance` PDA and initializes pending governance-transfer fields
+  to their inactive defaults.
+- `migrate_capital_class_layout` resizes an existing `CapitalClass` PDA and
+  initializes redemption FIFO cursors to zero.
+- `migrate_lp_position_layout` resizes an existing `LPPosition` PDA and
+  initializes its queued-redemption sequence/timestamp to zero.
+
+Run these migrations only as an explicit post-upgrade maintenance step for
+accounts created with the previous shorter layouts. Fresh accounts already use
+the current `INIT_SPACE` values.
+
 ## Common commands
 
 From the repository root:

--- a/programs/omegax_protocol/src/args.rs
+++ b/programs/omegax_protocol/src/args.rs
@@ -23,6 +23,17 @@ pub struct RotateProtocolGovernanceAuthorityArgs {
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct MigrateCapitalClassLayoutArgs {
+    #[max_len(MAX_ID_LEN)]
+    pub class_id: String,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
+pub struct MigrateLPPositionLayoutArgs {
+    pub owner: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, InitSpace)]
 pub struct CreateReserveDomainArgs {
     #[max_len(MAX_ID_LEN)]
     pub domain_id: String,

--- a/programs/omegax_protocol/src/lib.rs
+++ b/programs/omegax_protocol/src/lib.rs
@@ -24,6 +24,7 @@ pub mod plans_membership;
 pub mod reserve_custody;
 pub mod reserve_waterfall;
 pub mod state;
+pub mod state_migrations;
 pub mod types;
 
 pub use args::*;
@@ -43,6 +44,7 @@ pub use plans_membership::*;
 pub use reserve_custody::*;
 pub use reserve_waterfall::*;
 pub use state::*;
+pub use state_migrations::*;
 pub use types::*;
 
 // Anchor derives these hidden client-account modules next to each `Accounts`
@@ -74,6 +76,10 @@ pub(crate) use funding_obligations::{
 pub(crate) use reserve_waterfall::{
     __client_accounts_configure_reserve_asset_rail,
     __client_accounts_publish_reserve_asset_rail_price,
+};
+pub(crate) use state_migrations::{
+    __client_accounts_migrate_capital_class_layout, __client_accounts_migrate_lp_position_layout,
+    __client_accounts_migrate_protocol_governance_layout,
 };
 
 #[program]
@@ -111,6 +117,26 @@ pub mod omegax_protocol {
         ctx: Context<CancelProtocolGovernanceAuthorityTransfer>,
     ) -> Result<()> {
         crate::governance::cancel_protocol_governance_authority_transfer(ctx)
+    }
+
+    pub fn migrate_protocol_governance_layout(
+        ctx: Context<MigrateProtocolGovernanceLayout>,
+    ) -> Result<()> {
+        crate::state_migrations::migrate_protocol_governance_layout(ctx)
+    }
+
+    pub fn migrate_capital_class_layout(
+        ctx: Context<MigrateCapitalClassLayout>,
+        args: MigrateCapitalClassLayoutArgs,
+    ) -> Result<()> {
+        crate::state_migrations::migrate_capital_class_layout(ctx, args)
+    }
+
+    pub fn migrate_lp_position_layout(
+        ctx: Context<MigrateLPPositionLayout>,
+        args: MigrateLPPositionLayoutArgs,
+    ) -> Result<()> {
+        crate::state_migrations::migrate_lp_position_layout(ctx, args)
     }
 
     pub fn create_reserve_domain(

--- a/programs/omegax_protocol/src/state_migrations.rs
+++ b/programs/omegax_protocol/src/state_migrations.rs
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Raw-account layout migrations for accounts whose serialized state grew.
+//!
+//! These handlers intentionally avoid `Account<T>` for the migrated account so
+//! legacy, shorter account data can be reallocated and rewritten before Anchor
+//! attempts to deserialize the current account layout in ordinary handlers.
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{program::invoke, system_instruction};
+
+use crate::args::*;
+use crate::constants::*;
+use crate::errors::*;
+use crate::program::OmegaxProtocol;
+use crate::state::*;
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+struct LegacyProtocolGovernance {
+    governance_authority: Pubkey,
+    protocol_fee_bps: u16,
+    emergency_pause: bool,
+    audit_nonce: u64,
+    bump: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+struct LegacyCapitalClass {
+    reserve_domain: Pubkey,
+    liquidity_pool: Pubkey,
+    share_mint: Pubkey,
+    class_id: String,
+    display_name: String,
+    priority: u8,
+    impairment_rank: u8,
+    restriction_mode: u8,
+    redemption_terms_mode: u8,
+    wrapper_metadata_hash: [u8; 32],
+    permissioning_hash: [u8; 32],
+    fee_bps: u16,
+    min_lockup_seconds: i64,
+    pause_flags: u32,
+    queue_only_redemptions: bool,
+    total_shares: u64,
+    nav_assets: u64,
+    allocated_assets: u64,
+    reserved_assets: u64,
+    impaired_assets: u64,
+    pending_redemptions: u64,
+    active: bool,
+    bump: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+struct LegacyLPPosition {
+    capital_class: Pubkey,
+    owner: Pubkey,
+    shares: u64,
+    subscription_basis: u64,
+    pending_redemption_shares: u64,
+    pending_redemption_assets: u64,
+    realized_distributions: u64,
+    impaired_principal: u64,
+    lockup_ends_at: i64,
+    credentialed: bool,
+    queue_status: u8,
+    bump: u8,
+}
+
+pub(crate) fn migrate_protocol_governance_layout(
+    ctx: Context<MigrateProtocolGovernanceLayout>,
+) -> Result<()> {
+    migrate_account_layout(
+        &ctx.accounts.protocol_governance.to_account_info(),
+        &ctx.accounts.authority.to_account_info(),
+        &ctx.accounts.system_program.to_account_info(),
+        ProtocolGovernance::INIT_SPACE,
+        ProtocolGovernance::DISCRIMINATOR,
+        |body| {
+            let legacy = LegacyProtocolGovernance::deserialize(&mut &body[..])?;
+            Ok(ProtocolGovernance {
+                governance_authority: legacy.governance_authority,
+                pending_governance_authority: ZERO_PUBKEY,
+                pending_governance_proposed_at: 0,
+                pending_governance_expires_at: 0,
+                protocol_fee_bps: legacy.protocol_fee_bps,
+                emergency_pause: legacy.emergency_pause,
+                audit_nonce: legacy.audit_nonce,
+                bump: legacy.bump,
+            })
+        },
+    )
+}
+
+pub(crate) fn migrate_capital_class_layout(
+    ctx: Context<MigrateCapitalClassLayout>,
+    args: MigrateCapitalClassLayoutArgs,
+) -> Result<()> {
+    let (expected_key, _) = Pubkey::find_program_address(
+        &[
+            SEED_CAPITAL_CLASS,
+            ctx.accounts.liquidity_pool.key().as_ref(),
+            args.class_id.as_bytes(),
+        ],
+        ctx.program_id,
+    );
+    require_keys_eq!(
+        expected_key,
+        ctx.accounts.capital_class.key(),
+        OmegaXProtocolError::CapitalClassMismatch
+    );
+
+    migrate_account_layout(
+        &ctx.accounts.capital_class.to_account_info(),
+        &ctx.accounts.authority.to_account_info(),
+        &ctx.accounts.system_program.to_account_info(),
+        CapitalClass::INIT_SPACE,
+        CapitalClass::DISCRIMINATOR,
+        |body| {
+            let legacy = LegacyCapitalClass::deserialize(&mut &body[..])?;
+            require_keys_eq!(
+                legacy.liquidity_pool,
+                ctx.accounts.liquidity_pool.key(),
+                OmegaXProtocolError::LiquidityPoolMismatch
+            );
+            require!(
+                legacy.class_id == args.class_id,
+                OmegaXProtocolError::CapitalClassMismatch
+            );
+            Ok(CapitalClass {
+                reserve_domain: legacy.reserve_domain,
+                liquidity_pool: legacy.liquidity_pool,
+                share_mint: legacy.share_mint,
+                class_id: legacy.class_id,
+                display_name: legacy.display_name,
+                priority: legacy.priority,
+                impairment_rank: legacy.impairment_rank,
+                restriction_mode: legacy.restriction_mode,
+                redemption_terms_mode: legacy.redemption_terms_mode,
+                wrapper_metadata_hash: legacy.wrapper_metadata_hash,
+                permissioning_hash: legacy.permissioning_hash,
+                fee_bps: legacy.fee_bps,
+                min_lockup_seconds: legacy.min_lockup_seconds,
+                pause_flags: legacy.pause_flags,
+                queue_only_redemptions: legacy.queue_only_redemptions,
+                total_shares: legacy.total_shares,
+                nav_assets: legacy.nav_assets,
+                allocated_assets: legacy.allocated_assets,
+                reserved_assets: legacy.reserved_assets,
+                impaired_assets: legacy.impaired_assets,
+                pending_redemptions: legacy.pending_redemptions,
+                next_redemption_sequence: 0,
+                next_redemption_to_process: 0,
+                active: legacy.active,
+                bump: legacy.bump,
+            })
+        },
+    )
+}
+
+pub(crate) fn migrate_lp_position_layout(
+    ctx: Context<MigrateLPPositionLayout>,
+    args: MigrateLPPositionLayoutArgs,
+) -> Result<()> {
+    let (expected_key, _) = Pubkey::find_program_address(
+        &[
+            SEED_LP_POSITION,
+            ctx.accounts.capital_class.key().as_ref(),
+            args.owner.as_ref(),
+        ],
+        ctx.program_id,
+    );
+    require_keys_eq!(
+        expected_key,
+        ctx.accounts.lp_position.key(),
+        OmegaXProtocolError::CapitalClassMismatch
+    );
+
+    migrate_account_layout(
+        &ctx.accounts.lp_position.to_account_info(),
+        &ctx.accounts.authority.to_account_info(),
+        &ctx.accounts.system_program.to_account_info(),
+        LPPosition::INIT_SPACE,
+        LPPosition::DISCRIMINATOR,
+        |body| {
+            let legacy = LegacyLPPosition::deserialize(&mut &body[..])?;
+            require_keys_eq!(
+                legacy.capital_class,
+                ctx.accounts.capital_class.key(),
+                OmegaXProtocolError::CapitalClassMismatch
+            );
+            require_keys_eq!(legacy.owner, args.owner, OmegaXProtocolError::Unauthorized);
+            Ok(LPPosition {
+                capital_class: legacy.capital_class,
+                owner: legacy.owner,
+                shares: legacy.shares,
+                subscription_basis: legacy.subscription_basis,
+                pending_redemption_shares: legacy.pending_redemption_shares,
+                pending_redemption_assets: legacy.pending_redemption_assets,
+                realized_distributions: legacy.realized_distributions,
+                impaired_principal: legacy.impaired_principal,
+                lockup_ends_at: legacy.lockup_ends_at,
+                credentialed: legacy.credentialed,
+                queue_status: legacy.queue_status,
+                redemption_sequence: 0,
+                redemption_requested_at: 0,
+                bump: legacy.bump,
+            })
+        },
+    )
+}
+
+fn migrate_account_layout<'info, T, F>(
+    account: &AccountInfo<'info>,
+    payer: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+    current_body_space: usize,
+    discriminator: &[u8],
+    legacy_to_current: F,
+) -> Result<()>
+where
+    T: AnchorSerialize + AnchorDeserialize,
+    F: FnOnce(&[u8]) -> Result<T>,
+{
+    require_keys_eq!(*account.owner, crate::ID, OmegaXProtocolError::Unauthorized);
+
+    let current_len = 8usize
+        .checked_add(current_body_space)
+        .ok_or(OmegaXProtocolError::ArithmeticError)?;
+    let account_len = account.data_len();
+    require!(account_len >= 8, OmegaXProtocolError::Unauthorized);
+
+    {
+        let data = account.try_borrow_data()?;
+        require!(
+            &data[..discriminator.len()] == discriminator,
+            OmegaXProtocolError::Unauthorized
+        );
+        if account_len >= current_len {
+            let _ = T::deserialize(&mut &data[8..])?;
+            return Ok(());
+        }
+    }
+
+    let current = {
+        let data = account.try_borrow_data()?;
+        legacy_to_current(&data[8..])?
+    };
+
+    fund_realloc(account, payer, system_program, current_len)?;
+
+    let mut data = account.try_borrow_mut_data()?;
+    data[..discriminator.len()].copy_from_slice(discriminator);
+    let mut body = &mut data[8..];
+    current.serialize(&mut body)?;
+
+    Ok(())
+}
+
+fn fund_realloc<'info>(
+    account: &AccountInfo<'info>,
+    payer: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+    new_len: usize,
+) -> Result<()> {
+    let rent = Rent::get()?;
+    let required_lamports = rent.minimum_balance(new_len);
+    let current_lamports = account.lamports();
+
+    if current_lamports < required_lamports {
+        let top_up = required_lamports
+            .checked_sub(current_lamports)
+            .ok_or(OmegaXProtocolError::ArithmeticError)?;
+        invoke(
+            &system_instruction::transfer(payer.key, account.key, top_up),
+            &[payer.clone(), account.clone(), system_program.clone()],
+        )?;
+    }
+
+    account.resize(new_len)?;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct MigrateProtocolGovernanceLayout<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(mut, seeds = [SEED_PROTOCOL_GOVERNANCE], bump)]
+    /// CHECK: This handler must accept legacy shorter bytes before Anchor can
+    /// deserialize the current ProtocolGovernance layout. The PDA seed, owner,
+    /// discriminator, and upgrade authority are verified explicitly.
+    pub protocol_governance: UncheckedAccount<'info>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program: Program<'info, OmegaxProtocol>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(authority.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program_data: Account<'info, ProgramData>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct MigrateCapitalClassLayout<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub liquidity_pool: Account<'info, LiquidityPool>,
+    #[account(mut)]
+    /// CHECK: The account may still contain the legacy shorter CapitalClass
+    /// layout. The handler verifies the PDA key, owner, discriminator, and
+    /// parsed liquidity-pool/class-id binding before rewriting it.
+    pub capital_class: UncheckedAccount<'info>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program: Program<'info, OmegaxProtocol>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(authority.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program_data: Account<'info, ProgramData>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct MigrateLPPositionLayout<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    /// CHECK: CapitalClass may be legacy-sized during batched migrations. The
+    /// LP PDA key and parsed account body are both checked against this key.
+    pub capital_class: UncheckedAccount<'info>,
+    #[account(mut)]
+    /// CHECK: The account may still contain the legacy shorter LPPosition
+    /// layout. The handler verifies the PDA key, owner, discriminator, and
+    /// parsed capital-class/owner binding before rewriting it.
+    pub lp_position: UncheckedAccount<'info>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program: Program<'info, OmegaxProtocol>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(authority.key()) @ OmegaXProtocolError::Unauthorized
+    )]
+    pub program_data: Account<'info, ProgramData>,
+    pub system_program: Program<'info, System>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_protocol_governance() -> LegacyProtocolGovernance {
+        LegacyProtocolGovernance {
+            governance_authority: Pubkey::new_unique(),
+            protocol_fee_bps: 25,
+            emergency_pause: true,
+            audit_nonce: 9,
+            bump: 254,
+        }
+    }
+
+    #[test]
+    fn legacy_protocol_governance_maps_inserted_fields_to_defaults() {
+        let legacy = legacy_protocol_governance();
+        let mut bytes = Vec::new();
+        legacy.serialize(&mut bytes).unwrap();
+
+        let current = {
+            let legacy = LegacyProtocolGovernance::deserialize(&mut &bytes[..]).unwrap();
+            ProtocolGovernance {
+                governance_authority: legacy.governance_authority,
+                pending_governance_authority: ZERO_PUBKEY,
+                pending_governance_proposed_at: 0,
+                pending_governance_expires_at: 0,
+                protocol_fee_bps: legacy.protocol_fee_bps,
+                emergency_pause: legacy.emergency_pause,
+                audit_nonce: legacy.audit_nonce,
+                bump: legacy.bump,
+            }
+        };
+
+        assert_eq!(current.protocol_fee_bps, 25);
+        assert_eq!(current.pending_governance_authority, ZERO_PUBKEY);
+        assert_eq!(current.pending_governance_proposed_at, 0);
+        assert_eq!(current.pending_governance_expires_at, 0);
+        assert!(current.emergency_pause);
+        assert_eq!(current.audit_nonce, 9);
+        assert_eq!(current.bump, 254);
+    }
+}

--- a/shared/protocol_contract.json
+++ b/shared/protocol_contract.json
@@ -5465,6 +5465,208 @@
       ]
     },
     {
+      "name": "migrate_protocol_governance_layout",
+      "discriminator": [
+        142,
+        48,
+        202,
+        237,
+        234,
+        83,
+        239,
+        134
+      ],
+      "args": [],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "protocol_governance",
+          "writable": true,
+          "signer": false,
+          "optional": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108,
+                  95,
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "migrate_capital_class_layout",
+      "discriminator": [
+        92,
+        167,
+        94,
+        232,
+        0,
+        194,
+        56,
+        209
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "MigrateCapitalClassLayoutArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "liquidity_pool",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "capital_class",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
+      "name": "migrate_lp_position_layout",
+      "discriminator": [
+        113,
+        230,
+        184,
+        121,
+        86,
+        153,
+        219,
+        216
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "MigrateLPPositionLayoutArgs"
+            }
+          }
+        }
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "optional": false
+        },
+        {
+          "name": "capital_class",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "lp_position",
+          "writable": true,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "Bn6eixac1QEEVErGBvBjxAd6pgB9e2q4XHvAkinQ5y1B"
+        },
+        {
+          "name": "program_data",
+          "writable": false,
+          "signer": false,
+          "optional": false
+        },
+        {
+          "name": "system_program",
+          "writable": false,
+          "signer": false,
+          "optional": false,
+          "address": "11111111111111111111111111111111"
+        }
+      ]
+    },
+    {
       "name": "create_reserve_domain",
       "discriminator": [
         222,


### PR DESCRIPTION
### Motivation
- A recent layout change increased the serialized size of `ProtocolGovernance`, `CapitalClass`, and `LPPosition`, which causes Anchor to fail deserializing existing on-chain PDAs created with the prior, smaller layouts and can deny service for live deployments. 
- The intent is to provide an upgrade-authority scoped, explicit migration path that safely resizes existing accounts and backfills newly inserted fields to safe defaults so ordinary handlers can resume without requiring destructive reinitialization. 

### Description
- Added a new migration module `programs/omegax_protocol/src/state_migrations.rs` implementing `migrate_protocol_governance_layout`, `migrate_capital_class_layout`, and `migrate_lp_position_layout` that deserialize legacy bytes, construct current-layout structs with defaulted/backfilled fields, top up rent, `resize` the account, and write the new serialized body.  
- Introduced legacy layout helpers (`LegacyProtocolGovernance`, `LegacyCapitalClass`, `LegacyLPPosition`) and a shared `migrate_account_layout` routine that verifies program ownership, checks discriminators, treats already-current accounts as idempotent no-ops, and performs the reallocation/serialize flow. 
- Exposed the three migration instructions through the Anchor facade by adding migration args (`MigrateCapitalClassLayoutArgs`, `MigrateLPPositionLayoutArgs`), wiring the new `#[program]` entrypoints, and using `UncheckedAccount` for the account being migrated while constraining the caller to the program upgrade authority. 
- Updated developer docs and checked-in contract artifacts and IDL/front-end generated files so the new migration instructions, discriminators, and types are reflected in `idl/` and `frontend/lib/generated/` and added a short README note describing when to run the migrations. 

### Testing
- Ran `cargo test -p omegax_protocol --lib` and the crate unit tests passed (all tests in the program test profile succeeded). 
- Executed the repo verification lane: `npm run rust:fmt:check`, `npm run rust:test`, `npm run rust:lint`, `npm run idl:freshness:check`, and `npm run protocol:contract:check`, and all of those checks completed successfully. 
- Ran the JS/Node test harness via `npm run test:node` and targeted JS tests `node --import tsx --test tests/protocol_contract.test.ts tests/protocol_governance_builders.test.ts`, and these test suites passed. 
- Attempted to run `npm run anchor:idl` but it could not execute inside the container because the `anchor` CLI is not installed (`spawn anchor ENOENT`); IDL and contract artifacts were regenerated/validated in-tree and their freshness/contract checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb738f4340832f97d38ecb50c2a0d7)