### PR TITLE
fix(security): authorize private review mutations

### DIFF
--- a/docs/architecture/magicblock-private-claim-room.md
+++ b/docs/architecture/magicblock-private-claim-room.md
@@ -9,7 +9,7 @@ The adjunct program is `omegax_private_claim_review`. It stores only public-safe
 - evidence and schema hashes
 - review result and artifact hashes
 - review binary and TEE attestation digests
-- reviewer/operator key
+- reviewer/operator key captured when the session is opened
 - private payment reference hash
 - lifecycle status and timestamps
 
@@ -18,17 +18,17 @@ Raw medical evidence, encrypted evidence payloads, OCR text, storage paths, and 
 ## Demo Flow
 
 1. `omegax-health` prepares a redacted Genesis Protect Acute claim packet and hashes the private evidence bundle.
-2. `omegax_private_claim_review::open_review_session` creates a public review-session PDA on base Solana.
+2. `omegax_private_claim_review::open_review_session` creates a public review-session PDA on base Solana and stores the opener as the authorized reviewer/operator.
 3. `delegate_review_session` delegates that session PDA to MagicBlock ER.
 4. A TEE/private reviewer checks the private packet and emits a hash-bounded review artifact.
-5. `record_private_review` records only review hashes and status on the delegated session.
-6. The MagicBlock Private Payments API builds a devnet reimbursement preview; `record_private_payment_ref` stores only its reference hash.
-7. `commit_and_close_review_session` commits and undelegates the review session back to Solana.
+5. `record_private_review` records only review hashes and status on the delegated session, and it must be signed by the stored reviewer/operator.
+6. The MagicBlock Private Payments API builds a devnet reimbursement preview; `record_private_payment_ref` stores only its reference hash when signed by the stored reviewer/operator.
+7. `commit_and_close_review_session` commits and undelegates the review session back to Solana when signed by the stored reviewer/operator.
 8. The existing `omegax_protocol::attest_claim_case` consumes the committed review artifact hash through the normal claim attestation path.
 
 ## Boundaries
 
 - The main `omegax_protocol` program is not delegated to MagicBlock.
 - `ClaimCase`, reserves, vaults, funding lines, obligations, and payout accounts are not delegated.
-- The private reviewer may inspect plaintext inside the TEE path, but public Solana only receives hashes and status.
+- The private reviewer/operator may inspect plaintext inside the TEE path, but public Solana only receives hashes and status; state-changing review, payment-reference, failure, and commit instructions require that stored operator signer.
 - The hackathon reimbursement preview demonstrates MagicBlock private payments; it does not replace the production reserve kernel.

--- a/programs/omegax_private_claim_review/src/lib.rs
+++ b/programs/omegax_private_claim_review/src/lib.rs
@@ -72,7 +72,7 @@ pub mod omegax_private_claim_review {
         session.review_artifact_hash = [0; 32];
         session.review_binary_hash = [0; 32];
         session.tee_attestation_digest = [0; 32];
-        session.operator = Pubkey::default();
+        session.operator = ctx.accounts.payer.key();
         session.private_payment_ref_hash = [0; 32];
         session.status = REVIEW_STATUS_OPENED;
         session.opened_at = now_ts;
@@ -148,6 +148,7 @@ pub mod omegax_private_claim_review {
         );
 
         let session = &mut ctx.accounts.review_session;
+        require_session_operator(session, &ctx.accounts.reviewer.key())?;
         require!(
             session.status == REVIEW_STATUS_OPENED || session.status == REVIEW_STATUS_DELEGATED,
             PrivateClaimReviewError::ReviewNotWritable
@@ -187,6 +188,7 @@ pub mod omegax_private_claim_review {
         );
 
         let session = &mut ctx.accounts.review_session;
+        require_session_operator(session, &ctx.accounts.payer.key())?;
         require!(
             session.status == REVIEW_STATUS_APPROVED || session.status == REVIEW_STATUS_REVIEWED,
             PrivateClaimReviewError::PaymentRefNotAllowed
@@ -211,6 +213,7 @@ pub mod omegax_private_claim_review {
         ctx: Context<CommitAndCloseReviewSession>,
     ) -> Result<()> {
         let session = &mut ctx.accounts.review_session;
+        require_session_operator(session, &ctx.accounts.payer.key())?;
         require!(
             session.status == REVIEW_STATUS_REVIEWED
                 || session.status == REVIEW_STATUS_APPROVED
@@ -248,6 +251,7 @@ pub mod omegax_private_claim_review {
         );
 
         let session = &mut ctx.accounts.review_session;
+        require_session_operator(session, &ctx.accounts.payer.key())?;
         require!(
             session.status != REVIEW_STATUS_APPROVED,
             PrivateClaimReviewError::ApprovedReviewCannotFail
@@ -489,6 +493,17 @@ pub enum PrivateClaimReviewError {
     ReviewNotReadyToCommit,
     #[msg("approved private review cannot be marked failed")]
     ApprovedReviewCannotFail,
+    #[msg("signer is not the private review session operator")]
+    UnauthorizedReviewOperator,
+}
+
+fn require_session_operator(session: &PrivateClaimReviewSession, signer: &Pubkey) -> Result<()> {
+    require_keys_eq!(
+        session.operator,
+        *signer,
+        PrivateClaimReviewError::UnauthorizedReviewOperator
+    );
+    Ok(())
 }
 
 fn is_zero_hash(hash: &[u8; 32]) -> bool {

--- a/tests/magicblock_private_claim_review.test.ts
+++ b/tests/magicblock_private_claim_review.test.ts
@@ -53,6 +53,17 @@ test("MagicBlock adjunct keeps the main settlement kernel out of delegation scop
   assert.doesNotMatch(programSource, /omegax_protocol::/);
 });
 
+test("MagicBlock private claim review mutations require the stored operator", () => {
+  assert.match(programSource, /session\.operator = ctx\.accounts\.payer\.key\(\)/);
+  assert.match(programSource, /fn require_session_operator\(/);
+  assert.match(programSource, /UnauthorizedReviewOperator/);
+
+  for (const signer of ["reviewer", "payer"]) {
+    const operatorCheck = `require_session_operator(session, &ctx.accounts.${signer}.key())?`;
+    assert.ok(programSource.includes(operatorCheck));
+  }
+});
+
 test("MagicBlock private claim review program id is valid", () => {
   const match = anchorToml.match(/omegax_private_claim_review = "([^"]+)"/);
   assert.ok(match?.[1]);


### PR DESCRIPTION
### Motivation
- Close an authorization gap in the MagicBlock private claim review adjunct where any signer could finalize or mutate review-session state and thereby forge or grief review artifacts.  

### Description
- Store the session opener as the authorized operator by setting `session.operator = ctx.accounts.payer.key()` in `open_review_session` in `programs/omegax_private_claim_review/src/lib.rs`.  
- Add `require_session_operator` guard and `UnauthorizedReviewOperator` error, and call the guard before `record_private_review`, `record_private_payment_ref`, `commit_and_close_review_session`, and `mark_review_failed` to enforce that only the stored operator may perform those mutations.  
- Update the architecture doc `docs/architecture/magicblock-private-claim-room.md` to document that the opener is captured as the authorized reviewer/operator and that state-changing review/payment/failure/commit actions require that stored signer.  
- Add a Node regression check in `tests/magicblock_private_claim_review.test.ts` verifying the operator initialization and the presence of the `require_session_operator` checks.  

### Testing
- Ran `cargo fmt --check -p omegax_private_claim_review` and it succeeded.  
- Ran `cargo test -p omegax_private_claim_review --lib -- --nocapture` and all Rust unit tests passed.  
- Ran `node --import tsx --test tests/magicblock_private_claim_review.test.ts` and the added Node regression tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdeb408dc4832f8dbaae934109ece6)