### PR TITLE
fix(protocol): gate private review registry initialization

### DIFF
--- a/docs/architecture/magicblock-private-claim-room.md
+++ b/docs/architecture/magicblock-private-claim-room.md
@@ -20,7 +20,7 @@ Raw medical evidence, encrypted evidence payloads, OCR text, storage paths, and 
 ## Demo Flow
 
 1. `omegax-health` prepares a redacted Genesis Protect Acute claim packet and hashes the private evidence bundle.
-2. The demo operator initializes `PrivateReviewRegistry` and registers an active `PrivateReviewOperator` with the expected review binary hash.
+2. The demo operator initializes `PrivateReviewRegistry` with the `omegax_private_claim_review` program upgrade authority and registers an active `PrivateReviewOperator` with the expected review binary hash.
 3. `omegax_private_claim_review::open_review_session` creates a public review-session PDA on base Solana. The PDA is seeded by session authority, claim case, and session id to prevent third-party squatting.
 4. `delegate_review_session` verifies the session authority, marks the session delegated, and delegates that session PDA to MagicBlock ER.
 5. A TEE/private reviewer checks the private packet and emits a hash-bounded review artifact.
@@ -35,4 +35,5 @@ Raw medical evidence, encrypted evidence payloads, OCR text, storage paths, and 
 - `ClaimCase`, reserves, vaults, funding lines, obligations, and payout accounts are not delegated.
 - The private reviewer may inspect plaintext inside the TEE path, but public Solana only receives hashes and status.
 - The hackathon reimbursement preview demonstrates MagicBlock private payments; it does not replace the production reserve kernel.
+- The `PrivateReviewRegistry` singleton initializer is gated by the adjunct program's upgrade authority so arbitrary first callers cannot seize the canonical registry PDA.
 - The adjunct is not authoritative by itself. Consumers must verify registry binding, reviewer binding, expected hashes, payment reference, and committed ownership before treating it as claim-attestation input.

--- a/idl/omegax_private_claim_review.json
+++ b/idl/omegax_private_claim_review.json
@@ -358,6 +358,12 @@
           }
         },
         {
+          "name": "program"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -1554,6 +1560,11 @@
       "code": 6038,
       "name": "TerminalReviewCannotFail",
       "msg": "terminal private review cannot be marked failed"
+    },
+    {
+      "code": 6039,
+      "name": "UnauthorizedRegistryInitializer",
+      "msg": "signer is not the private review program upgrade authority"
     }
   ],
   "types": [

--- a/idl/omegax_private_claim_review.source-hash
+++ b/idl/omegax_private_claim_review.source-hash
@@ -1,4 +1,4 @@
-c73b4d36c53ebc23a203de7a740145d4aae9d75992522ddb7eacd098b956284f
+940f3b3b8e07d07516830f5204c74e32b1b7b4feadfa10c7dca3523e5e056017
   Cargo.toml
   programs/omegax_private_claim_review/Cargo.toml
   programs/omegax_private_claim_review/src/lib.rs

--- a/programs/omegax_private_claim_review/src/lib.rs
+++ b/programs/omegax_private_claim_review/src/lib.rs
@@ -607,6 +607,14 @@ pub struct InitializeReviewRegistry<'info> {
         bump,
     )]
     pub registry: Account<'info, PrivateReviewRegistry>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ PrivateClaimReviewError::UnauthorizedRegistryInitializer
+    )]
+    pub program: Program<'info, crate::program::OmegaxPrivateClaimReview>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(authority.key()) @ PrivateClaimReviewError::UnauthorizedRegistryInitializer
+    )]
+    pub program_data: Account<'info, ProgramData>,
     pub system_program: Program<'info, System>,
 }
 
@@ -966,6 +974,8 @@ pub enum PrivateClaimReviewError {
     ReviewAlreadyCommitted,
     #[msg("terminal private review cannot be marked failed")]
     TerminalReviewCannotFail,
+    #[msg("signer is not the private review program upgrade authority")]
+    UnauthorizedRegistryInitializer,
 }
 
 fn is_zero_hash(hash: &[u8; 32]) -> bool {

--- a/tests/magicblock_private_claim_review.test.ts
+++ b/tests/magicblock_private_claim_review.test.ts
@@ -62,6 +62,12 @@ test("MagicBlock adjunct uses an authority registry for review sessions", () => 
   assert.match(programSource, /operator\.active @ PrivateClaimReviewError::OperatorInactive/);
 });
 
+test("MagicBlock adjunct registry initialization is upgrade-authority gated", () => {
+  assert.match(programSource, /program\.programdata_address\(\)\? == Some\(program_data\.key\(\)\)/);
+  assert.match(programSource, /program_data\.upgrade_authority_address == Some\(authority\.key\(\)\)/);
+  assert.match(programSource, /UnauthorizedRegistryInitializer/);
+});
+
 test("review session PDA seeds bind session authority and claim case", () => {
   assert.match(
     programSource,


### PR DESCRIPTION
### Motivation
- Prevent first-initializer takeover of the singleton `PrivateReviewRegistry` PDA by binding registry creation to the program upgrade authority rather than an arbitrary signer.

### Description
- Require the `initialize_review_registry` account context to include the adjunct `program` and its `program_data`, and validate `program.programdata_address()` and `program_data.upgrade_authority_address == authority.key()` before creating the singleton registry.
- Add a new `UnauthorizedRegistryInitializer` error for failed upgrade-authority initialization attempts.
- Update the checked-in IDL (`idl/omegax_private_claim_review.json`) and freshness hash to reflect the added initialization accounts and error code.
- Add a unit/regression test asserting the initializer guard and update the MagicBlock private claim room docs to state that registry init is upgrade-authority gated.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Ran `cargo test -p omegax_private_claim_review --lib` and `cargo test -p omegax_private_claim_review --features idl-build __anchor_private_print_idl_program -- --nocapture`, both of which passed all unit tests.
- Ran the repository Node tests with `node --import tsx --test tests/magicblock_private_claim_review.test.ts` which passed and includes the new regression assertion.
- Ran linting (`cargo clippy` via `npm run rust:lint`) and protocol contract generation/checks (`npm run protocol:contract:check`), both of which completed successfully and the IDL freshness check (`npm run idl:freshness:check`) reports the updated hash.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee76205a0832f8561ecf81dc4184a)