### PR TITLE
docs(claims): tighten Genesis claims operating docs

### DIFF
--- a/docs/architecture/genesis-protect-acute-claims-processing-spec.md
+++ b/docs/architecture/genesis-protect-acute-claims-processing-spec.md
@@ -1,0 +1,555 @@
+# Genesis Protect Acute v1 — Claims Processing Specification
+
+> **Version**: 1.1  
+> **Author**: Manuel Soldatini — Protocol Verification & Claims  
+> **Status**: Draft — Internal  
+> **Date**: May 2026  
+> **Changelog**: v1.1 — updated to reflect multi-asset payout rails and MagicBlock private claim review path (protocol v0.3.2, May 2026 pull)  
+> **Companion docs**:
+> [`genesis-protect-claim-trace.md`](./genesis-protect-claim-trace.md) (onchain truth chain),
+> [`genesis-protect-acute-full-protect-flow.md`](./genesis-protect-acute-full-protect-flow.md) (operational flow — KR 1.1),
+> [`magicblock-private-claim-room.md`](./magicblock-private-claim-room.md) (private review adjunct),
+> [`decentralized-coverage-claims.md`](./decentralized-coverage-claims.md) (abstract model),
+> [`../../frontend/public/schemas/genesis-protect-acute-claim-v1.json`](../../frontend/public/schemas/genesis-protect-acute-claim-v1.json) (evidence schema)
+
+---
+
+## 1. Purpose and Scope
+
+This document specifies the full operational and technical claims-processing workflow for
+**Genesis Protect Acute v1** — covering Event 7 and Travel 30 policy SKUs.
+
+It defines:
+
+- what evidence members must submit and how it is validated
+- what eligibility checks are performed before and during intake
+- what signals trigger fraud review or escalation
+- the complete settlement state machine (onchain and operator-layer)
+- escalation rules and the human escalation hierarchy
+- the full audit trail that must exist for every claim, verifiable by third parties
+
+This spec governs the **Phase 0 launch posture** (operator-backed oracle, human review, offchain
+dispute resolution). Phase 1 extensions (onchain dispute-case state, multi-attestation finality,
+`protocol-oracle-service`) are noted where they change behavior but are not in scope for this release.
+
+---
+
+## 2. Roles and Authorities
+
+| Role | Who | What they can do | What they cannot do |
+|---|---|---|---|
+| **Member** | Enrolled wallet (MemberPosition) | Open claim case, submit evidence via oracle portal, authorize payout recipient, check claim status | Adjudicate their own claim, mutate evidence after attestation |
+| **Claims Operator** | OmegaX ops team (claims_operator key) | Attach evidence hash, adjudicate, reserve obligation, settle claim | Move funds outside claim-linked liabilities, override oracle attestation |
+| **Oracle Authority** | Designated oracle profile | Attest claim case against verified evidence schema | Adjudicate or settle claim unilaterally |
+| **Plan Admin** | OmegaX admin key (plan_admin) | Pause plan, set operational controls, open claim on behalf of incapacitated member | Rewrite approved or settled liabilities |
+| **LP / Sponsor** | Capital providers | Monitor reserve exposure, fund FundingLine | Intervene in individual claim decisions |
+| **TEE Reviewer** | MagicBlock private review path (Phase 0 demo) | Inspect private evidence in TEE, emit hash-bounded review artifact | Access raw PHI outside TEE, adjudicate or settle claim |
+
+---
+
+## 3. Product Reference
+
+| Parameter | Event 7 | Travel 30 |
+|---|---|---|
+| Premium | $39 USDC | $99 USDC |
+| Coverage duration | 7 days | 30 days |
+| Benefit mode | Fixed only | Hybrid: fixed tier + UCR reimbursement top-up |
+| Max benefit | $1,000 | $3,000 |
+| Tier 1 — ER same-day | $150 fixed | $250 fixed |
+| Tier 2 — Overnight | $500 fixed | $1,000 fixed |
+| Tier 3 — Surgery + ICU (2+ nights) | $1,000 fixed | $2,500 fixed + reimbursement top-up to $3,000 aggregate |
+| Waiting period (illness onset) | 7 days pre-enrollment | 7 days pre-enrollment |
+| Internal claim review target | 24 hours | 24 hours |
+| Internal settlement target | 48 hours post-approval | 48 hours post-approval |
+
+---
+
+## 4. Pre-Claim Eligibility Checks
+
+These checks are performed **before** a `ClaimCase` is opened or accepted for review.
+Failure at any of these gates results in an immediate denial without entering the claims queue.
+
+### 4.1 Policy Validity
+
+| Check | Pass condition | Failure action |
+|---|---|---|
+| Active MemberPosition exists | `member_position.wallet == claimant` and position is in an active state | Deny: no valid policy |
+| Policy is within coverage window | Incident date falls within the 7-day (Event 7) or 30-day (Travel 30) coverage period from activation | Deny: outside coverage window |
+| Premium payment confirmed | `record_premium_payment` instruction has been executed for this member position | Deny: unpaid policy |
+| Protocol is not paused | `HealthPlan.emergency_pause == false` | Hold: system pause — re-queue when cleared |
+| FundingLine is open | The relevant FundingLine is active and not exhausted | Hold: funding suspension — escalate to Plan Admin |
+
+### 4.2 Incident Eligibility
+
+| Check | Pass condition | Failure action |
+|---|---|---|
+| Incident is within covered travel context | Evidence confirms care occurred outside member's home country or at covered event venue | Deny: not a covered travel context |
+| Condition is an acute emergency | Clinical summary confirms unplanned acute event (not pre-scheduled, not elective) | Deny: non-acute / elective — see Exclusion §8 |
+| Waiting period satisfied | Illness onset is not within the 7-day pre-enrollment waiting period | Deny: waiting period not satisfied |
+| Single claim per coverage period | No prior settled or approved `ClaimCase` exists for this `MemberPosition` in the same policy window | Deny: duplicate claim |
+
+### 4.3 Member Identity Verification
+
+| Check | Pass condition | Failure action |
+|---|---|---|
+| Claimant wallet matches MemberPosition | `args.claimant == member_position.wallet` | Reject at intake (PT-04 constraint — protocol-enforced) |
+| Operator submission is authorized | If operator opens on behalf of member, authority is `claims_operator` or `plan_admin` | Reject at intake (protocol-enforced) |
+
+---
+
+## 5. Required Evidence
+
+All evidence is submitted **offchain** through the OmegaX Health oracle portal. The operator
+attaches a SHA-256 hash of the evidence packet to the `ClaimCase` via `attach_claim_evidence_ref`.
+Raw medical documents are never stored onchain or published publicly.
+
+### 5.1 Mandatory Documents (all claims)
+
+| Document | Accepted formats | Minimum content |
+|---|---|---|
+| **Discharge summary or doctor note** | PDF, scanned image (min 300 DPI), hospital letterhead preferred | Diagnosis, treatment dates, treating physician name and signature |
+| **Itemized invoice or bill** | PDF, hospital-issued format | Line-item charges, facility name, patient name matching policy, dates |
+| **Proof of payment** | Bank receipt, credit card statement, payment confirmation | Amount paid, currency, date, payee |
+| **Location and date proof** | Boarding pass, hotel receipt, conference badge, visa stamp | Confirms member was present in covered travel context on incident date |
+
+### 5.2 Additional Documents — Tier 3 Claims (Surgery + ICU)
+
+| Document | Accepted formats | Minimum content |
+|---|---|---|
+| **Operative or procedure report** | PDF, hospital-issued | Procedure performed, surgeon name, anaesthetic record if applicable |
+| **ICU admission and discharge record** | PDF, hospital-issued | Admission date, discharge date, treating consultant |
+| **Anaesthesiologist report** (if applicable) | PDF | Confirms inpatient surgical anaesthesia |
+
+### 5.3 Additional Documents — Travel 30 Reimbursement Top-Up
+
+| Document | Accepted formats | Minimum content |
+|---|---|---|
+| **Itemized bill with UCR annotation** | PDF | Each line item with corresponding UCR ceiling noted by operator |
+| **Receipts for all charged line items** | PDF, bank statement | Individual line-item payments matching the invoice |
+
+### 5.4 Document Quality Standards
+
+- All documents must be in English, or accompanied by a certified translation.
+- Translated documents must include the translator's name, credentials, and date.
+- Handwritten notes are accepted only if on official facility letterhead and countersigned.
+- Blurred, cropped, or partially obscured documents are rejected — member must resubmit.
+- Documents dated after the claim submission window trigger a fraud flag (see §7.2).
+
+---
+
+## 6. Evidence Review Checklist
+
+The claims operator performs the following checks before attaching the evidence hash and
+triggering oracle attestation.
+
+### 6.1 Clinical Review
+
+- [ ] Diagnosis is consistent with an acute emergency (ICD-10 code review)
+- [ ] Treatment dates fall within the active coverage window
+- [ ] Treating facility is a licensed hospital, clinic, or emergency care provider
+- [ ] Clinical narrative is internally consistent (onset → treatment → discharge sequence is logical)
+- [ ] No mention of pre-existing chronic condition management as primary diagnosis
+- [ ] No mention of elective, pre-scheduled, or cosmetic procedure
+
+### 6.2 Financial Review
+
+- [ ] Requested approval amount is capped by the applicable benefit schedule
+- [ ] All invoice line items are medically relevant to the acute diagnosis
+- [ ] UCR comparison completed for Travel 30 reimbursement line items
+- [ ] Proof of payment matches invoice amounts (no unexplained delta)
+- [ ] Payment currency and date are consistent with the care timeline
+
+### 6.3 Identity and Location Review
+
+- [ ] Patient name on medical documents matches the wallet holder's identity record
+- [ ] Care location is consistent with member's stated travel itinerary
+- [ ] Location and date proof confirms member was physically present at the care location
+- [ ] No conflict between boarding pass dates and incident dates
+
+### 6.4 Tier Classification Decision
+
+| Tier | Classification criteria |
+|---|---|
+| Tier 1 — ER Same-Day | ER attendance confirmed, discharged same calendar day, no admission |
+| Tier 2 — Overnight | Hospital admission confirmed, 1–2 nights, no surgery or ICU |
+| Tier 3 — Surgery + ICU | Surgical procedure confirmed OR ICU admission confirmed, 2+ nights |
+
+For Travel 30, after tier classification, the reimbursement top-up is calculated from
+UCR-benchmarked line items and capped so the total approved amount never exceeds $3,000.
+
+---
+
+## 6b. MagicBlock Private Claim Review Path (Optional Oracle Path)
+
+As of protocol v0.3.2, a **MagicBlock Ephemeral Rollup adjunct** (`omegax_private_claim_review`) is
+available as an optional oracle attestation adjunct for cases where standard human review would
+benefit from stronger privacy boundaries — for example, when evidence is inspected by a Trusted
+Execution Environment (TEE) reviewer without placing raw PHI on the Solana base layer.
+
+### When this path applies
+
+- High-sensitivity Tier 3 claims (surgery, ICU) where OCR processing of medical records is needed
+- Claims involving third-party reimbursement where private payment reference must be attested
+- Pilot / hackathon demo contexts (current Phase 0 status: demo-grade, not production settlement)
+
+### Flow (adjunct path)
+
+| Step | Action | What is recorded |
+|---|---|---|
+| 1 | Claims operator prepares redacted claim packet and hashes the evidence bundle | Hash only — raw PHI stays offchain |
+| 2 | `open_review_session` creates a public review-session PDA on base Solana | Session PDA seeded by authority + claim case + session ID (prevents squatting) |
+| 3 | `delegate_review_session` delegates the PDA to MagicBlock ER | Session marked `delegated` |
+| 4 | TEE/private reviewer inspects private packet, emits hash-bounded review artifact | Review result and binary hash — not raw content |
+| 5 | `record_private_review` records review hashes and status on the delegated session | Only the registered reviewer can write; binary hash must match operator registry |
+| 6 | `record_private_payment_ref` stores private payment reference hash (if applicable) | Reference hash only — payment details never onchain |
+| 7 | `commit_and_close_review_session` commits and undelegates back to Solana | Approved sessions require payment ref before commit |
+| 8 | `omegax_protocol::attest_claim_case` consumes the committed review artifact hash via normal attestation path | Onchain attestation proceeds as in standard flow |
+
+### Boundaries (must not be crossed)
+
+- The main `omegax_protocol` program is **not** delegated to MagicBlock — only the adjunct session PDA is.
+- `ClaimCase`, reserves, vaults, FundingLines, Obligations, and payout accounts are never delegated.
+- The adjunct is **not authoritative by itself** — consumers must verify registry binding, reviewer
+  binding, expected hashes, payment reference, and committed ownership before treating the result
+  as valid attestation input.
+- Phase 0 MagicBlock status: **demo-grade**. The production reserve kernel (USDC settlement, obligation
+  reservation, claim adjudication) is not routed through this path in Phase 0. It demonstrates the
+  privacy architecture for investor and partner audiences.
+
+---
+
+## 7. Fraud Flags and Escalation Triggers
+
+### 7.1 Automatic Fraud Flags (block approval, require senior review)
+
+These signals automatically place the claim in a **fraud hold** state. Senior operator review
+is required before adjudication can proceed.
+
+| Flag | Trigger condition |
+|---|---|
+| **Date inconsistency** | Document date precedes policy activation date, or discharge date is after the current date |
+| **Location mismatch** | Care facility country does not match the location proof submitted |
+| **Document anachronism** | Invoice or doctor note bears a date that post-dates the claim submission timestamp |
+| **Duplicate evidence hash** | `evidence_ref_hash` matches a hash from a previously submitted claim (same or different member) |
+| **Policy-period overlap** | Member has another open or recently settled claim within the same coverage window |
+| **Velocity flag** | Member has submitted 2+ claims across separate policy periods within 90 days |
+| **Known exclusion keyword** | Clinical narrative contains terms triggering a mandatory exclusion review (see §8) |
+| **Invoice-to-payment mismatch** | Invoice total and proof-of-payment total differ by more than 10% without explanation |
+| **UCR outlier** | Any single line item on a Travel 30 claim exceeds UCR ceiling by more than 200% |
+
+### 7.2 Soft Fraud Signals (flag for enhanced review, do not auto-block)
+
+| Signal | Operator action |
+|---|---|
+| Handwritten invoice from unlicensed provider | Request facility license documentation |
+| Cash payment with no bank trail | Request secondary documentation (e.g., witness statement, facility receipt) |
+| Diagnosis inconsistent with reported symptoms | Request clarifying note from treating physician |
+| Member contacted claims team before the policy activation | Document and flag — no action unless combined with other signals |
+| Invoice issued in a currency unusual for the care country | Verify exchange rate and independent receipt |
+| Unusual tier escalation (e.g., Tier 3 with minimal clinical record) | Request full surgical or ICU admission records before classification |
+
+### 7.3 Fraud Referral Procedure
+
+When 2 or more automatic fraud flags are triggered on a single claim:
+
+1. Claims operator places the claim in `fraud_hold` (offchain state, claim remains `proposed` onchain)
+2. Senior operator is notified within 2 hours
+3. Member is notified that additional documentation is required (no disclosure of fraud suspicion)
+4. Senior operator has 72 hours to complete fraud review
+5. If fraud is confirmed: claim is denied with reason code `FRAUD_MISREPRESENTATION` (Section 8.2)
+6. If fraud is confirmed and evidence is strong: referral to legal team + account suspension
+7. If fraud is cleared: claim re-enters normal review queue
+
+---
+
+## 8. Exclusion Schedule
+
+Claims meeting any of the following criteria are denied. Denial reason codes are recorded in
+the `adjudicate_claim_case` instruction and hashed as the denial reason in the audit trail.
+
+| Code | Exclusion category | Trigger |
+|---|---|---|
+| `EXCL_5_1` | Elective / pre-planned procedure | Procedure was scheduled before policy activation, or is cosmetic, or is not medically urgent |
+| `EXCL_5_2` | Intentional self-harm | Clinical record contains evidence of self-inflicted injury (absolute exclusion — no appeal) |
+| `EXCL_5_3` | Dental and oral conditions | Primary diagnosis is dental, periodontal, or orthodontic in nature |
+| `EXCL_5_4` | Chronic disease management | Visit is for routine management, prescription refill, or monitoring of a pre-existing chronic condition |
+| `EXCL_5_5` | Obesity / weight-loss surgery | Procedure is bariatric or weight-management in nature |
+| `EXCL_5_6` | Substance dependence treatment | Admission is for detox, rehabilitation, or management of substance dependence |
+| `EXCL_8_2` | Fraud / misrepresentation | Evidence of deliberate falsification, document manipulation, or identity misrepresentation |
+| `EXCL_PRE` | Pre-existing condition (waiting period) | Condition onset is within the 7-day pre-enrollment waiting period |
+| `EXCL_WIN` | Outside coverage window | Incident date is outside the active policy window |
+| `EXCL_CTX` | Non-covered travel context | Care did not occur during covered travel or event |
+
+---
+
+## 9. Claim State Machine
+
+### 9.1 Onchain States (ClaimCase / Obligation)
+
+```
+                          ┌─────────────────────────────────┐
+                          │         CLAIM LIFECYCLE          │
+                          └─────────────────────────────────┘
+
+   open_claim_case                    adjudicate_claim_case
+        │                                     │
+        ▼                                     ▼
+  [PROPOSED] ──────────── evidence ────────► [APPROVED] ──► reserve_obligation ──► [RESERVED]
+      │                    review                │                                       │
+      │                                          │                                       ▼
+      │                                    [DENIED] ◄──────────────────────────── settle_obligation
+      │                                          │                                       │
+      │                                    (end state)                                   ▼
+      │                                                                           [SETTLED / IMPAIRED]
+      │
+      └────────────────────────────────────────► [CANCELED] (operator void before adjudication)
+```
+
+| Onchain state | Instruction | Economic consequence |
+|---|---|---|
+| `proposed` | `open_claim_case` | No money moved. Claim identity recorded. |
+| `evidence_attached` | `attach_claim_evidence_ref` | Evidence hash locked onchain. No money moved. |
+| `attested` | `attest_claim_case` | Oracle has signed the evidence hash. No money moved. |
+| `approved` | `adjudicate_claim_case` (approve) | Decision recorded. Tier and amount confirmed. No money moved yet. |
+| `denied` | `adjudicate_claim_case` (deny) | Denial reason hash recorded. No money moved. End state. |
+| `reserved` | `reserve_obligation` | USDC reserved on FundingLine. Encumbered reserve increases. |
+| `claimable` | `reserve_obligation` → settlement pending | Approved and reserved, awaiting settlement signer. |
+| `settled` | `settle_claim_case` / `settle_obligation` | USDC transferred to member (or delegate recipient). |
+| `impaired` | `mark_impairment` | Settled at less than booked amount. LP junior class absorbs delta. |
+| `canceled` | Operator void | Claim voided before adjudication. No economic impact. |
+
+### 9.2 Operator-Layer States (Offchain Workflow)
+
+These states exist in the operator review queue only. The onchain `ClaimCase` remains in
+`proposed` until the operator is ready to proceed.
+
+| Operator state | Meaning | Next action |
+|---|---|---|
+| `awaiting_evidence` | Member has not yet submitted documents | Await member submission (max 14 days, then deny) |
+| `evidence_review` | Operator is reviewing documents | Complete checklist within 24h internal target |
+| `fraud_hold` | Automatic or manual fraud flag triggered | Senior review within 72h |
+| `translation_pending` | Documents are not in English; awaiting certified translation | Await translation (max 5 business days) |
+| `additional_docs_required` | Checklist incomplete; member contacted for more documents | Await member response (max 7 days, then deny) |
+| `senior_review` | Complex case escalated to senior operator | Senior decision within 48h |
+| `legal_escalation` | Fraud confirmed or complex legal issue | Legal team engagement; no time cap |
+| `ready_to_adjudicate` | All checklist items complete; decision can be made | Proceed to `adjudicate_claim_case` |
+
+---
+
+## 10. Escalation Rules and Hierarchy
+
+### 10.1 Automatic Escalation Triggers
+
+| Condition | Escalation level |
+|---|---|
+| Event 7 Tier 3 or near-cap claim | Senior operator review required before approval |
+| Claim amount > $2,000 (Travel 30) | Senior operator review required before approval |
+| Any Tier 3 claim (Surgery + ICU) | Senior operator review required before approval |
+| 2+ automatic fraud flags | Senior operator review required before any action |
+| Member disputes a denial | Senior operator re-opens review (Phase 0: offchain; Phase 1: new ClaimCase) |
+| Operator checklist incomplete after 24h internal target | Escalate to claims team lead |
+| Translation pending > 5 business days | Escalate to claims team lead; consider requesting alternative documentation |
+| FundingLine free balance < 120% of reserved amount | Escalate to Plan Admin for reserve top-up |
+
+### 10.2 Escalation Hierarchy
+
+```
+Level 1 — Claims Operator (standard review)
+   ↓  [triggers above or 24h internal-target miss]
+Level 2 — Senior Claims Operator (enhanced review)
+   ↓  [fraud confirmed, legal question, member dispute unresolved]
+Level 3 — Claims Team Lead (final operational decision)
+   ↓  [confirmed fraud, litigation risk, policy ambiguity requiring legal input]
+Level 4 — Legal / Compliance Team
+```
+
+### 10.3 Member Dispute Process (Phase 0)
+
+In Phase 0, there is no onchain dispute-case state. Member appeals are handled as follows:
+
+1. Member notifies OmegaX Health via the oracle portal within 14 days of denial.
+2. Claims operator opens a **new** `ClaimCase` PDA with updated or additional evidence.
+3. Senior operator reviews the appeal claim independently of the original decision.
+4. The original denied `ClaimCase` is not modified — both the original denial and the appeal
+   result are recorded separately onchain. An external reviewer can correlate them via
+   the offchain claim manifest.
+5. Appeal decision is final in Phase 0. Phase 1 will add onchain dispute-case state.
+
+---
+
+## 11. Settlement States and Timing
+
+### 11.1 Internal Settlement Targets
+
+These are operating targets for staffing and queue design. They are not member-facing guarantees.
+
+| Stage | Internal target |
+|---|---|
+| Evidence review complete → adjudication | 24 hours from evidence submission |
+| Approval → reserve booking | 2 hours |
+| Reserve booked → USDC settlement | 48 hours |
+| Fraud hold → senior review decision | 72 hours |
+| Additional docs requested → timeout denial | 7 days from member notification |
+| Evidence awaited → timeout denial | 14 days from claim opening |
+
+### 11.2 Settlement Mechanics
+
+**Preferred settlement asset**: USDC (SPL token, `hWMfBLfo8EBaRTCcrWV33xaUR8gK2iTtqPoQvEMHmvu` on devnet).
+
+**Multi-asset payout rails (protocol v0.3.2+)**: `settle_claim_case` and `settle_obligation` now
+require a matching `ReserveAssetRail` for the selected payout asset. The off-chain settlement router
+or oracle service selects the asset from the approved waterfall. The Solana program enforces the
+following before any value leaves custody:
+
+| Rail check | Requirement | Failure behaviour |
+|---|---|---|
+| Domain and mint binding | Rail must be bound to the same reserve domain and asset mint as the claim | Settlement fails |
+| Rail active | `rail.active == true` | Settlement fails |
+| Payout enabled | `rail.payout_enabled == true` | Settlement fails |
+| Oracle price freshness | Published price must be within the rail's freshness window | Asset counted as zero capacity — cannot be selected |
+| Oracle confidence | Price confidence must be ≤ `rail.max_confidence_bps` | Asset counted as zero capacity — cannot be selected |
+
+Approved fallback rails (where configured): PUSD, USDT, SOL, WBTC, WETH.
+The program **does not swap assets** and does not treat pending commitment custody as
+claims-paying reserve until activation/posting rules have made that true.
+
+Other settlement mechanics:
+- Payout is transferred atomically via `transfer_from_domain_vault` — the only authorized path
+  money leaves the reserve domain (PT-01/PT-02 — protocol-enforced).
+- Default payout wallet: `MemberPosition.wallet`.
+- Delegated payout wallet: `ClaimCase.delegate_recipient` if set via `authorize_claim_recipient`
+  before settlement. The delegate can only be set by the member, not by the operator (PT-04).
+- Protocol fee and oracle fee are carved out at settlement according to the fee vault configuration.
+- Net payout = approved amount − protocol fee − oracle fee.
+
+### 11.3 Partial Settlement and Impairment
+
+- **Partial approval**: adjudication records both the requested amount and the approved capped amount.
+  The obligation is booked and settled at the approved cap, never at the requested amount.
+- **Over-cap denial**: if invoiced amount exceeds the applicable benefit cap, the excess is denied.
+  The cap amount is approved and settled; the excess is recorded as `denied (over-cap)`.
+- **Impairment**: if the FundingLine cannot cover the full approved amount at settlement time,
+  `mark_impairment` records the shortfall. Junior capital class absorbs the impairment first;
+  senior class is shielded. The member receives the available amount, not the full approved amount.
+  Impairment is an exceptional state and triggers immediate Plan Admin notification.
+
+---
+
+## 12. Audit Trail Requirements
+
+Every claim must produce a complete, replayable audit trail satisfying the following requirements.
+
+### 12.1 Onchain Audit Trail (mandatory for all claims)
+
+An external reviewer must be able to answer all of the following from onchain state alone:
+
+| Question | Source |
+|---|---|
+| Who opened the claim and when? | `ClaimCase.claimant` + opening transaction signer + slot timestamp |
+| What was the policy series and coverage window? | `ClaimCase.policy_series` + `MemberPosition` |
+| What evidence was attached? | `ClaimCase.evidence_ref_hash` (immutable after first attestation) |
+| Who attested the evidence? | `ClaimAttestation` — oracle profile, attestation hash, schema hash/version |
+| Who adjudicated and what was the decision? | Adjudication transaction signer + `ClaimCase.state` + reason hash |
+| How much was approved and from which FundingLine? | `Obligation.reserved_amount` + `FundingLine` reference |
+| Was the payout recipient changed between approval and settlement? | `ClaimCase.delegate_recipient` history (recoverable from transaction logs) |
+| What was paid, to whom, and when? | Settlement transaction signature + vault balance delta + recipient wallet |
+| Were any fees collected? | Fee vault accrual counters in settlement transaction |
+
+### 12.2 Offchain Audit Trail (operator-maintained)
+
+The following should be retained in the operator's offchain claim manifest and made available only
+through authorized internal audit or third-party review processes:
+
+| Record | Retention period |
+|---|---|
+| Raw evidence documents (PHI) | Per approved compliance-retention policy, encrypted at rest, access-logged |
+| Operator review checklist completion record | Per approved compliance-retention policy |
+| Decision rationale note (for every denial or escalation) | Per approved compliance-retention policy |
+| Fraud review notes and outcome | Per approved compliance-retention policy |
+| Member communications log (portal messages, email) | Per approved compliance-retention policy |
+| Translation records (if applicable) | Per approved compliance-retention policy |
+| Appeal and dispute records | Per approved compliance-retention policy |
+
+### 12.3 Onchain / Offchain Boundary
+
+This boundary is a critical security and privacy design choice. It must not be blurred.
+
+| What lives onchain | What stays offchain |
+|---|---|
+| Claim identity, state, and lifecycle | Raw medical documents (PHI) |
+| Evidence hash (SHA-256 of full packet) | Actual invoice content, diagnoses, clinical notes |
+| Decision result and reason hash | Decision rationale narrative |
+| Reserve and settlement amounts | Member identity documents |
+| Transaction signatures (full audit graph) | Operator review notes |
+| Fee vault accrual | Fraud investigation records |
+
+Any document published to a public endpoint must never contain raw PHI.
+The `evidence_ref_hash` onchain is a tamper-evident commitment to the offchain packet — not a link to the content.
+
+### 12.4 Third-Party Audit Path
+
+An authorized third-party reviewer (for example, an LP, sponsor, or independent reviewer) can verify
+claim integrity without access to PHI using the following steps:
+
+1. Retrieve the `ClaimCase` PDA from any Solana RPC using the claim's transaction signature.
+2. Verify `ClaimCase.evidence_ref_hash` matches the hash of the full evidence packet (provided
+   by OmegaX Health under NDA with auditor).
+3. Verify `ClaimAttestation.evidence_ref_hash` matches the same hash — confirming the oracle
+   attested to an unmodified packet.
+4. Verify the adjudication transaction signer matches the registered `claims_operator` key.
+5. Verify settlement transaction via `transfer_from_domain_vault` — net payout, fee vaults, recipient.
+6. Cross-check `FundingLine.reserved` and `domain_asset_vault.balance` deltas.
+
+All six steps can be performed without accessing any PHI.
+
+---
+
+## 13. Denial Notification to Member
+
+When a claim is denied, the member receives:
+
+1. A notification via the OmegaX Health oracle portal within 2 hours of adjudication.
+2. The denial reason category (from §8 — no raw clinical language disclosed).
+3. Information on the appeal process (see §10.3).
+4. Confirmation that no money has moved and no reserve has been booked.
+
+Denial notifications must not:
+- Disclose the specific fraud flags that triggered a fraud hold.
+- Reference internal operator notes or checklist items.
+- Make representations about future policy eligibility.
+
+---
+
+## 14. Phase 0 vs Phase 1 Posture
+
+This spec governs Phase 0 launch. The following behaviors change in Phase 1:
+
+| Behavior | Phase 0 (this spec) | Phase 1 (future) |
+|---|---|---|
+| Dispute handling | Offchain — new ClaimCase opened for appeal | Onchain dispute-case state via `protocol-oracle-service` |
+| Oracle quorum | Single oracle authority per HealthPlan | Multi-attestation finality gate |
+| Fraud referral state | Offchain hold, ClaimCase stays `proposed` | Dedicated onchain `fraud_hold` state |
+| Operator audit trail | Offchain manifest maintained by OmegaX Health | Protocol-level operator action log |
+
+Any public-facing claim posture statement in Phase 0 must accurately represent the above. Specifically:
+appeals, disputes, and fraud holds are operator-workflow concerns in Phase 0, not decentralized
+on-chain state. Misrepresenting these as "decentralized claims adjudication" is a release-candidate
+risk and is explicitly prohibited.
+
+---
+
+## 15. References
+
+| Document | Path |
+|---|---|
+| Onchain claim truth chain | `docs/architecture/genesis-protect-claim-trace.md` |
+| Abstract claims model | `docs/architecture/decentralized-coverage-claims.md` |
+| Evidence schema (JSON) | `frontend/public/schemas/genesis-protect-acute-claim-v1.json` |
+| Actuarial workbook (updated May 2026) | `examples/genesis-protect-acute-actuarial-review/review-memo.md` |
+| 32 claim simulation scenarios | `examples/genesis-protect-acute-claims/genesis-acute-claim-simulations-v1.json` |
+| Mainnet privileged role controls | `docs/security/mainnet-privileged-role-controls.md` |
+| Operator runbook index | `docs/operations/runbooks.md` |
+| Protocol surface audit | `docs/testing/protocol-surface-audit.md` |
+| MagicBlock private claim room | `docs/architecture/magicblock-private-claim-room.md` |
+| Phase 0 mainnet surface gating | `docs/operations/phase0-mainnet-surface-gating.md` |
+| Full operational protect flow (KR 1.1) | `docs/architecture/genesis-protect-acute-full-protect-flow.md` |

--- a/docs/architecture/genesis-protect-acute-full-protect-flow.md
+++ b/docs/architecture/genesis-protect-acute-full-protect-flow.md
@@ -1,0 +1,503 @@
+# Genesis Protect Acute v1 — Full Protect Flow (Operational)
+
+> **Version**: 1.0  
+> **Author**: Manuel Soldatini — Protocol Verification & Claims  
+> **Status**: Draft — Internal  
+> **Date**: May 2026  
+> **Scope**: End-to-end operational flow from member onboarding through Phase 0 member payout, with provider settlement noted as a Phase 1 target.
+> This document is the **operational complement** to the onchain truth chain.
+> The onchain truth chain (what changes on Solana at each step) is documented separately in
+> [`genesis-protect-claim-trace.md`](./genesis-protect-claim-trace.md).  
+> The claims-processing specification (evidence requirements, fraud flags, escalation rules) is in
+> [`genesis-protect-acute-claims-processing-spec.md`](./genesis-protect-acute-claims-processing-spec.md).
+
+---
+
+## How to Read This Document
+
+The founder's `genesis-protect-claim-trace.md` answers: *"what changes onchain at each step?"*
+
+This document answers: *"what do the member, operator, oracle, and AI-assisted review tools do at each step,
+in what sequence, with what internal operating target, and what happens when things go wrong?"*
+
+Together they form the complete picture of the Genesis Protect Acute claim lifecycle — technical
+truth chain on one side, operational workflow on the other.
+
+---
+
+## 1. Overview: The Protect Flow in One View
+
+```
+MEMBER JOURNEY                    OPERATOR / ORACLE WORKFLOW               ONCHAIN EVENTS
+──────────────                    ──────────────────────────               ──────────────
+1. Onboarding & policy mint  ───► Policy series check + premium           PolicySeries, MemberPosition,
+   (wallet + USDC payment)         confirmation                             record_premium_payment
+
+2. Incident occurs           ───► [no operator action at this stage]       —
+
+3. Evidence upload           ───► Oracle portal receipt + auto-checks       —  (offchain)
+   (oracle portal)                 (completeness, format, language)
+
+4. Claim intake              ───► Operator opens ClaimCase                  open_claim_case
+                                   (or member self-submits)
+
+5. Automated review          ───► AI pre-screening of documents             —  (offchain)
+   (AI pre-screening)              Flags anomalies → operator queue
+
+6. Human review trigger      ───► Operator receives flagged or              —  (offchain)
+                                   standard review item in queue
+
+7. Evidence hash attachment  ───► Operator attaches hash of                 attach_claim_evidence_ref
+                                   reviewed evidence packet
+
+8. Oracle attestation        ───► Oracle signs the evidence hash            attest_claim_case
+   (standard or MagicBlock)        Standard path or TEE private path        (+ ClaimAttestation PDA)
+
+9. Adjudication              ───► Operator approves/denies +                adjudicate_claim_case
+                                   tier classification                       obligation → reserved
+
+10. Reserve booking          ───► Obligation reserved against               reserve_obligation
+                                   FundingLine
+
+11. Payout / Settlement      ───► Asset rail selected → USDC                settle_claim_case /
+                                   (or fallback) transferred                  settle_obligation
+
+12. Provider settlement      ───► Direct provider payment workflow           —  (Phase 1 target)
+    (Phase 0: member wallet)       (Phase 0: member receives funds)
+```
+
+---
+
+## 2. Stage 1 — Member Onboarding and Policy Mint
+
+### 2.1 Member actions
+
+1. Member connects wallet to the OmegaX Health portal (or Breakpoint registration flow).
+2. Member selects a product SKU: **Event 7** ($39 / 7 days) or **Travel 30** ($99 / 30 days).
+3. Member reviews coverage terms and exclusion schedule (Phase 0: mandatory pre-sign review via
+   `protocol-transaction-review` frontend component).
+4. Member pays premium in USDC — the `record_premium_payment` instruction is executed.
+5. A `MemberPosition` PDA is created on Solana, wallet-linked, with an active coverage window.
+
+### 2.2 Operator checks at onboarding
+
+| Check | How it is enforced |
+|---|---|
+| Reserve pool has sufficient capacity | Frontend reads `FundingLine.free_balance` — mint is blocked if VaR 99.5% ceiling would be breached |
+| Policy series is not paused | `HealthPlan.emergency_pause == false` — protocol-enforced |
+| Member wallet not on sanctions list | Offchain pre-mint check by oracle service before `record_premium_payment` is submitted |
+| Venue cap (Event 7 only) | Operator monitors per-venue policy count — hard cap of 50 policies per named event/venue |
+
+### 2.3 What the member receives
+
+- Solana wallet confirmation with `MemberPosition` address
+- Coverage window start and end dates
+- Summary of benefit schedule and exclusion categories
+- Link to oracle portal for claim submission
+
+**Internal target**: onboarding is automated, and policy mint confirmation should complete after normal Solana confirmation.
+
+---
+
+## 3. Stage 2 — Incident Occurs
+
+No operator action is required or possible at this stage. The member experiences a medical event
+and seeks care at any licensed facility.
+
+### 3.1 What the member should do immediately
+
+1. Seek care — coverage is in effect the moment the `MemberPosition` is active.
+2. Request an **itemized invoice** from the facility (not a summary bill).
+3. Request a **discharge summary or doctor note** before leaving the facility.
+4. Keep all receipts and payment proofs.
+5. Keep location evidence: boarding pass, hotel receipt, event badge, or equivalent.
+
+### 3.2 What the member should NOT do
+
+- Do not self-diagnose and choose a facility based on the benefit schedule — seek appropriate care first.
+- Do not request that the facility omit or alter any diagnosis from the record.
+- Do not wait until the coverage window expires to submit — the claim must be **opened within
+  the coverage window or within 14 days of expiry**, whichever is later.
+
+**Note on incapacity**: If the member is incapacitated and cannot self-submit, the `plan_admin`
+or `claims_operator` can open the claim case on their behalf, with the member's wallet address
+as the claimant. The operator cannot change the beneficiary wallet at this stage.
+
+---
+
+## 4. Stage 3 — Evidence Upload via Oracle Portal
+
+### 4.1 Portal submission flow
+
+The OmegaX Health oracle portal is the **only authorized channel** for claim evidence submission.
+Evidence submitted via email, social media, or any other channel is not accepted.
+
+| Step | Member action | System action |
+|---|---|---|
+| 1 | Logs in to oracle portal with claim wallet | Session verified against MemberPosition |
+| 2 | Selects "Submit new claim" | Pulls active MemberPosition details |
+| 3 | Uploads mandatory documents (see §5 of claims spec) | Auto-format check: PDF/image, min resolution, file size limit |
+| 4 | Fills in basic claim form: incident date, facility name, country, type of care | Pre-populates from uploaded document OCR (AI-assisted, human-verified) |
+| 5 | Confirms submission | Claim record created in operator queue; member receives confirmation |
+
+### 4.2 Automated pre-checks at upload (AI layer)
+
+Before the claim enters the human review queue, the following automated checks run:
+
+| Check | Tool | Outcome on failure |
+|---|---|---|
+| **Document completeness** | Schema validator against `genesis-protect-acute-claim-v1.json` | Member prompted to resubmit missing document |
+| **Incident date extraction** | OCR + date parser | Flagged for human verification if date is ambiguous |
+| **Facility name and country extraction** | OCR + entity recognition | Flagged for human verification if unclear |
+| **Language detection** | Language classifier | If not English: translation required flag → queue paused |
+| **Duplicate hash detection** | SHA-256 of document set vs prior submissions | If match: automatic fraud flag — senior review triggered |
+| **Exclusion keyword scan** | NLP classifier against exclusion schedule | Soft flag: operator sees highlighted terms in review queue |
+| **Invoice format check** | Structure validator | If no itemization: member notified to request itemized bill |
+
+AI pre-screening is **advisory only**. No AI flag alone triggers a denial. All flags are reviewed
+by a human operator before any adjudication decision is made.
+
+### 4.3 Evidence that cannot be accepted
+
+- Documents in languages other than English without a certified translation
+- Handwritten invoices not on official facility letterhead
+- PDFs with password protection or corrupted files
+- Screenshots of documents (printable PDF or scan required)
+- Documents with visible redactions over clinically relevant fields
+
+---
+
+## 5. Stage 4 — Claim Intake
+
+### 5.1 Who opens the ClaimCase
+
+| Scenario | Who calls `open_claim_case` | Signer check |
+|---|---|---|
+| Standard self-submission | Member via oracle portal UI (portal submits on behalf) | `args.claimant == member_position.wallet` |
+| Incapacitated member | Claims operator | `authority == claims_operator` AND `args.claimant == member_position.wallet` |
+| Operator batch intake | Claims operator | Same as above |
+
+### 5.2 Intake validation (protocol-enforced)
+
+At the moment `open_claim_case` is submitted, the Solana program checks:
+
+- Protocol emergency pause is clear
+- MemberPosition is active and wallet matches claimant
+- FundingLine is open
+- No duplicate ClaimCase for the same MemberPosition and policy window
+
+If any check fails, the instruction reverts — no ClaimCase is created.
+
+### 5.3 Member notification at intake
+
+Member receives an oracle portal notification:
+- Claim reference number (derived from ClaimCase PDA address)
+- Confirmation that the claim is under review
+- Internal review target (24 hours)
+- List of any documents still awaited
+
+---
+
+## 6. Stage 5 — Automated Review and AI Pre-Screening
+
+After intake, the claim enters the automated review pipeline before any human operator touches it.
+
+### 6.1 AI pre-screening checks (expanded)
+
+| Check | Input | Output |
+|---|---|---|
+| **Eligibility gate** | Incident date vs MemberPosition activation date, coverage window | Pass / Fail with reason |
+| **Waiting period check** | Illness onset date vs enrollment date | Pass / Fail |
+| **Tier classification suggestion** | Clinical summary + invoice | Suggested tier (T1/T2/T3) with confidence score |
+| **UCR benchmark** (Travel 30 only) | Invoice line items vs UCR database for care country | Line-item UCR flags |
+| **Duplicate claim detection** | Evidence hashes vs all prior claims | Match / No match |
+| **Exclusion screen** | Full clinical text vs exclusion taxonomy | Flagged exclusions with confidence scores |
+| **Fraud signal scoring** | All documents + claim metadata | Fraud risk score (Low / Medium / High) |
+
+### 6.2 AI output routing
+
+| AI risk score | Queue destination | Human review target |
+|---|---|---|
+| Low — no flags | Standard review queue | 24 hours |
+| Medium — soft flags | Enhanced review queue (senior operator) | 12 hours |
+| High — hard flags | Fraud hold queue | 2 hours (senior) |
+| Critical — known exclusion | Auto-hold for human confirmation before denial | 4 hours |
+
+**The AI never adjudicates.** It sorts, flags, and pre-fills the operator review interface.
+
+---
+
+## 7. Stage 6 — Human Review Trigger and Oracle Workflow
+
+### 7.1 Standard human review (Phase 0 — operator-backed oracle)
+
+The claims operator receives the claim in their review queue with:
+- Pre-filled claim form from AI (incident date, facility, country, tier suggestion)
+- All uploaded documents with AI highlights on flagged sections
+- Checklist auto-populated from `genesis-protect-acute-claim-v1.json` schema
+- Fraud risk score and individual flag details
+
+The operator works through the checklist (see §6 of claims spec). If all items pass:
+1. Operator confirms the evidence packet is complete and accurate
+2. System assembles the **evidence packet** (all documents + AI review log + operator checklist)
+3. System computes SHA-256 hash of the full packet
+4. Operator reviews the hash and calls `attach_claim_evidence_ref` onchain
+
+### 7.2 MagicBlock private review path (optional — Phase 0 demo)
+
+For high-sensitivity claims or when TEE-verified AI processing is required:
+
+1. Claims operator prepares a **redacted claim packet** (hashed, not plaintext onchain)
+2. `open_review_session` creates a review session PDA on base Solana
+3. `delegate_review_session` delegates the PDA to MagicBlock Ephemeral Rollup
+4. TEE reviewer inspects the private packet inside the TEE — raw PHI is not written to Solana or public endpoints
+5. TEE emits a **hash-bounded review artifact** (no clinical content)
+6. `record_private_review` records only hashes and status — only the registered reviewer can write
+7. `record_private_payment_ref` stores the private payment reference hash (if reimbursement applies)
+8. `commit_and_close_review_session` commits and undelegates back to base Solana
+9. The committed review artifact hash feeds into `attest_claim_case` via the normal path
+
+**Phase 0 status**: Demo-grade. The reserve kernel (obligation, settlement) is not routed through
+this path in Phase 0. It demonstrates the privacy architecture for investor/partner audiences.
+
+### 7.3 When a human escalates mid-review
+
+If the operator discovers an issue that was not caught by the AI:
+
+| Issue found | Operator action | Internal target |
+|---|---|---|
+| Document quality insufficient | Contacts member via portal — requests resubmission | Member has 7 days |
+| Translation missing | Requests certified translation | 5 business days |
+| Fraud suspicion (manual) | Moves to fraud hold; notifies senior operator | Senior review: 72 hours |
+| High-value claim (above threshold) | Escalates to senior operator for co-review | Senior decision: 48 hours |
+| Legal ambiguity (e.g., exclusion borderline) | Escalates to claims team lead | Team lead: 48 hours |
+| Incapacity or emergency (member unreachable) | Documents and proceeds with available evidence | No additional delay |
+
+---
+
+## 8. Stage 7 — Oracle Attestation
+
+After the operator attaches the evidence hash (`attach_claim_evidence_ref`), the oracle authority
+signs the attestation via `attest_claim_case`.
+
+### 8.1 Oracle attestation requirements (protocol-enforced)
+
+| Requirement | Enforcement |
+|---|---|
+| Oracle profile is active and claimed | Protocol check on `OracleProfile.status` |
+| Schema is governance-verified | `attestation_ref_hash` must reference `genesis-protect-acute-claim` v1 schema |
+| Evidence hash matches | `attestation_ref_hash == claim_case.evidence_ref_hash` |
+| No oracle-finality hold on the plan | `HealthPlan.oracle_finality_hold == false` |
+| Correct oracle authority for funding source | Premium/sponsor claims: plan's `oracle_authority`; LP-backed claims: pool oracle approval + `POOL_ORACLE_PERMISSION_ATTEST_CLAIM` |
+
+### 8.2 What the oracle attestation records onchain
+
+A `ClaimAttestation` PDA is created containing:
+- Attestation hash
+- Evidence ref hash (must match `ClaimCase.evidence_ref_hash`)
+- Decision support hash
+- Schema hash and version
+- Oracle profile reference
+- LP pool / allocation reference (if applicable)
+- Slot timestamp
+
+**Once attested, evidence is immutable.** If the member needs to submit new evidence (e.g., after
+receiving more-info-needed notification), a **new ClaimCase** must be opened. The original attested
+claim is not modified.
+
+---
+
+## 9. Stage 8 — Adjudication (Decision)
+
+### 9.1 Decision types
+
+| Decision | Instruction | Onchain result |
+|---|---|---|
+| **Approve — full amount** | `adjudicate_claim_case` | `state = approved`, tier and amount recorded |
+| **Approve — partial (over-cap)** | `adjudicate_claim_case` | Approved amount = tier cap; excess recorded as denied |
+| **Deny — exclusion** | `adjudicate_claim_case` | `state = denied`, exclusion reason hash recorded |
+| **Deny — fraud** | `adjudicate_claim_case` | `state = denied`, fraud reason hash recorded |
+| **Deny — insufficient evidence** | `adjudicate_claim_case` | `state = denied`, reason hash recorded |
+| **Hold — more info needed** | No onchain action yet | Claim stays `proposed`; operator waits for new evidence |
+
+### 9.2 Tier classification at adjudication
+
+The operator confirms (or overrides) the AI-suggested tier classification based on the full evidence review:
+
+| Tier | Event 7 benefit | Travel 30 fixed | Travel 30 top-up |
+|---|---|---|---|
+| T1 — ER same-day | $150 | $250 | UCR-benchmarked top-up, total capped at $3,000 |
+| T2 — Overnight | $500 | $1,000 | UCR-benchmarked top-up, total capped at $3,000 |
+| T3 — Surgery + ICU | $1,000 | $2,500 | UCR-benchmarked top-up, total capped at $3,000 |
+
+For Travel 30 reimbursement top-up: the operator calculates
+`min(UCR_eligible_itemized_cost - fixed_tier_benefit, 3000 - fixed_tier_benefit)` so the
+total approved amount remains within the $3,000 aggregate cap.
+
+### 9.3 Denial notification timing
+
+Within 2 hours of adjudication, the member receives:
+- Denial reason category (not raw clinical detail or fraud flag language)
+- Information on the Phase 0 appeal process (new ClaimCase with additional evidence)
+
+---
+
+## 10. Stage 9 — Reserve Booking and Settlement
+
+### 10.1 Reserve booking (`reserve_obligation`)
+
+After approval, the obligation is reserved against the appropriate FundingLine(s):
+
+| Funding source | Reserve routing |
+|---|---|
+| Event 7 (sponsor lane) | Split: premium FundingLine first, then sponsor backstop FundingLine |
+| Travel 30 (LP-backed) | Split: premium FundingLine + LP allocation (junior class first) |
+
+`FundingLine.reserved_amount` increases. The encumbered reserve figure visible on the
+public protocol console moves up. No USDC has moved yet.
+
+### 10.2 Payout settlement (`settle_claim_case` / `settle_obligation`)
+
+The settlement router selects the payout asset from the approved waterfall:
+
+```
+Preferred: USDC
+Fallback (if USDC rail fails freshness/confidence check): PUSD → USDT → SOL → WBTC → WETH
+```
+
+For each candidate asset, the Solana program checks (in order):
+1. `ReserveAssetRail` bound to same domain + asset mint ✓
+2. Rail active + payout enabled ✓
+3. Oracle price fresh (within freshness window) ✓
+4. Oracle confidence ≤ `max_confidence_bps` ✓
+
+The first asset that passes all checks is used. If no asset passes, settlement is deferred and
+the Plan Admin is notified immediately.
+
+Settlement transfers atomically via `transfer_from_domain_vault`:
+- Net payout to member wallet (or `delegate_recipient` if set)
+- Protocol fee carved out to protocol fee vault
+- Oracle fee carved out to oracle fee vault when a configured oracle fee applies
+
+### 10.3 Internal Settlement Targets
+
+These timings are internal operating targets for staffing and queue design, not member-facing guarantees.
+
+| Step | Internal target |
+|---|---|
+| Evidence uploaded → review complete | 24 hours |
+| Approval decision → reserve booked | 2 hours |
+| Reserve booked → USDC settlement | 48 hours |
+| Total: evidence upload → payout | **≤ 74 hours** (standard path) |
+| Total: evidence upload → payout (Tier 3 / senior review) | **≤ 120 hours** |
+
+---
+
+## 11. Stage 10 — Provider Settlement (Phase 0 → Phase 1)
+
+### 11.1 Phase 0 posture: member-wallet settlement
+
+In Phase 0, **all payouts go directly to the member's wallet** (or a delegated recipient wallet
+set by the member via `authorize_claim_recipient`). The member is responsible for paying the
+provider directly, or the payout supplements a payment the member has already made.
+
+This is the correct conservative posture for Phase 0:
+- No legal relationship between OmegaX and the provider is required
+- No provider onboarding is needed to launch
+- Settlement can proceed through the existing member-recipient rail once approved and once reserve,
+  oracle-quality, fee, and rail checks pass
+
+### 11.2 Phase 1 target: direct provider settlement
+
+In Phase 1, the oracle service (`protocol-oracle-service`) may introduce direct provider
+settlement, where the member authorizes routing to a provider wallet rather than the member wallet.
+
+Requirements before Phase 1 provider settlement can launch:
+- Provider has completed OmegaX KYB (Know Your Business) process
+- Provider wallet is registered in the OmegaX provider registry
+- Member has authorized provider as `delegate_recipient` during claim submission
+- Provider has agreed to accept USDC as payment for the specific claim
+
+### 11.3 Provider partnership pipeline (current status)
+
+The Phase 1 provider settlement path requires an active provider outreach program (KR 2.4 / KR 2.5).
+Target markets: UAE, Malaysia/Singapore, Web3 travel hubs. See `docs/operations/` for provider
+partnership runbooks as they are developed.
+
+---
+
+## 12. Internal Target Matrix (Complete Reference)
+
+These targets are for operational readiness. They should not be copied into public member-facing
+copy as guaranteed service levels.
+
+| Touchpoint | Internal target | Responsible party | Escalation if missed |
+|---|---|---|---|
+| Policy mint confirmation | Normal Solana confirmation | Protocol (automated) | — |
+| Oracle portal: upload confirmation | < 30 seconds | Oracle service | Engineering on-call |
+| AI pre-screening | < 5 minutes | Oracle service | Engineering on-call |
+| Standard review queue: operator picks up | < 2 hours from upload | Claims operator | Claims team lead |
+| Standard review: complete and attach hash | < 24 hours from upload | Claims operator | Claims team lead |
+| Enhanced review (medium AI flag) | < 12 hours from upload | Senior operator | Claims team lead |
+| Fraud hold: senior review decision | < 72 hours | Senior operator | Claims team lead + legal |
+| High-value claim (senior co-review) | < 48 hours | Senior operator | Claims team lead |
+| Translation pending | < 5 business days | Member (action) | Deny after deadline |
+| Additional docs requested | < 7 days | Member (action) | Deny after deadline |
+| Evidence awaited (no submission) | < 14 days | Member (action) | Deny after deadline |
+| Adjudication → reserve booking | < 2 hours | Claims operator | Claims team lead |
+| Reserve booked → settlement | < 48 hours | Claims operator + settlement router | Claims team lead |
+| Denial notification to member | < 2 hours post-adjudication | Oracle service (automated) | Claims operator manual |
+| Appeal acknowledgment | < 24 hours | Claims operator | Claims team lead |
+
+---
+
+## 13. Operator Staffing and Availability (Phase 0)
+
+Phase 0 launch requires the following minimum operator coverage to meet the above internal targets:
+
+| Role | Coverage | Responsibilities |
+|---|---|---|
+| **Claims Operator** | Business hours (5 days/week) + on-call | Standard review, evidence hash attachment, adjudication, settlement |
+| **Senior Claims Operator** | Business hours + on-call (24h for fraud hold) | Enhanced review, fraud holds, high-value approvals, member disputes |
+| **Claims Team Lead** | Business hours (available for escalations) | Target misses, policy ambiguities, team oversight |
+| **Oracle Authority (signing key)** | Automated (key management system) | Attestation signing (must not require human intervention per claim) |
+| **Plan Admin** | On-call (for emergency pauses, reserve alerts) | Emergency pause, FundingLine monitoring, reserve top-up |
+
+**Oracle key custody production requirement**: before production automation, the oracle authority
+signing key should be held in an HSM/KMS or equivalent secure key management system rather than a
+claims-operator hot wallet. The target workflow is that operators submit attestation requests to an
+oracle service that signs through the managed key boundary.
+
+---
+
+## 14. Onchain / Offchain Boundary Summary
+
+| What lives on Solana | What lives offchain |
+|---|---|
+| PolicySeries, MemberPosition (policy state) | Raw member identity documents |
+| ClaimCase PDA (claim identity, state, hashes) | Raw medical evidence (PHI) |
+| ClaimAttestation PDA (oracle signature, schema hash) | Operator review checklist |
+| Obligation PDA (reserve amount, FundingLine reference) | AI pre-screening logs |
+| Settlement transaction (vault delta, recipient, fees) | Fraud investigation notes |
+| Fee vault accruals | Member communications |
+| MagicBlock: review session hashes only | MagicBlock demo: private evidence packet handled by TEE/private reviewer adapter |
+
+The onchain record is the **truth** about what was decided and what was paid.
+The offchain record is the **evidence** supporting that truth.
+Neither is sufficient alone — both must be retained.
+
+---
+
+## 15. References
+
+| Document | Path |
+|---|---|
+| Onchain claim truth chain | `docs/architecture/genesis-protect-claim-trace.md` |
+| Claims processing specification (KR 1.2) | `docs/architecture/genesis-protect-acute-claims-processing-spec.md` |
+| MagicBlock private claim room | `docs/architecture/magicblock-private-claim-room.md` |
+| Abstract claims model | `docs/architecture/decentralized-coverage-claims.md` |
+| Phase 0 mainnet surface gating | `docs/operations/phase0-mainnet-surface-gating.md` |
+| Evidence schema (JSON) | `frontend/public/schemas/genesis-protect-acute-claim-v1.json` |
+| Actuarial workbook (May 2026) | `examples/genesis-protect-acute-actuarial-review/review-memo.md` |
+| 32 claim simulation scenarios | `examples/genesis-protect-acute-claims/genesis-acute-claim-simulations-v1.json` |
+| Solana instruction map | `docs/architecture/solana-instruction-map.md` |


### PR DESCRIPTION
Supersedes #90 by preserving Manuel's claims-operations docs and adding a signed corrective commit that aligns the public docs with current Genesis Protect launch truth.\n\nChanges:\n- Canonicalizes Event 7 and Travel 30 prices, caps, fixed tiers, and Travel 30 top-up cap.\n- Reframes SLA language as internal operating targets, not member guarantees.\n- Keeps Phase 0 as operator-backed oracle review, not decentralized adjudication.\n- Keeps MagicBlock as optional/demo-grade adjunct for Phase 0, not the production settlement kernel.\n- Reframes AI pre-screening, provider settlement, HSM/KMS custody, regulator/HIPAA claims, and evidence retention language as public-safe staged requirements.\n\nLocal validation:\n- npm run test:node\n- npm run semantic:readiness:check\n- npm run public:hygiene:check\n\nCo-authored-by: Manuel Soldatini <manuel.sold@gmail.com>