### PR TITLE
Polish protocol console navigation and design contract

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,198 @@
+# OmegaX Protocol Design System
+
+This is the UI/UX source of truth for the public OmegaX Protocol repository and
+its Next.js protocol console in `frontend/`.
+
+The console is not a marketing site, not a consumer checkout, and not a generic
+crypto admin dashboard. It is a public protocol control room for sponsors,
+operators, capital providers, auditors, oracle operators, and serious observers
+who need to understand the current state without confusing pending custody with
+active cover or claims-paying reserve.
+
+## Product Job
+
+The first useful action is understanding what the protocol can prove today:
+
+- what is live on the selected network
+- what is pending or operator-mediated
+- what is devnet-only or simulated
+- what is off-chain custody or external Protect flow
+- what action a connected wallet can safely attempt
+
+Every route must help a user answer one of those questions before it asks them
+to sign, configure, or interpret protocol state.
+
+## Visual Theme
+
+- Atmosphere: industrial, calm, protocol-native, and audit-friendly.
+- Density: 7/10. Dense enough for registers, ledgers, hashes, and route context;
+  never so dense that financial state becomes hard to scan.
+- Variance: 4/10. Use controlled asymmetry on `/overview`, then predictable
+  workbench structure on operating routes.
+- Motion: 3/10. Motion is status feedback, not decoration. Avoid deep animation
+  unless it clarifies loading, live sync, or state transition.
+- Shape: radius hierarchy is restrained. Repeated cards should stay at 8px or
+  less unless an existing protocol surface already uses a larger semantic shell.
+- Surface: prefer full-width workbench bands, tables, rails, and registers over
+  card stacks. Do not nest cards inside cards.
+
+## Brand Palette
+
+The existing palette is the protocol brand baseline. Do not replace it with a
+new palette unless the broader OmegaX brand direction explicitly changes.
+
+- Protocol Canvas `#F8F9FA` - light app background.
+- Protocol Canvas Dark `#0A1525` - dark app background.
+- Ceramic Surface `rgba(234, 237, 239, 0.97)` - primary panels.
+- Ceramic Surface Dark `rgba(17, 29, 47, 0.92)` - dark primary panels.
+- Protocol Ink `#191C1D` - primary light-mode text.
+- Protocol Ink Dark `#F0F1F2` - primary dark-mode text.
+- Muted Slate `#495A63` / `#94A3B8` - secondary labels and descriptions.
+- OmegaX Cyan `#33C5F4` - the single brand accent for active states, focus,
+  network sync, and selected protocol context.
+- Reserve Green `#19B47A` - semantic success only.
+- Warning Amber `#F5A524` - semantic caution only.
+- Risk Red `#BA1A1A` / `#FF7A7A` - semantic danger only.
+
+Rules:
+
+- Cyan is a surgical accent, not a fill color for every component.
+- Green, amber, and red are never brand colors. Pair them with text or icons;
+  never rely on color alone.
+- Do not introduce purple, neon blue, beige, brown, orange, or one-note dark
+  slate themes.
+- No pure black. No outer neon glows. No gradient-orb decoration.
+
+## Typography
+
+The current font stack is intentional:
+
+- Display: Newsreader for restrained editorial emphasis and large proof moments.
+- UI sans: Space Grotesk for navigation, labels, body UI, and route chrome.
+- Mono: Fira Code for hashes, addresses, timestamps, build stamps, and raw
+  protocol amounts.
+
+Rules:
+
+- Use display type for first-level route framing only.
+- Use smaller, tighter headings inside panels, rails, tables, and drawers.
+- Numbers, hashes, addresses, and protocol identifiers should use mono or
+  tabular-number treatment.
+- Letter spacing must be 0 for normal prose. Uppercase micro-labels may use
+  positive tracking only when already established locally.
+- Do not scale font size with viewport width. Use explicit responsive steps.
+
+## Route Responsibility Table
+
+| Route | Primary user | Primary question answered | Allowed actions | Guardrails |
+| --- | --- | --- | --- | --- |
+| `/` | First-time observer | Where do I begin? | Redirect to `/overview` | Root must match docs and tests. |
+| `/overview` | Public observer, sponsor, auditor | What is the system state and where should I go next? | Navigate to workbenches | Demo mode must be explicit via `?demo=1`. |
+| `/plans` | Sponsor/operator | What plan, coverage product, claims, members, and treasury state exist? | Operator actions only when role-gated | No LP-capital language as sponsor budget. |
+| `/plans/new` | Plan operator | What will this launch create and who signs? | Create configured protocol objects after review | No root product-type field, no hidden write consequences. |
+| `/capital` | Capital provider, auditor | What capital is posted, allocated, queued, or impaired? | LP/operator actions when role-gated | Queue and pending values must never contradict. |
+| `/claims` | Claims operator, auditor | Which claim cases need review and what reserve effect exists? | Contextual claim handoff only | Phase 0 operator-backed review must stay explicit. |
+| `/members` | Sponsor/operator | Which wallets have coverage rights? | Redirect into `/plans?tab=members` | Member rights are not active cover by themselves. |
+| `/governance` | Governance/operator | What controls, proposals, and authorities are active? | Scoped proposal/bootstrap actions | Disabled actions need reason and consequence. |
+| `/oracles` | Oracle operator, auditor | Which operators, schemas, disputes, and staking states are visible? | Registry/profile actions when role-gated | No raw health data, only public proof metadata. |
+| `/schemas` | Builder, auditor, governance | What outcome schemas and series comparability rules are live? | Schema governance handoff only | Schema mismatch is a route-level warning, not a blank state. |
+| `/coverage/technical-terms` | Buyer, reviewer, operator | What public coverage technical terms are referenced? | Read-only | Genesis is bounded launch truth, not universal coverage. |
+| `/coverage/risk-disclosures` | Buyer, reviewer, operator | What risks and reserve limits are disclosed? | Read-only | Claims-paying reserve must stay strictly defined. |
+| `/magicblock-claim-room` | Reviewer, demo auditor | Is a private-review receipt verifiable? | Devnet receipt lookup only | Mainnet fails closed until separately approved. |
+| `/pools/*`, `/staking` | Legacy users | Where did the old surface move? | Redirect only | No retired pool-first language in active UI. |
+
+## State Map
+
+```mermaid
+flowchart TD
+  Overview["/overview: public observer systems map"] --> Plans["/plans: sponsor/operator plan state"]
+  Plans --> Reservation["Founder reservation: off-chain pending custody"]
+  Plans --> Quote["Protect quote: eligibility and pricing"]
+  Plans --> Activation["Activation: posted premium, backstop, or LP capital"]
+  Activation --> Cover["Active cover"]
+  Activation --> Reserve["Claims-paying reserve"]
+  Reservation -. "no reserve impact until activation/posting" .-> Reserve
+  Quote -. "not active cover by itself" .-> Cover
+  Simulator["Devnet simulator: QA/demo only"] -. "not mainnet coverage" .-> Cover
+  Claims["ClaimCase and Obligation state"] --> Reserve
+  MagicBlock["MagicBlock private-review receipt"] -. "hash receipt only" .-> Claims
+```
+
+Copy and UI labels must preserve this map. If a UI change makes any dotted edge
+look like a solid edge, it is a high-severity product bug.
+
+## Component Rules
+
+- Buttons use icons when an icon exists. Use lucide icons in React components.
+- Primary CTAs must name the action consequence, not just say "Continue".
+- Disabled actions must explain the missing prerequisite next to the control.
+- Every write path needs pre-sign review or an equivalent consequence summary.
+- Loading states preserve layout with skeletons or stable panels.
+- Empty states explain what is absent and where the user can go next.
+- Error states fail closed. RPC failure is not an empty success state.
+- Menus, drawers, disclosures, tabs, and filters must close on outside click,
+  route change, and `Esc` where applicable.
+- Long addresses middle-truncate in dense UI and expose full values in detail
+  or title text.
+
+## Responsive Rules
+
+- Desktop is the primary operating surface. Mobile must remain good enough for
+  review, inspection, and route navigation.
+- No horizontal page scroll below 768px.
+- Touch targets are at least 44px.
+- Tables and registers must convert into stacked rows or scroll-contained
+  regions with visible context labels.
+- Footers and fixed chrome must never cover active route content.
+- Text must never overflow buttons, pills, cards, or register rows.
+
+## Accessibility Rules
+
+- Every interactive control needs keyboard focus.
+- Focus styles must be visible in light and dark modes.
+- Status must not rely on color only.
+- `aria-current`, `aria-expanded`, `aria-controls`, and `role` should be used
+  for navigation, tabs, menus, and drawers.
+- Reduced-motion preferences must disable decorative or continuous animation.
+
+## Copy Rules
+
+Use plain protocol truth:
+
+- "Posted claims-paying reserve" for funds that can back claims now.
+- "Pending custody" for Founder reservations before activation or posting.
+- "Eligibility/pricing quote" for Protect quote state.
+- "Active cover" only after coverage is actually activated.
+- "Devnet demo" or "simulator" for non-mainnet proof flows.
+- "Phase 0 operator-backed review" for current claim review posture.
+
+Banned:
+
+- Do not call pending reservations active cover.
+- Do not call treasury inventory claims-paying reserve until posting rules pass.
+- Do not describe devnet simulator activity as live mainnet coverage.
+- Do not imply MagicBlock receipt verification settles claims or moves funds.
+- Do not use vague hype copy like "next-gen", "seamless", "unleash", or
+  generic trust claims without protocol evidence.
+
+## Stitch Note
+
+Stitch MCP was checked during the May 2026 polish pass. The API key and service
+were healthy through `npx -y @_davideast/stitch-mcp@latest doctor`, but no
+OmegaX Protocol-specific Stitch project or screen was available through callable
+tools. The CLI project viewer exposed unrelated projects and then failed because
+raw terminal mode is unavailable in this Codex environment; direct tool schema
+calls also failed on a Stitch schema reference error. Treat Stitch as design
+inspiration only for this pass.
+
+## Anti-Slop Bans
+
+- No landing-page shell for the protocol console.
+- No generic crypto-dashboard hero.
+- No card-inside-card layout.
+- No decorative orbs, bokeh, or gradient blobs.
+- No fake round-number proof claims.
+- No stock imagery for protocol state.
+- No hidden fallback from failed live reads to fixture-looking success.
+- No public-safe docs or UI that mention private endpoints, private key paths,
+  operator secrets, or machine-local evidence.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,47 @@
 # OmegaX Protocol
 
-OmegaX Protocol is a Solana settlement layer for builders creating health apps, oracle services, sponsor programs, and outcome-triggered capital flows.
+OmegaX Protocol's current launch job is concrete: help a sponsor fund Travel 30 acute travel protection for a cohort, show whether the reserve posture can support it, and trace every claim from evidence to payout.
+
+Plainly: a sponsor can fund a protected group, see what backs the promise, and audit what happened when a claim is reviewed or paid.
+
+The current public launch reference is Genesis Protect Acute. `Travel 30` is the primary SKU, with a 30-day window and a 5,000 USDC aggregate cap. `Event 7` is the short-window cohort/demo SKU, with a 7-day window and a 3,000 USDC fixed-benefit cap. Both remain bounded launch surfaces: not broadly live insurance today, and Phase 0 claim review is operator-backed rather than fully decentralized.
 
 On Solana devnet beta today, the public surface in this repository can already anchor:
 
-- normalized outcome events produced by OmegaX Health or future compatible oracle operators
+- sponsor-funded reward or protection lanes with explicit reserve and funding-line attribution
 - operator-mediated member enrollment, claim intake, obligations, reserve booking, and payouts
-- sponsor-funded reward or protection lanes
 - LP-facing capital pools, classes, allocations, redemptions, and impairment handling
+- normalized outcome events produced by OmegaX Health or future compatible oracle operators
 
 ## Start Here
 
-- [SDK Overview](https://docs.omegax.health/docs/sdk/sdk-overview)
-- [SDK Getting Started](https://docs.omegax.health/docs/sdk/sdk-getting-started)
-- [Oracle Event Production](https://docs.omegax.health/docs/oracle/event-production)
+- [Genesis Protect V1 Curve Launch Plan](./docs/architecture/genesis-protect-v1-curve-launch.md)
+- [Genesis Protect Claim Trace](./docs/architecture/genesis-protect-claim-trace.md)
 - [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
 - [Repository Documentation Map](./docs/README.md)
+- [SDK Overview](https://docs.omegax.health/docs/sdk/sdk-overview)
 
 ## Choose Your Path
+
+### Sponsors and protection operators
+
+Fund a Travel 30 cohort, inspect reserve sufficiency, follow claim obligations, and prove payouts without treating pending custody, premiums, LP capital, or claims-paying reserve as the same thing.
+
+Start with:
+
+- [Genesis Protect V1 Curve Launch Plan](./docs/architecture/genesis-protect-v1-curve-launch.md)
+- [Genesis Protect Claim Trace](./docs/architecture/genesis-protect-claim-trace.md)
+- [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
+
+### Capital integrators
+
+Connect pools, classes, allocations, redemption queues, and reserve-domain accounting to the same Travel 30 / Event 7 launch truth.
+
+Start with:
+
+- [Protocol Architecture](https://docs.omegax.health/docs/protocol/architecture)
+- [Public Release Gate](./docs/operations/public-release-gate.md)
+- [Release v0.3.1](./docs/operations/release-v0.3.1.md)
 
 ### Oracle and event producers
 
@@ -38,16 +62,6 @@ Start with:
 - [SDK Getting Started](https://docs.omegax.health/docs/sdk/sdk-getting-started)
 - [SDK Workflows](https://docs.omegax.health/docs/sdk/sdk-workflows)
 - [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
-
-### Sponsor and capital integrators
-
-Connect sponsor budgets, policy series, funding lines, pools, classes, and allocations to one reserve-aware settlement kernel.
-
-Start with:
-
-- [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
-- [Protocol Architecture](https://docs.omegax.health/docs/protocol/architecture)
-- [Release v0.3.1](./docs/operations/release-v0.3.1.md)
 
 ## What Exists Today on Devnet Beta
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,17 @@
 
 This directory contains the public documentation set for `omegax-protocol`.
 
-If you are an external builder, start with the public docs site before diving into the repo-internal architecture notes here.
+If you are evaluating the current Genesis launch surface, start with the sponsor Travel 30 path below before diving into the broader repo-internal architecture notes.
+
+## Sponsor Travel 30 start here
+
+- [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) — primary Travel 30 launch recommendation, Event 7 cohort/demo boundary, reserve gating, and current cap doctrine
+- [Genesis Protect Claim Trace](./architecture/genesis-protect-claim-trace.md) — one Travel 30 claim from intake through evidence, attestation, obligation, reserve impact, and payout
+- [Genesis Protect Acute Claims Processing Spec](./architecture/genesis-protect-acute-claims-processing-spec.md) — Phase 0 claim workflow, evidence rules, escalation, denial, and payout timing
+- [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
+- [Protocol Architecture](https://docs.omegax.health/docs/protocol/architecture)
+
+This path is intentionally launch-truth-first: `Travel 30` is the primary SKU, `Event 7` is the short-window cohort/demo SKU, and Phase 0 claims remain operator-backed rather than fully decentralized.
 
 ## External builder start here
 
@@ -73,6 +83,9 @@ If you are an external builder, start with the public docs site before diving in
 
 ## Audience Guide
 
+- Use [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) when deciding how a sponsor-backed Travel 30 cohort should launch, what Event 7 is allowed to mean, and how reserve gating constrains the promise.
+- Use [Genesis Protect Claim Trace](./architecture/genesis-protect-claim-trace.md) when a sponsor, operator, or reviewer needs to follow one claim from evidence through payout without reading the whole program.
+- Use [Genesis Protect Acute Claims Processing Spec](./architecture/genesis-protect-acute-claims-processing-spec.md) when checking Phase 0 claim operations, evidence requirements, denial/appeal posture, and payout timing.
 - Use [SDK Overview](https://docs.omegax.health/docs/sdk/sdk-overview) when you want the fastest public explanation of what builders can ship on OmegaX today.
 - Use [SDK Getting Started](https://docs.omegax.health/docs/sdk/sdk-getting-started) when you want to connect a client and choose the right builder workflow on devnet beta.
 - Use [Oracle Event Production](https://docs.omegax.health/docs/oracle/event-production) when you are designing an oracle, signal-normalization layer, or event pipeline.
@@ -83,7 +96,6 @@ If you are an external builder, start with the public docs site before diving in
 - Use [Solana Program Architecture](./architecture/solana-program-architecture.md) to understand the on-chain program layout and reviewer read order.
 - Use [Solana Instruction Map](./architecture/solana-instruction-map.md) when tracing an instruction from entrypoint to handler, accounts, and helpers.
 - Use [Decentralized Coverage Claims](./architecture/decentralized-coverage-claims.md) when you need the signer model, claim roles, and payout-path rules for reviewed coverage claims.
-- Use [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) when deciding what to ship first on mainnet after the quote-curve, sidecar, prediction-market, and health-bond actuarial review.
 - Use [Protocol Console Functional Specification](./architecture/protocol-console-functional-spec.md) when you need the target-state screen-by-screen functional brief for the public protocol console.
 - Use [Review and Iterate Readiness Review](./reviews/review-and-iterate-2026-05-10.md) for the latest scored audit, remaining blockers, and validation evidence.
 - Use [Solana Public Readiness Review](./reviews/solana-public-readiness-review.md) for the historical March 2026 scored audit and cleanup backlog.

--- a/docs/architecture/frontend-information-architecture.md
+++ b/docs/architecture/frontend-information-architecture.md
@@ -17,7 +17,8 @@ The public UI should treat these as first-order objects:
 
 ## Navigation model
 
-- `/overview` is the editorial systems-map entrypoint for the protocol workbench
+- `/` redirects to `/overview`, the editorial systems-map entrypoint for the protocol workbench
+- `/overview` is the first-impression observer route for public protocol state, route selection, and explicit demo/live posture
 - `/plans` is the sponsor/operator view
 - `/plans/new?template=genesis-protect-acute` is the canonical Genesis bootstrap entrypoint
 - `/plans?...&setup=genesis-protect-acute` is the bounded Genesis setup, reserve-warning, and issuance-posture view inside the mounted plan workspace
@@ -54,7 +55,26 @@ The overview route is not a generic dashboard. It is the protocol entry composit
 - Desktop keeps the hero rail visually stable while the document scroll moves the access stream beneath the floating top and bottom chrome.
 - Mobile collapses to one column, but keeps the same sequence and hierarchy instead of inventing a separate dashboard layout.
 
-The approved visual grammar for this route lives in the OmegaX design-system file `references/DESIGN_PROTOCOL_FRONTEND.md`. Treat that document as the source of truth when extending or redesigning `/overview`.
+The approved visual grammar for this route lives in the repository-level [`DESIGN.md`](../../DESIGN.md). Treat that document as the source of truth when extending or redesigning `/overview` or any mounted protocol-console route.
+
+## Route responsibility contract
+
+Each mounted route must have one clear job:
+
+| Route | Primary question | Route responsibility |
+| --- | --- | --- |
+| `/` | Where do I begin? | Redirect to `/overview` so the first impression is the public systems map. |
+| `/overview` | What is live, pending, simulated, or unavailable? | Orient observers and route them to the correct workbench without implying fixture or demo state is live. |
+| `/plans` | What sponsor/operator state exists for a plan and its coverage products? | Keep plan, member, claim, treasury, and Genesis setup state together. |
+| `/capital` | What capital is posted, allocated, queued, or impaired? | Keep LP capital separate from sponsor budgets and claim obligations. |
+| `/claims` | Which claim cases and obligations need review? | Mount the claim queue without presenting Phase 0 review as decentralized adjudication. |
+| `/members` | Which wallets have plan/series rights? | Redirect into the mounted `/plans` member tab with context preserved. |
+| `/governance` | Which authorities and proposals control protocol state? | Expose scoped control lanes and templates without hiding disabled-action reasons. |
+| `/oracles` | Which oracle operators and bindings are visible? | Keep profile, schema, attestation, dispute, and staking readiness separate. |
+| `/schemas` | Which outcome schemas and series comparability rules are live? | Provide first-class registry and inspector access from the main navigation. |
+| `/coverage/*` | What public coverage terms and risk disclosures are referenced? | Stay read-only and bounded to the current Genesis launch truth. |
+| `/magicblock-claim-room` | Is a private-review receipt verifiable? | Stay devnet-only for verification and fail closed on mainnet. |
+| `/pools/*`, `/staking` | Where did retired routes move? | Redirect to canonical routes without reintroducing pool-first language. |
 
 ## Naming rules
 

--- a/docs/architecture/genesis-protect-acute-claims-processing-spec.md
+++ b/docs/architecture/genesis-protect-acute-claims-processing-spec.md
@@ -54,10 +54,10 @@ dispute resolution). Phase 1 extensions (onchain dispute-case state, multi-attes
 | Premium | $39 USDC | $99 USDC |
 | Coverage duration | 7 days | 30 days |
 | Benefit mode | Fixed only | Hybrid: fixed tier + UCR reimbursement top-up |
-| Max benefit | $1,000 | $3,000 |
+| Max benefit | $3,000 | $5,000 |
 | Tier 1 — ER same-day | $150 fixed | $250 fixed |
 | Tier 2 — Overnight | $500 fixed | $1,000 fixed |
-| Tier 3 — Surgery + ICU (2+ nights) | $1,000 fixed | $2,500 fixed + reimbursement top-up to $3,000 aggregate |
+| Tier 3 — Surgery + ICU (2+ nights) | $3,000 fixed | $2,500 fixed + reimbursement top-up to $5,000 aggregate |
 | Waiting period (illness onset) | 7 days pre-enrollment | 7 days pre-enrollment |
 | Internal claim review target | 24 hours | 24 hours |
 | Internal settlement target | 48 hours post-approval | 48 hours post-approval |
@@ -175,7 +175,7 @@ triggering oracle attestation.
 | Tier 3 — Surgery + ICU | Surgical procedure confirmed OR ICU admission confirmed, 2+ nights |
 
 For Travel 30, after tier classification, the reimbursement top-up is calculated from
-UCR-benchmarked line items and capped so the total approved amount never exceeds $3,000.
+UCR-benchmarked line items and capped so the total approved amount never exceeds $5,000.
 
 ---
 

--- a/docs/architecture/genesis-protect-acute-full-protect-flow.md
+++ b/docs/architecture/genesis-protect-acute-full-protect-flow.md
@@ -326,13 +326,13 @@ The operator confirms (or overrides) the AI-suggested tier classification based 
 
 | Tier | Event 7 benefit | Travel 30 fixed | Travel 30 top-up |
 |---|---|---|---|
-| T1 — ER same-day | $150 | $250 | UCR-benchmarked top-up, total capped at $3,000 |
-| T2 — Overnight | $500 | $1,000 | UCR-benchmarked top-up, total capped at $3,000 |
-| T3 — Surgery + ICU | $1,000 | $2,500 | UCR-benchmarked top-up, total capped at $3,000 |
+| T1 — ER same-day | $150 | $250 | UCR-benchmarked top-up, total capped at $5,000 |
+| T2 — Overnight | $500 | $1,000 | UCR-benchmarked top-up, total capped at $5,000 |
+| T3 — Surgery + ICU | $3,000 | $2,500 | UCR-benchmarked top-up, total capped at $5,000 |
 
 For Travel 30 reimbursement top-up: the operator calculates
-`min(UCR_eligible_itemized_cost - fixed_tier_benefit, 3000 - fixed_tier_benefit)` so the
-total approved amount remains within the $3,000 aggregate cap.
+`min(UCR_eligible_itemized_cost - fixed_tier_benefit, 5000 - fixed_tier_benefit)` so the
+total approved amount remains within the $5,000 aggregate cap.
 
 ### 9.3 Denial notification timing
 

--- a/docs/architecture/genesis-protect-claim-trace.md
+++ b/docs/architecture/genesis-protect-claim-trace.md
@@ -14,8 +14,8 @@ The following objects exist before the first claim is opened. Their addresses, o
 |--------|----------|-----|
 | `ReserveDomain` | `open-health-usdc` | Custody boundary; the domain's asset vault is the **only** source of payout funds |
 | `HealthPlan` | `genesis-protect-acute-v1` | Owns membership state, plan-level pause flags, and the `claims_operator` / `plan_admin` keys |
-| `PolicySeries` (Event 7) | `genesis-event-7-v1` | 7-day acute event cover; tier benefits up to USD 1,000; fixed-only |
-| `PolicySeries` (Travel 30) | `genesis-travel-30-v1` | 30-day acute travel cover; tier benefits + reimbursement top-up up to USD 3,000; hybrid |
+| `PolicySeries` (Event 7) | `genesis-event-7-v1` | 7-day acute event cover; tier benefits up to USD 3,000; fixed-only |
+| `PolicySeries` (Travel 30) | `genesis-travel-30-v1` | 30-day acute travel cover; tier benefits + reimbursement top-up up to USD 5,000; hybrid |
 | `OutcomeSchema` | `genesis-protect-acute-claim` v1 | Verified evidence schema; key hash recorded in `idl/omegax_protocol.source-hash` lineage |
 | `OracleProfile` | configured oracle authority | Will sign claim attestations |
 | `FundingLine` (premium) | `genesis-event7-premium` / `genesis-travel30-premium` | Member premium income; reduces claims-paying floor when reserved against |

--- a/docs/architecture/genesis-protect-v1-curve-launch.md
+++ b/docs/architecture/genesis-protect-v1-curve-launch.md
@@ -50,7 +50,7 @@ This gives the product the useful "put in what you want" behavior without preten
 - Cover window: 30 days.
 - Scope: acute, unplanned emergency medical care during the cover window.
 - Minimum member budget: 15 USD.
-- Maximum member cap: 3,000 USD.
+- Maximum member cap: 5,000 USD after the May 11 cap increase.
 - Illness waiting period: 7 days.
 - Accident waiting period: 24 hours.
 - Coverage cap is fixed at purchase.
@@ -72,7 +72,7 @@ Event 7 can remain the short trip, conference, or sponsor demo SKU:
 
 - 7-day cover window.
 - 39 USD retail.
-- 1,000 USD max cap.
+- 3,000 USD max cap after the May 11 cap increase.
 - Fixed benefit only in V1.
 - Same anti-selection posture: 24-hour accident wait; illness cover only if bought at least 7 days before the window unless a prefunded sponsor roster explicitly waives it.
 
@@ -153,7 +153,7 @@ The updated Nomad curve PoC tested multiple models:
 Main finding:
 
 - "Pay anything" is viable when the amount paid maps to a fixed reserve-gated cap.
-- "Pay anything for the same 3,000 USD promise" fails.
+- "Pay anything for the same fixed cap promise" fails.
 - Predictor collateral can become useful claims capital later, but only for the slice explicitly locked into the claims waterfall.
 - Health bonds are promising later because they align members around no-claim behavior, but they should not be in the first public mainnet launch.
 
@@ -188,6 +188,7 @@ The detailed truth-chain walkthrough is in `docs/architecture/genesis-protect-cl
 V1 should include:
 
 - acute-only emergency medical scope
+- offchain coverage certificates anchored to active `MemberPosition`, `PolicySeries`, terms hash, reserve/pool metadata, and premium proof
 - explicit exclusions
 - hard coverage caps
 - waiting periods
@@ -202,6 +203,7 @@ V1 should include:
 V1 should not include:
 
 - broad annual health insurance
+- visa-compliance claims unless a legal insurance wrapper and matching medical evacuation/repatriation benefits are in force
 - chronic care
 - routine outpatient care
 - maternity/fertility

--- a/docs/architecture/protocol-console-functional-spec.md
+++ b/docs/architecture/protocol-console-functional-spec.md
@@ -30,9 +30,9 @@ Use this together with:
 
 | Element | Type | Required functionality | Required states / rules |
 | --- | --- | --- | --- |
-| Brand mark | Link | Always returns the user to `/plans` as the default home surface. | Focusable, keyboard accessible, screen-reader label for home. |
-| Primary navigation | Route tabs | Expose `Plans`, `Capital`, `Claims`, `Members`, `Governance`, `Oracles`, `Schemas`, and external `Docs`. | Active route state, hover state, keyboard navigation, external-link treatment for `Docs`. |
-| Overflow navigation | `More` menu | Move lower-priority tabs into an overflow menu on narrower desktop widths without removing access. | Active-state inheritance, close on outside click, close on `Esc`. |
+| Brand mark | Link | Always returns the user to `/overview` as the public systems-map entrypoint. | Focusable, keyboard accessible, screen-reader label for home. |
+| Primary navigation | Route tabs | Expose `Overview`, `Plans`, `Capital`, `Governance`, `Oracles`, `Schemas`, and external `Docs`. `Claims` and `Members` remain mounted plan-workspace tabs and redirecting legacy paths, not separate top-level tabs. | Active route state, hover state, keyboard navigation, explicit external-link treatment for `Docs`. |
+| Compact navigation | Menu | Move primary route tabs into a stacked menu on narrower desktop and mobile widths without removing access. | Active-state inheritance, close on outside click, close on `Esc`, same route coverage as desktop. |
 | Theme toggle | Button | Toggle light/dark mode and persist user choice locally. | Works on desktop and mobile; label reflects next theme. |
 | Network selector | Button + menu | Show current cluster and allow switching between supported public networks. | Disabled options must remain visible with `Coming soon`; switching updates connection context and URL-safe explorer behavior. |
 | Wallet control | Button + menu | Connect wallet, show connected address, copy address, switch wallet, disconnect. | Observer, connecting, connected, disconnecting, copied-address success, menu open/close. |
@@ -92,12 +92,33 @@ Use this together with:
 
 Purpose:
 
-- Resolve the console entrypoint to the sponsor/operator landing route.
+- Resolve the console entrypoint to the public observer systems map.
 
 Required behavior:
 
-- Immediately redirect to `/plans`.
+- Immediately redirect to `/overview`.
 - Preserve query parameters only if a future canonical mapping explicitly supports them.
+- The root behavior must stay aligned with `frontend/app/page.tsx`, `tests/genesis_first_routing.test.ts`, and [`DESIGN.md`](../../DESIGN.md).
+
+### 3.1.1 `/overview`
+
+Purpose:
+
+- Explain the public protocol state and route users into the correct mounted workbench.
+
+Primary users:
+
+- first-time observer
+- sponsor reviewer
+- auditor
+- operator choosing the next surface
+
+Required behavior:
+
+- Show live metrics only from the configured protocol snapshot unless `?demo=1` is explicit.
+- Never fall back from a failed live read into fixture-looking success state.
+- Present route cards for the major mounted workbenches, including Schemas.
+- Route copy must distinguish posted reserve, pending custody, eligibility quotes, active cover, devnet demos, and fail-closed mainnet states.
 
 ### 3.2 `/plans`
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,9 +23,9 @@ This directory contains the Next.js protocol console for the canonical OmegaX he
 
 ## Design references
 
-- Keep the frontend aligned with the OmegaX design system rather than generic SaaS admin patterns.
-- For AI-assisted editing in Codex, load the `omegax-design` skill first.
-- Follow the shared design tokens and the protocol frontend surface guidance in the OmegaX design system before large UI changes or route rewrites.
+- Keep the frontend aligned with the repository-level [`../DESIGN.md`](../DESIGN.md) rather than generic SaaS admin patterns.
+- `../DESIGN.md` is the source of truth for the protocol console palette, route responsibilities, state-boundary copy, responsive rules, accessibility rules, and anti-slop bans.
+- The separate `omegax-design` skill is for the consumer health-agent app, not this protocol frontend. Do not import health-agent-only visual rules into the protocol console unless a protocol-specific design decision explicitly adopts them.
 
 ## Commands
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2737,6 +2737,64 @@
     display: none;
   }
 
+  @media (min-width: 900px) and (max-width: 1180px) {
+    .protocol-topbar-nav {
+      display: none;
+    }
+
+    .protocol-topbar-menu-button {
+      display: inline-flex;
+      flex-shrink: 0;
+    }
+
+    .protocol-mobile-nav {
+      display: grid;
+      width: var(--protocol-chrome-width);
+      margin: 0 auto 0.45rem;
+      gap: 0.25rem;
+      padding: 0.55rem 1.15rem 0.65rem;
+      border: 1px solid color-mix(in oklab, var(--border) 85%, transparent);
+      border-radius: 1.2rem;
+      background: color-mix(in oklab, var(--surface-elevated) 82%, transparent);
+      backdrop-filter: blur(28px) saturate(170%);
+    }
+
+    .protocol-mobile-nav-link {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-height: 2.75rem;
+      padding: 0.6rem 0.85rem;
+      border-radius: 0.85rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      color: var(--foreground);
+      text-decoration: none;
+      transition: background-color 120ms ease;
+    }
+
+    .protocol-mobile-nav-link:hover,
+    .protocol-mobile-nav-link:focus-visible {
+      background: color-mix(in oklab, var(--surface-elevated) 88%, white 12%);
+      outline: none;
+    }
+
+    .protocol-mobile-nav-link-active {
+      color: var(--accent);
+      background: color-mix(in oklab, var(--status-surface) 88%, var(--surface-elevated) 12%);
+    }
+
+    .protocol-mobile-nav-divider {
+      height: 1px;
+      margin: 0.5rem 0 0.15rem;
+      background: color-mix(in oklab, var(--border) 80%, transparent);
+    }
+
+    .protocol-mobile-wallet {
+      padding-top: 0.15rem;
+    }
+  }
+
   /* ── Toolbar controls (dropdowns, buttons, menus) ── */
 
   .protocol-toolbar-dropdown {
@@ -9508,6 +9566,7 @@
     .protocol-mobile-nav-link {
       display: flex;
       align-items: center;
+      gap: 0.5rem;
       min-height: 2.75rem;
       padding: 0.6rem 0.85rem;
       border-radius: 0.85rem;

--- a/frontend/components/overview-workbench.tsx
+++ b/frontend/components/overview-workbench.tsx
@@ -256,6 +256,11 @@ export function OverviewWorkbench({ demo = false }: OverviewWorkbenchProps) {
         label: cleanLabel(label),
         value: `${value} lane${value === 1 ? "" : "s"}`,
       }));
+    const schemaRows = snapshot.outcomeSchemas.slice(0, 2).map((schema, index) => ({
+      label: `Schema ${String(index + 1).padStart(2, "0")}`,
+      value: `${schema.schemaKey} · v${schema.version}${schema.verified ? " · verified" : ""}`,
+    }));
+    const verifiedSchemaCount = snapshot.outcomeSchemas.filter((schema) => schema.verified).length;
 
     return [
       {
@@ -326,6 +331,25 @@ export function OverviewWorkbench({ demo = false }: OverviewWorkbenchProps) {
         details: obligationDetails,
         note: "Attestation operators and reserve-obligation integrity",
       },
+      {
+        align: "start" as const,
+        entry: "Surface 05",
+        href: "/schemas",
+        status: `${snapshot.outcomeSchemas.length} schemas`,
+        title: "Schemas",
+        summary: "Outcome definitions, versioned terms, and series comparability across live coverage products.",
+        highlightLabel: "Verified schemas",
+        highlightValue: String(verifiedSchemaCount),
+        metrics: [
+          { label: "Schemas", value: String(snapshot.outcomeSchemas.length) },
+          { label: "Series", value: String(stats.seriesCount) },
+          { label: "Plans", value: String(stats.planCount) },
+        ],
+        details: schemaRows.length > 0
+          ? schemaRows
+          : [{ label: "Registry", value: "No live schemas visible" }],
+        note: "Schema registry and versioned policy-series truth",
+      },
     ];
   }, [
     governanceQueue,
@@ -352,6 +376,7 @@ export function OverviewWorkbench({ demo = false }: OverviewWorkbenchProps) {
     stats.totalObligationPrincipal,
     stats.tvl,
     stats.utilization,
+    snapshot.outcomeSchemas,
   ]);
   const signalMetrics = useMemo(() => [
     { label: "Utilization", value: `${stats.utilization}%` },

--- a/frontend/components/protocol-workbench-shell.tsx
+++ b/frontend/components/protocol-workbench-shell.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useConnection } from "@solana/wallet-adapter-react";
-import { ChevronDown, Menu, MoonStar, SunMedium, Users, X } from "lucide-react";
+import { ChevronDown, ExternalLink, Menu, MoonStar, SunMedium, Users, X } from "lucide-react";
 
 import { useNetworkContext } from "@/components/network-context";
 import { useTheme } from "@/components/theme-provider";
@@ -79,6 +79,8 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
 
   const networkMenuRef = useRef<HTMLDivElement | null>(null);
   const personaMenuRef = useRef<HTMLDivElement | null>(null);
+  const mobileNavButtonRef = useRef<HTMLButtonElement | null>(null);
+  const mobileNavRef = useRef<HTMLElement | null>(null);
 
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const [isNetworkMenuOpen, setIsNetworkMenuOpen] = useState(false);
@@ -107,10 +109,18 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
   }, [pathname]);
 
   useEffect(() => {
-    if (!isNetworkMenuOpen && !isPersonaMenuOpen) return;
+    if (!isMobileNavOpen && !isNetworkMenuOpen && !isPersonaMenuOpen) return;
 
     function handlePointerDown(event: PointerEvent) {
       const target = event.target as Node;
+      if (
+        isMobileNavOpen
+        && mobileNavRef.current
+        && !mobileNavRef.current.contains(target)
+        && !mobileNavButtonRef.current?.contains(target)
+      ) {
+        setIsMobileNavOpen(false);
+      }
       if (isNetworkMenuOpen && networkMenuRef.current && !networkMenuRef.current.contains(target)) {
         setIsNetworkMenuOpen(false);
       }
@@ -121,6 +131,7 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
+        setIsMobileNavOpen(false);
         setIsNetworkMenuOpen(false);
         setIsPersonaMenuOpen(false);
       }
@@ -132,7 +143,7 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isNetworkMenuOpen, isPersonaMenuOpen]);
+  }, [isMobileNavOpen, isNetworkMenuOpen, isPersonaMenuOpen]);
 
   useEffect(() => {
     let cancelled = false;
@@ -187,6 +198,7 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
         <div className="protocol-topbar-row">
           <div className="protocol-topbar-left">
             <button
+              ref={mobileNavButtonRef}
               type="button"
               className="protocol-topbar-menu-button"
               aria-controls={MOBILE_NAV_ID}
@@ -227,6 +239,16 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
                   </Link>
                 );
               })}
+              <Link
+                href={DOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="OmegaX Docs (opens in new tab)"
+                className="protocol-topbar-tab protocol-topbar-tab-external"
+              >
+                Docs
+                <ExternalLink className="h-3 w-3" strokeWidth={1.9} aria-hidden="true" />
+              </Link>
             </nav>
           </div>
 
@@ -362,7 +384,7 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
       </header>
 
       {isMobileNavOpen ? (
-        <nav id={MOBILE_NAV_ID} className="protocol-mobile-nav" aria-label="Mobile navigation">
+        <nav ref={mobileNavRef} id={MOBILE_NAV_ID} className="protocol-mobile-nav" aria-label="Mobile navigation">
           {WORKBENCH_NAV.map((item) => {
             const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
 
@@ -377,6 +399,16 @@ export default function ProtocolWorkbenchShell({ children }: { children: React.R
               </Link>
             );
           })}
+          <Link
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="OmegaX Docs (opens in new tab)"
+            className="protocol-mobile-nav-link"
+          >
+            Docs
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.9} aria-hidden="true" />
+          </Link>
 
           <div className="protocol-mobile-nav-divider" aria-hidden="true" />
           <div className="protocol-mobile-wallet">

--- a/frontend/lib/workbench.ts
+++ b/frontend/lib/workbench.ts
@@ -24,7 +24,7 @@ import {
 
 import type { GovernanceProposalSummary } from "@/lib/governance-readonly";
 
-export type WorkbenchSection = "overview" | "plans" | "capital" | "governance" | "oracles";
+export type WorkbenchSection = "overview" | "plans" | "capital" | "governance" | "oracles" | "schemas";
 
 export type WorkbenchPersona = "observer" | "sponsor" | "capital" | "governance";
 
@@ -54,13 +54,14 @@ export const WORKBENCH_NAV: Array<{
   id: WorkbenchSection;
   href: `/${WorkbenchSection}`;
   label: string;
-  icon: "overview" | "plans" | "capital" | "governance" | "oracles";
+  icon: "overview" | "plans" | "capital" | "governance" | "oracles" | "schemas";
 }> = [
   { id: "overview", href: "/overview", label: "Overview", icon: "overview" },
   { id: "plans", href: "/plans", label: "Plans", icon: "plans" },
   { id: "capital", href: "/capital", label: "Capital", icon: "capital" },
   { id: "governance", href: "/governance", label: "Governance", icon: "governance" },
   { id: "oracles", href: "/oracles", label: "Oracles", icon: "oracles" },
+  { id: "schemas", href: "/schemas", label: "Schemas", icon: "schemas" },
 ] as const;
 
 export const PLAN_TABS = [
@@ -394,6 +395,7 @@ export function sectionFromPathname(pathname: string): WorkbenchSection {
   if (pathname.startsWith("/capital")) return "capital";
   if (pathname.startsWith("/governance")) return "governance";
   if (pathname.startsWith("/oracles")) return "oracles";
+  if (pathname.startsWith("/schemas")) return "schemas";
   if (pathname.startsWith("/plans")) return "plans";
   return "overview";
 }
@@ -427,6 +429,12 @@ export function sectionChrome(section: WorkbenchSection): {
         title: "Oracles",
         eyebrow: "Registry, attestations, and dispute posture",
         description: "Track verification operators and settlement-sensitive bindings without exposing raw health data.",
+      };
+    case "schemas":
+      return {
+        title: "Schemas",
+        eyebrow: "Outcome schemas and series comparability",
+        description: "Audit the live schema registry and versioned series rules without losing route context.",
       };
     case "overview":
     default:
@@ -465,6 +473,8 @@ export function defaultTabForPersona(
   section: Exclude<WorkbenchSection, "overview">,
   persona: WorkbenchPersona,
 ): string {
+  if (section === "schemas") return "registry";
+
   if (section === "plans") {
     if (persona === "capital") return "treasury";
     if (persona === "governance") return "claims";

--- a/tests/protocol_workbench_shell_layout.regression-1.test.ts
+++ b/tests/protocol_workbench_shell_layout.regression-1.test.ts
@@ -3,10 +3,26 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const protocolWorkbenchShell = readFileSync("frontend/components/protocol-workbench-shell.tsx", "utf8");
+const workbenchModel = readFileSync("frontend/lib/workbench.ts", "utf8");
 
 test("schemas route uses fullscreen workbench chrome", () => {
   // Regression: ISSUE-001 - /schemas kept the default inner-scroll shell, so the footer consumed viewport space and hid the lower registry rail.
   // Found by /qa on 2026-05-11.
   // Report: .gstack/qa-reports/qa-report-127-0-0-1-3001-2026-05-11.md
   assert.match(protocolWorkbenchShell, /"\/schemas"/);
+});
+
+test("primary workbench navigation exposes schemas and docs", () => {
+  assert.match(workbenchModel, /href: "\/schemas", label: "Schemas"/);
+  assert.match(protocolWorkbenchShell, /className="protocol-topbar-tab protocol-topbar-tab-external"/);
+  assert.match(protocolWorkbenchShell, />\s*Docs\s*</);
+});
+
+test("compact workbench navigation closes on outside click and Escape", () => {
+  assert.match(protocolWorkbenchShell, /const mobileNavButtonRef = useRef<HTMLButtonElement \| null>\(null\)/);
+  assert.match(protocolWorkbenchShell, /const mobileNavRef = useRef<HTMLElement \| null>\(null\)/);
+  assert.match(protocolWorkbenchShell, /document\.addEventListener\("pointerdown", handlePointerDown\)/);
+  assert.match(protocolWorkbenchShell, /!mobileNavRef\.current\.contains\(target\)/);
+  assert.match(protocolWorkbenchShell, /!mobileNavButtonRef\.current\?\.contains\(target\)/);
+  assert.match(protocolWorkbenchShell, /event\.key === "Escape"[\s\S]*setIsMobileNavOpen\(false\)/);
 });


### PR DESCRIPTION
## Summary
- Add a repo-level DESIGN.md source of truth for the public protocol console
- Align /overview routing, frontend IA, functional spec, and README guidance
- Promote Schemas into primary/compact navigation and the overview surface
- Harden compact navigation responsive behavior, Escape close, and outside-click close
- Add regression coverage for Schemas/Docs nav and compact nav lifecycle

## Review scores
- qa-only: 94/100 PASS
- design-review: A-/HIGH PASS
- product-review: 8.3/10 PASS
- roast-my-product: 86/100 PASS

## Validation
- git diff --check
- node --import tsx --test tests/protocol_workbench_shell_layout.regression-1.test.ts tests/genesis_first_routing.test.ts
- npm run frontend:build
- npm run verify:public

No push to main was performed before this PR.