### PR TITLE
Add Genesis Protect guidance files and session-id hardening

### DIFF
--- a/examples/genesis-protect-acute-actuarial-review/AGENTS.md
+++ b/examples/genesis-protect-acute-actuarial-review/AGENTS.md
@@ -1,0 +1,21 @@
+# Genesis Protect Acute Actuarial Review
+
+## Scope
+
+This folder is the public-safe fixed-SKU launch-gate workbook for Genesis Protect Acute Event 7 and Travel 30.
+
+## Rules
+
+- Keep this folder public-safe. `omegax-protocol` is a public repository.
+- Do not import raw Health claim-simulation JSONL, synthetic-user profiles, scenario-pack internals, local `.superstack/` reports, private endpoint details, or machine-local paths.
+- Treat generated outputs as deterministic workbook artifacts. Prefer changing `assumptions.json`, `scenario-matrix.json`, or `scripts/genesis_actuarial_review.ts` over manually editing generated conclusions.
+- Keep SKU facts aligned with `frontend/lib/genesis-protect-acute.ts` and the Genesis Protect analysis hub.
+- Frame the workbook as a launch-gate model, not an external actuarial opinion, insurance filing, legal opinion, or regulatory approval.
+- Country posture is an operational gating taxonomy, not a legal availability promise.
+
+## Validation
+
+- Run `npm run genesis:actuarial:review` after changing assumptions, scenarios, generated outputs, or source metadata.
+- Run `node --import tsx --test tests/genesis_actuarial_review.test.ts` for focused test coverage.
+- Run `git diff --check` before committing.
+- Protocol commits require DCO sign-off.

--- a/examples/genesis-protect-acute-actuarial-review/CLAUDE.md
+++ b/examples/genesis-protect-acute-actuarial-review/CLAUDE.md
@@ -1,0 +1,17 @@
+# Claude Notes
+
+This is the public launch-gate actuarial workbook.
+
+Do:
+
+- keep the evidence reviewer-friendly and reproducible
+- explain reserve gates, SKU caps, cohort constraints, and pause logic plainly
+- regenerate the workbook instead of hand-tuning generated files
+- link richer private diligence only through sanitized aggregate summaries
+
+Do not:
+
+- publish raw Health simulator cases
+- publish local-only `.superstack` analysis as if it were public doctrine
+- claim real paid-claim history, regulatory approval, or external actuarial sign-off
+- turn country examples into a blanket jurisdictional launch green light

--- a/examples/genesis-protect-acute-claims/AGENTS.md
+++ b/examples/genesis-protect-acute-claims/AGENTS.md
@@ -1,0 +1,20 @@
+# Genesis Protect Acute Public Claim Fixtures
+
+## Scope
+
+This folder contains curated public claim fixtures for Genesis Protect Acute. These are small, inspectable examples for reviewers, frontend consoles, operator training, and protocol documentation.
+
+## Rules
+
+- Keep fixtures public-safe, synthetic, and curated.
+- Do not import raw Health claim-simulation JSONL, full synthetic profiles, scenario-pack internals, or proprietary generator logic.
+- Do not describe these examples as real claims, paid claim history, medical advice, underwriting, legal advice, or live on-chain state.
+- Keep fixture fields aligned with public schemas and protocol docs.
+- If a richer example is needed, build a curated public fixture here rather than copying a private case row from `omegax-health`.
+
+## Validation
+
+- Run `jq empty genesis-acute-claim-simulations-v1.json` after editing the fixture JSON.
+- Run relevant claim/schema tests when fields change: `node --import tsx --test tests/claim_funding_readiness.test.ts tests/magicblock_private_claim_review.test.ts` as applicable.
+- Run `git diff --check` before committing.
+- Protocol commits require DCO sign-off.

--- a/examples/genesis-protect-acute-claims/CLAUDE.md
+++ b/examples/genesis-protect-acute-claims/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Notes
+
+This is the public fixture side of claims.
+
+The useful posture is curated, small, and legible. These fixtures should help someone understand claim states and operator flow without exposing the private Health simulator.
+
+Before adding detail, ask whether it belongs here or in the private Health claim simulation lab. Public fixtures can include clean synthetic facts and claim-state coverage. They should not include row-level synthetic-user machinery, private scenario archetypes, or raw evidence packets.

--- a/examples/nomad-protect-curve-poc/AGENTS.md
+++ b/examples/nomad-protect-curve-poc/AGENTS.md
@@ -1,0 +1,20 @@
+# Nomad Protect Curve PoC
+
+## Scope
+
+This folder is an experimental public-safe actuarial/product model for future curve-priced protection and open risk backing. It does not replace the approved Genesis Protect Acute fixed-SKU launch model.
+
+## Rules
+
+- Keep the experiment public-safe and clearly labeled as exploratory.
+- Do not merge future curve assumptions into Genesis Protect Acute launch doctrine without an explicit product decision.
+- Do not import private Health claim-simulation rows, scenario-pack internals, local `.superstack/` diligence, or private market research into tracked artifacts.
+- Keep member quote-curve mechanics separate from risk-backer capital mechanics.
+- Avoid presenting prediction-market/backer concepts as regulatory, legal, or external actuarial approval.
+
+## Validation
+
+- Run `npm run nomad:curve:poc` after changing assumptions, product logic, or generated reports.
+- Run `node --import tsx --test tests/nomad_curve_actuarial_poc.test.ts` for focused test coverage.
+- Run `git diff --check` before committing.
+- Protocol commits require DCO sign-off.

--- a/examples/nomad-protect-curve-poc/CLAUDE.md
+++ b/examples/nomad-protect-curve-poc/CLAUDE.md
@@ -1,0 +1,10 @@
+# Claude Notes
+
+This folder is for future-market exploration, not the current launch promise.
+
+Keep comparisons honest:
+
+- Genesis Protect Acute fixed-SKU launch gate lives in `../genesis-protect-acute-actuarial-review/`.
+- This PoC can explore quote curves, micro-cover, open backstop deposits, and hybrid models.
+- Red-team the pay-anything version instead of making it sound production-ready.
+- Keep raw medical evidence offchain and private simulator details out of the public repo.

--- a/frontend/lib/private-claim-review.ts
+++ b/frontend/lib/private-claim-review.ts
@@ -9,7 +9,7 @@ export const PRIVATE_CLAIM_REVIEW_PROGRAM_ID = new PublicKey(
   privateClaimReviewIdl.address ?? "FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn",
 );
 export const SEED_PRIVATE_CLAIM_REVIEW_SESSION = "private_claim_review";
-export const MAX_PRIVATE_CLAIM_REVIEW_SESSION_ID_BYTES = 64;
+export const MAX_PRIVATE_CLAIM_REVIEW_SESSION_ID_BYTES = 32;
 
 const PRIVATE_CLAIM_REVIEW_IDL = privateClaimReviewIdl as Idl;
 const PRIVATE_CLAIM_REVIEW_CODER = new BorshCoder(PRIVATE_CLAIM_REVIEW_IDL);

--- a/idl/omegax_private_claim_review.source-hash
+++ b/idl/omegax_private_claim_review.source-hash
@@ -1,4 +1,4 @@
-23b7b6f8e4011919b1220d980d2e252569c248ca1d99a714cf608aef5ee8b638
+28cbe3f8393d4a3bff7ec33c989de4d86d0bee70045f75b93c6fa8218598c134
   Cargo.toml
   programs/omegax_private_claim_review/Cargo.toml
   programs/omegax_private_claim_review/src/lib.rs

--- a/programs/omegax_private_claim_review/src/lib.rs
+++ b/programs/omegax_private_claim_review/src/lib.rs
@@ -18,7 +18,7 @@ declare_id!("FADqaRcJHERauzMo3BRzXZVY2qvrpPqg1ie2FGqACCVn");
 pub const SEED_REVIEW_REGISTRY: &[u8] = b"private_review_registry";
 pub const SEED_REVIEW_OPERATOR: &[u8] = b"private_review_operator";
 pub const SEED_REVIEW_SESSION: &[u8] = b"private_claim_review";
-pub const MAX_SESSION_ID_LEN: usize = 64;
+pub const MAX_SESSION_ID_LEN: usize = 32;
 pub const MAGICBLOCK_DEVNET_TEE_VALIDATOR: Pubkey = Pubkey::new_from_array([
     5, 61, 71, 26, 133, 158, 115, 46, 104, 11, 201, 88, 248, 65, 7, 43, 143, 63, 188, 25, 115, 155,
     230, 151, 196, 198, 129, 18, 111, 140, 31, 116,

--- a/scripts/devnet_magicblock_claim_review_smoke.ts
+++ b/scripts/devnet_magicblock_claim_review_smoke.ts
@@ -15,7 +15,7 @@ import {
   TransactionInstruction,
 } from "@solana/web3.js";
 import bs58 from "bs58";
-import * as nacl from "tweetnacl";
+import tweetnacl from "tweetnacl";
 
 type ReviewStatusName =
   | "reviewed"
@@ -202,7 +202,7 @@ function parsePositiveInteger(value: string, name: string): number {
 function canonicalRunId(value: string): string {
   const normalized = value.trim().replace(/[^a-zA-Z0-9_-]/g, "-");
   if (!normalized) throw new Error("--run-id must not be empty");
-  if (normalized.length > 32) throw new Error("--run-id must be 32 characters or fewer");
+  if (normalized.length > 16) throw new Error("--run-id must be 16 characters or fewer");
   return normalized;
 }
 
@@ -426,6 +426,8 @@ async function getTeeAuthToken(
       : Date.now() + 30 * 24 * 60 * 60 * 1000,
   };
 }
+
+const nacl = tweetnacl;
 
 async function ensureRegistryAndOperator(params: {
   baseConnection: Connection;
@@ -923,7 +925,8 @@ function normalizeStatus(value: RawFixture["status"], index: number): ReviewStat
 
 function canonicalSessionId(runId: string, index: number, source: string): string {
   const safeSource = source.trim().replace(/[^a-zA-Z0-9_-]/g, "-").replace(/-+/g, "-");
-  const sessionId = `${runId}-${index + 1}-${safeSource}`.slice(0, 64);
+  const sourceHash = createHash("sha256").update(safeSource).digest("hex").slice(0, 8);
+  const sessionId = `${runId}-${index + 1}-${sourceHash}`.slice(0, 32);
   if (!sessionId || sessionId.trim() !== sessionId) {
     throw new Error(`Generated non-canonical session id for ${source}`);
   }

--- a/tests/magicblock_private_claim_review.test.ts
+++ b/tests/magicblock_private_claim_review.test.ts
@@ -260,8 +260,8 @@ test("MagicBlock review session PDA derivation uses the public program seeds", (
     /leading or trailing whitespace/,
   );
   assert.throws(
-    () => derivePrivateClaimReviewSessionPda({ sessionAuthority, claimCase, sessionId: "x".repeat(65) }),
-    /64 bytes or fewer/,
+    () => derivePrivateClaimReviewSessionPda({ sessionAuthority, claimCase, sessionId: "x".repeat(33) }),
+    /32 bytes or fewer/,
   );
 });
 


### PR DESCRIPTION
## Summary
- add folder-local AGENTS/CLAUDE guidance for public Genesis Protect actuarial and claim example surfaces
- tighten private claim review session identifiers to 32 bytes across program, frontend helper, smoke script, and tests
- keep IDL source hash fresh

## Validation
- node --import tsx --test tests/magicblock_private_claim_review.test.ts
- cargo fmt --all -- --check
- npm run idl:freshness:check
- git diff --check