### PR TITLE
Align Travel 30 reserve-indexed cap ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OmegaX Protocol's current launch job is concrete: help a sponsor fund Travel 30 
 
 Plainly: a sponsor can fund a protected group, see what backs the promise, and audit what happened when a claim is reviewed or paid.
 
-The current public launch reference is Genesis Protect Acute. `Travel 30` is the primary SKU, with a 30-day window and a 5,000 USDC aggregate cap. `Event 7` is the short-window cohort/demo SKU, with a 7-day window and a 3,000 USDC fixed-benefit cap. Both remain bounded launch surfaces: not broadly live insurance today, and Phase 0 claim review is operator-backed rather than fully decentralized.
+The current public launch reference is Genesis Protect Acute. `Travel 30` is the primary Founder SKU: a 100-seat cohort where 99 USDC reserves access to a reserve-indexed 30-day travel cap targeting up to 250,000 USDC at activation, unlocked only when the posted claims-paying reserve/backstop reaches the required threshold and final terms are ready. `Event 7` is the short-window cohort/demo SKU, with a 7-day window and a 3,000 USDC fixed-benefit cap. Both remain bounded launch surfaces: reservations are not active cover today, pending custody is not claims-paying reserve, this is not comprehensive travel insurance, and Phase 0 claim review is operator-backed rather than fully decentralized.
 
 On Solana devnet beta today, the public surface in this repository can already anchor:
 
@@ -132,7 +132,7 @@ This patch hardens the first publishable canonical OmegaX health-capital-markets
 
 Genesis Protect Acute sprint-1 launch truth is frozen in the public metadata and fixture surface for the April 16-20, 2026 implementation window.
 
-- `Travel 30` is the primary launch SKU and `Event 7` is the fast demo SKU
+- `Travel 30` is the primary Founder launch SKU with a reserve-indexed target cap, and `Event 7` is the fast demo SKU
 - the current public target is end-of-month mainnet readiness, not broadly live insurance issuance today
 - phase-0 claims trust is an operator-backed oracle flow rather than decentralized adjudication
 - AI recommendation and more explicit decentralized review remain next-phase work, not current public fact

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,13 @@ If you are evaluating the current Genesis launch surface, start with the sponsor
 
 ## Sponsor Travel 30 start here
 
-- [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) — primary Travel 30 launch recommendation, Event 7 cohort/demo boundary, reserve gating, and current cap doctrine
+- [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) — primary Travel 30 Founder launch recommendation, Event 7 cohort/demo boundary, reserve gating, and reserve-indexed cap doctrine
 - [Genesis Protect Claim Trace](./architecture/genesis-protect-claim-trace.md) — one Travel 30 claim from intake through evidence, attestation, obligation, reserve impact, and payout
 - [Genesis Protect Acute Claims Processing Spec](./architecture/genesis-protect-acute-claims-processing-spec.md) — Phase 0 claim workflow, evidence rules, escalation, denial, and payout timing
 - [What Exists Today](https://docs.omegax.health/docs/protocol/current-program-surface)
 - [Protocol Architecture](https://docs.omegax.health/docs/protocol/architecture)
 
-This path is intentionally launch-truth-first: `Travel 30` is the primary SKU, `Event 7` is the short-window cohort/demo SKU, and Phase 0 claims remain operator-backed rather than fully decentralized.
+This path is intentionally launch-truth-first: `Travel 30` is the primary reserve-indexed Founder SKU, `Event 7` is the short-window cohort/demo SKU, and Phase 0 claims remain operator-backed rather than fully decentralized.
 
 ## External builder start here
 
@@ -32,7 +32,7 @@ This path is intentionally launch-truth-first: `Travel 30` is the primary SKU, `
 - [Solana Instruction Map](./architecture/solana-instruction-map.md)
 - [Decentralized Coverage Claims](./architecture/decentralized-coverage-claims.md) — abstract claim model
 - [Genesis Protect Claim Trace](./architecture/genesis-protect-claim-trace.md) — deterministic end-to-end walkthrough + messy-path map
-- [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) — accepted V1 launch recommendation for curve-priced Travel 30, reserve gating, and Phase 0 claims
+- [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) — accepted V1 launch recommendation for reserve-indexed Travel 30, reserve gating, and Phase 0 claims
 - [Frontend Information Architecture](./architecture/frontend-information-architecture.md)
 - [Protocol Console Functional Specification](./architecture/protocol-console-functional-spec.md)
 
@@ -83,7 +83,7 @@ This path is intentionally launch-truth-first: `Travel 30` is the primary SKU, `
 
 ## Audience Guide
 
-- Use [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) when deciding how a sponsor-backed Travel 30 cohort should launch, what Event 7 is allowed to mean, and how reserve gating constrains the promise.
+- Use [Genesis Protect V1 Curve Launch Plan](./architecture/genesis-protect-v1-curve-launch.md) when deciding how a sponsor-backed Travel 30 Founder cohort should launch, what Event 7 is allowed to mean, and how reserve gating constrains the promise.
 - Use [Genesis Protect Claim Trace](./architecture/genesis-protect-claim-trace.md) when a sponsor, operator, or reviewer needs to follow one claim from evidence through payout without reading the whole program.
 - Use [Genesis Protect Acute Claims Processing Spec](./architecture/genesis-protect-acute-claims-processing-spec.md) when checking Phase 0 claim operations, evidence requirements, denial/appeal posture, and payout timing.
 - Use [SDK Overview](https://docs.omegax.health/docs/sdk/sdk-overview) when you want the fastest public explanation of what builders can ship on OmegaX today.

--- a/docs/architecture/frontend-information-architecture.md
+++ b/docs/architecture/frontend-information-architecture.md
@@ -43,7 +43,7 @@ Genesis Protect Acute uses the same mounted `/plans` workspace rather than a sep
 - `/plans?...&setup=genesis-protect-acute&tab=claims` is the Genesis operator claim queue, with queue filters and selected-case detail inside the mounted workspace rather than a separate operator app.
 - `/plans?...&setup=genesis-protect-acute&tab=treasury` is the Genesis reserve console, with lane filters, degraded-visibility warnings, and treasury actions scoped from the selected live funding lane.
 - Travel 30 is the primary launch SKU and Event 7 remains the fast demo SKU when no explicit Genesis series is selected.
-- This mounted mode must speak in launch-readiness language: end-of-month mainnet target, not broadly live insurance today, and Phase 0 operator-backed claim review with later AI and decentralized steps framed as roadmap.
+- This mounted mode must speak in launch-readiness language: Founder reservations pending activation, not broadly live insurance today, and Phase 0 operator-backed claim review with later AI and decentralized steps framed as roadmap.
 - Setup, claims, and treasury must share one Genesis-derived posture model so queue warnings, reserve warnings, and launch-readiness copy do not drift between tabs.
 
 ## Overview route

--- a/docs/architecture/genesis-protect-acute-claims-processing-spec.md
+++ b/docs/architecture/genesis-protect-acute-claims-processing-spec.md
@@ -32,6 +32,11 @@ This spec governs the **Phase 0 launch posture** (operator-backed oracle, human 
 dispute resolution). Phase 1 extensions (onchain dispute-case state, multi-attestation finality,
 `protocol-oracle-service`) are noted where they change behavior but are not in scope for this release.
 
+Travel 30 Founder reservations are not active cover. The first 100-seat Founder cohort targets a
+reserve-indexed cap up to $250,000 only if posted claims-paying reserve/backstop proof supports it
+before activation. This claims spec applies after activation, when the exact cap, terms hash,
+reserve snapshot, waiting periods, exclusions, and quote expiry are locked.
+
 ---
 
 ## 2. Roles and Authorities
@@ -54,10 +59,10 @@ dispute resolution). Phase 1 extensions (onchain dispute-case state, multi-attes
 | Premium | $39 USDC | $99 USDC |
 | Coverage duration | 7 days | 30 days |
 | Benefit mode | Fixed only | Hybrid: fixed tier + UCR reimbursement top-up |
-| Max benefit | $3,000 | $5,000 |
+| Max benefit | $3,000 | Locked at activation; Founder target up to $250,000 |
 | Tier 1 — ER same-day | $150 fixed | $250 fixed |
 | Tier 2 — Overnight | $500 fixed | $1,000 fixed |
-| Tier 3 — Surgery + ICU (2+ nights) | $3,000 fixed | $2,500 fixed + reimbursement top-up to $5,000 aggregate |
+| Tier 3 — Surgery + ICU (2+ nights) | $3,000 fixed | $2,500 fixed + reimbursement top-up to locked aggregate cap |
 | Waiting period (illness onset) | 7 days pre-enrollment | 7 days pre-enrollment |
 | Internal claim review target | 24 hours | 24 hours |
 | Internal settlement target | 48 hours post-approval | 48 hours post-approval |
@@ -175,7 +180,7 @@ triggering oracle attestation.
 | Tier 3 — Surgery + ICU | Surgical procedure confirmed OR ICU admission confirmed, 2+ nights |
 
 For Travel 30, after tier classification, the reimbursement top-up is calculated from
-UCR-benchmarked line items and capped so the total approved amount never exceeds $5,000.
+UCR-benchmarked line items and capped so the total approved amount never exceeds the cap locked at activation.
 
 ---
 

--- a/docs/architecture/genesis-protect-acute-full-protect-flow.md
+++ b/docs/architecture/genesis-protect-acute-full-protect-flow.md
@@ -23,6 +23,11 @@ in what sequence, with what internal operating target, and what happens when thi
 Together they form the complete picture of the Genesis Protect Acute claim lifecycle — technical
 truth chain on one side, operational workflow on the other.
 
+Travel 30 Founder reservations are not active cover. The first 100-seat Founder cohort targets a
+reserve-indexed cap up to $250,000 only when posted claims-paying reserve/backstop proof supports
+it before activation. This flow begins once a member activates cover and receives a quote receipt
+with exact cap, terms hash, reserve snapshot, waiting periods, exclusions, and quote expiry.
+
 ---
 
 ## 1. Overview: The Protect Flow in One View
@@ -73,7 +78,7 @@ MEMBER JOURNEY                    OPERATOR / ORACLE WORKFLOW               ONCHA
 ### 2.1 Member actions
 
 1. Member connects wallet to the OmegaX Health portal (or Breakpoint registration flow).
-2. Member selects a product SKU: **Event 7** ($39 / 7 days) or **Travel 30** ($99 / 30 days).
+2. Member selects a product SKU: **Event 7** ($39 / 7 days) or activates reserved **Travel 30** Founder access ($99 / 30 days; exact cap locked at activation).
 3. Member reviews coverage terms and exclusion schedule (Phase 0: mandatory pre-sign review via
    `protocol-transaction-review` frontend component).
 4. Member pays premium in USDC — the `record_premium_payment` instruction is executed.
@@ -326,13 +331,13 @@ The operator confirms (or overrides) the AI-suggested tier classification based 
 
 | Tier | Event 7 benefit | Travel 30 fixed | Travel 30 top-up |
 |---|---|---|---|
-| T1 — ER same-day | $150 | $250 | UCR-benchmarked top-up, total capped at $5,000 |
-| T2 — Overnight | $500 | $1,000 | UCR-benchmarked top-up, total capped at $5,000 |
-| T3 — Surgery + ICU | $3,000 | $2,500 | UCR-benchmarked top-up, total capped at $5,000 |
+| T1 — ER same-day | $150 | $250 | UCR-benchmarked top-up, total capped at locked aggregate cap |
+| T2 — Overnight | $500 | $1,000 | UCR-benchmarked top-up, total capped at locked aggregate cap |
+| T3 — Surgery + ICU | $3,000 | $2,500 | UCR-benchmarked top-up, total capped at locked aggregate cap |
 
 For Travel 30 reimbursement top-up: the operator calculates
-`min(UCR_eligible_itemized_cost - fixed_tier_benefit, 5000 - fixed_tier_benefit)` so the
-total approved amount remains within the $5,000 aggregate cap.
+`min(UCR_eligible_itemized_cost - fixed_tier_benefit, locked_cap - fixed_tier_benefit)` so the
+total approved amount remains within the aggregate cap locked at activation.
 
 ### 9.3 Denial notification timing
 

--- a/docs/architecture/genesis-protect-claim-trace.md
+++ b/docs/architecture/genesis-protect-claim-trace.md
@@ -6,6 +6,8 @@
 >
 > **What this is NOT**: a substitute for the operator runbook. The runbook covers operator UX and tooling — this doc covers the **state truth chain**, i.e. exactly what changes on-chain at each step.
 
+> **Founder cap note**: Travel 30 Founder reservations are not active cover. The public Founder cohort targets a reserve-indexed cap up to USD 250,000 for the first 100 seats, but the exact active cap, terms hash, reserve snapshot, waiting periods, and exclusions lock only at activation.
+
 ## Pre-conditions (already on-chain at claim time)
 
 The following objects exist before the first claim is opened. Their addresses, owners, and economic parameters are recorded in [`frontend/lib/devnet-fixtures.ts`](../../frontend/lib/devnet-fixtures.ts) (devnet) and produced by `scripts/bootstrap_genesis_live_protocol.ts` (mainnet via Genesis live bootstrap).
@@ -15,7 +17,7 @@ The following objects exist before the first claim is opened. Their addresses, o
 | `ReserveDomain` | `open-health-usdc` | Custody boundary; the domain's asset vault is the **only** source of payout funds |
 | `HealthPlan` | `genesis-protect-acute-v1` | Owns membership state, plan-level pause flags, and the `claims_operator` / `plan_admin` keys |
 | `PolicySeries` (Event 7) | `genesis-event-7-v1` | 7-day acute event cover; tier benefits up to USD 3,000; fixed-only |
-| `PolicySeries` (Travel 30) | `genesis-travel-30-v1` | 30-day acute travel cover; tier benefits + reimbursement top-up up to USD 5,000; hybrid |
+| `PolicySeries` (Travel 30) | `genesis-travel-30-v1` | 30-day acute travel cover; tier benefits + reimbursement top-up up to the cap locked at activation; hybrid |
 | `OutcomeSchema` | `genesis-protect-acute-claim` v1 | Verified evidence schema; key hash recorded in `idl/omegax_protocol.source-hash` lineage |
 | `OracleProfile` | configured oracle authority | Will sign claim attestations |
 | `FundingLine` (premium) | `genesis-event7-premium` / `genesis-travel30-premium` | Member premium income; reduces claims-paying floor when reserved against |
@@ -72,7 +74,7 @@ The default recipient is the member's own wallet. This step lets the member rout
 |--------|------------------|----|
 | Claims operator | `require_claim_operator` | `claim_case.intake_status` moves to `approved` or `denied`; adjudicator, approved/denied amounts, and decision metadata are persisted |
 
-**Member-visible**: claim shows `approved at tier 2 (overnight admission), USD 1,000 fixed benefit + reimbursement top-up inside the USD 5,000 aggregate cap` — or `denied with reason hash <hex>` for unhappy paths.
+**Member-visible**: claim shows `approved at tier 2 (overnight admission), USD 1,000 fixed benefit + reimbursement top-up inside the locked aggregate cap` — or `denied with reason hash <hex>` for unhappy paths.
 
 **Truth chain**: the protocol now has a final claim decision. The decision is the input to the next step — reserve booking against an `Obligation`.
 

--- a/docs/architecture/genesis-protect-v1-curve-launch.md
+++ b/docs/architecture/genesis-protect-v1-curve-launch.md
@@ -9,7 +9,7 @@ Source-of-truth record: internal decision log; public repo copy intentionally om
 
 Ship Genesis Protect Acute V1 on mainnet as a working coverage and claims product with:
 
-- Travel 30 Curve as the primary member offer.
+- Travel 30 Founder access as the primary member offer: 100 seats at 99 USD, targeting a reserve-indexed cap up to 250,000 USD at activation.
 - Event 7 fixed cover as the short-window demo/cohort SKU if it is already operationally ready.
 - Explicit claims-paying reserve from opening reserve, collected premiums, and private/operator backstop capital.
 - AI/operator-assisted offchain claim processing in Phase 0.
@@ -20,9 +20,10 @@ Do not ship the public prediction market, predictor rewards, health bonds, self-
 The simplest accurate description is:
 
 ```text
-Member chooses budget
--> quote curve returns a fixed cap
--> member buys capped acute cover
+Member reserves Founder access
+-> reserve/backstop proof unlocks a cap ladder
+-> activation quote returns the exact locked cap and terms
+-> member activates capped acute cover
 -> AI/operator processes claim offchain
 -> protocol records claim truth and reserve consequence
 -> claim settles from claims-paying reserve
@@ -30,41 +31,48 @@ Member chooses budget
 
 ## Why this is the V1
 
-The fixed-price V1 is now 99 USD, but the product gap still exists: some users will not buy a one-size Travel 30 policy, while they may buy 15 to 39 USD of reserve-gated protection.
+The public Founder V1 is now a fixed 99 USD reservation for Travel 30 access, but the cap must stay reserve-gated. The better launch promise is not "99 USD buys 250,000 USD live coverage today." It is "99 USD reserves access; the activation quote locks the cap that the posted reserve/backstop can actually support."
 
 The later full-stack market design is strategically stronger, but it is too much surface area for the first mainnet launch. It adds public market rules, settlement logic, predictor onboarding, collateral accounting, reward waterfalls, market integrity risk, and legal review.
 
 The V1 compromise is better:
 
 - keep the coverage promise boring and claimable
-- let the quote curve make entry flexible
+- let reserve-indexed activation make the benefit flexible
 - keep capital accounting explicit
 - ship real claims before shipping a public underwriting market
 
-This gives the product the useful "put in what you want" behavior without pretending prediction-market volume is reserve.
+This keeps the useful dynamic behavior without pretending prediction-market volume, waitlist deposits, or pending reservations are claims-paying reserve.
 
 ## V1 offer
 
-### Primary SKU: Travel 30 Curve
+### Primary SKU: Travel 30 Founder access
 
 - Cover window: 30 days.
 - Scope: acute, unplanned emergency medical care during the cover window.
-- Minimum member budget: 15 USD.
-- Maximum member cap: 5,000 USD after the May 11 cap increase.
+- Founder reservation price: 99 USD.
+- Founder cohort: first 100 seats.
+- Target max benefit: up to 250,000 USD.
+- Cap mode: reserve-indexed until activation.
 - Illness waiting period: 7 days.
 - Accident waiting period: 24 hours.
-- Coverage cap is fixed at purchase.
-- Terms hash, pricing curve hash, reserve snapshot, and quote TTL must be attached to the quote receipt.
+- Coverage cap is fixed only at activation, not at reservation.
+- Terms hash, cap ladder hash, reserve snapshot/hash, exclusions, waiting periods, and quote TTL must be attached to the activation quote receipt.
 
-Fresh-market quote examples from the Nomad Protect Curve PoC:
+Public copy:
 
-| Member budget | Coverage cap | Premium / cap |
-| ---: | ---: | ---: |
-| 15 USD | 286 USD | 5.25% |
-| 39 USD | 743 USD | 5.25% |
-| 99 USD | 1,884 USD | 5.25% |
+> $99 Travel 30 Founder access. First cohort: 100 seats. Target cap up to $250k, unlocked only when posted claims-paying reserve/backstop reaches the required threshold. Exact cap and terms lock at activation.
 
-Warm and stressed markets quote less cover per dollar. That is intentional. The curve should protect reserve health rather than preserve a marketing cap.
+Reserve-indexed cap ladder for launch copy:
+
+| Posted claims-paying reserve/backstop floor | Travel 30 activation cap |
+| ---: | ---: |
+| 250,000 USD | 25,000 USD |
+| 750,000 USD | 75,000 USD |
+| 1,500,000 USD | 150,000 USD |
+| 2,500,000 USD | 250,000 USD |
+
+The ladder is campaign metadata and activation gating guidance, not active cover. If reserve/backstop proof is unavailable, activation copy must fail closed and show no live 250,000 USD coverage claim.
 
 ### Optional V1 SKU: Event 7 fixed cover
 
@@ -76,24 +84,26 @@ Event 7 can remain the short trip, conference, or sponsor demo SKU:
 - Fixed benefit only in V1.
 - Same anti-selection posture: 24-hour accident wait; illness cover only if bought at least 7 days before the window unless a prefunded sponsor roster explicitly waives it.
 
-Do not block V1 on Event 7 if Travel 30 Curve and claims operations are ready first.
+Do not block V1 on Event 7 if Travel 30 Founder access and claims operations are ready first.
 
 ## Member language
 
 Use plain product language:
 
-> Choose your protection budget. We quote exactly how much acute emergency cover it buys before you join.
+> Reserve Travel 30 Founder access now. We quote the exact active cap before you activate.
 
-For a 39 USD quote:
+For the 99 USD Founder offer:
 
-> Your 39 USD buys up to 743 USD of acute emergency cover for 30 days.
+> Your 99 USD reserves access to the first 100-seat Travel 30 cohort. The target cap is up to 250,000 USD, but only if posted reserve/backstop proof supports it before activation.
 
 Avoid:
 
 - "Pay anything and you are insured" without the quoted cap.
+- "250,000 USD coverage is live" before the reserve threshold is met and terms are frozen.
 - "Prediction-market insurance" for V1.
 - "Fully decentralized claims" while Phase 0 uses AI/operator-assisted review.
 - "Yield-backed insurance" unless rewards and reserve waterfalls are actually live.
+- "Comprehensive travel insurance" unless a licensed wrapper and matching benefits are in force.
 
 ## Reserve model
 
@@ -114,6 +124,7 @@ Do not count:
 - expected future yield
 - token collateral without explicit haircuts and disclosure
 - member budgets before purchase finality
+- waitlist deposits or pending Founder reservations
 
 Issuance must pause or reprice when free reserve after the quote would breach the SKU floor.
 
@@ -124,9 +135,9 @@ The repo contains two relevant workbooks:
 - Genesis Protect Acute fixed SKU launch review: `examples/genesis-protect-acute-actuarial-review/review-memo.md`
 - Nomad curve and market-structure PoC: `examples/nomad-protect-curve-poc/hybrid-model-report.md`
 
-### Current Genesis fixed SKU launch gate
+### Historical Genesis fixed SKU launch gate
 
-The May 11 Genesis workbook applies the approved cap increase: Event 7 now carries a 3,000 USD fixed-benefit cap, and Travel 30 now carries a 5,000 USD aggregate cap. The baseline public-open mix remains healthy, while adverse and stress paths now gate to caution or pause unless additional posted reserve or sponsor/backstop capital is added:
+The May 11 Genesis workbook was the fixed-cap basis before the Founder cohort target changed: Event 7 carried a 3,000 USD fixed-benefit cap, and Travel 30 carried a 5,000 USD aggregate cap. It remains useful as the conservative Phase 0 claims-processing baseline, but it no longer defines the public Travel 30 Founder headline. A 250,000 USD target cap requires the reserve/backstop ladder above, fresh actuarial review, and final activation terms before any member receives active cover.
 
 | Scenario | Gate | Premium | p99.5 claims | Reserve |
 | --- | --- | ---: | ---: | ---: |
@@ -136,7 +147,7 @@ The May 11 Genesis workbook applies the approved cap increase: Event 7 now carri
 | travel30-only 500 | healthy | 49,500 USD | 53,064 USD | 84,900 USD |
 | travel30-only adverse 500 | caution | 49,500 USD | 76,888 USD | 84,900 USD |
 
-This is the current repo basis for mainnet launch gating after the cap increase.
+This is retained as repo evidence for the earlier fixed-cap gate. Do not use it to claim that the 250,000 USD Founder target is actuarially approved or active.
 
 ### Curve and market-structure simulations
 
@@ -244,11 +255,14 @@ Once that is live, market capital can graduate through:
 
 Before public mainnet activation, the launch surface should have:
 
-- Travel 30 Curve terms frozen.
-- Cap and premium curve published.
+- Travel 30 Founder terms frozen for the activated cohort.
+- 100-seat Founder cohort metadata published.
+- Reserve-indexed cap ladder published and hashable.
+- Cap, waiting periods, exclusions, terms hash, reserve snapshot/hash, and quote TTL returned by activation quote.
 - Reserve floor and issuance pause logic implemented.
 - Opening reserve posted.
 - Backstop capital posted or explicitly documented.
+- Existing active terms protected from later reserve changes; reserve changes affect only new activations or renewals.
 - AI/operator claim intake ready.
 - Evidence reference and claim attestation path ready.
 - Settlement path tested with real payout rail assumptions.
@@ -278,7 +292,9 @@ Ship:
 
 ```text
 Genesis Protect Acute V1
-- Travel 30 Curve as the main offer
+- Travel 30 Founder access as the main offer
+- 100 seats at 99 USD
+- reserve-indexed target cap up to 250,000 USD
 - Event 7 fixed cover only if operationally ready
 - private/operator backstop sidecar
 - signed quote receipts
@@ -300,4 +316,4 @@ full public backer marketplace
 complex yield waterfall
 ```
 
-This is the fastest credible mainnet path because it ships real coverage, real claims, and flexible pricing without turning launch into a capital-markets release.
+This is the fastest credible mainnet path because it ships real reserved access, real activation gates, real claims, and flexible benefit limits without turning launch into a capital-markets release or overstating inactive cover.

--- a/docs/architecture/genesis-protect-v1-curve-launch.md
+++ b/docs/architecture/genesis-protect-v1-curve-launch.md
@@ -70,9 +70,12 @@ Reserve-indexed cap ladder for launch copy:
 | 250,000 USD | 25,000 USD |
 | 750,000 USD | 75,000 USD |
 | 1,500,000 USD | 150,000 USD |
+| 2,000,000 USD | 200,000 USD |
 | 2,500,000 USD | 250,000 USD |
 
 The ladder is campaign metadata and activation gating guidance, not active cover. If reserve/backstop proof is unavailable, activation copy must fail closed and show no live 250,000 USD coverage claim.
+
+The `/protect/devnet` website simulator may use the 2,000,000 USD row to show a 200,000 USD locked Travel 30 demo cap with simulated reserve and terms hashes. That is QA/demo state only: it is not public mainnet cover, not a licensed insurance policy, and not a real payout obligation.
 
 ### Optional V1 SKU: Event 7 fixed cover
 

--- a/docs/architecture/protocol-console-functional-spec.md
+++ b/docs/architecture/protocol-console-functional-spec.md
@@ -159,7 +159,7 @@ Genesis Protect Acute is a required mounted variant of this same workspace, not 
 - after bootstrap, the operator must land back in `/plans?...&setup=genesis-protect-acute` so the live checklist and issuance posture remain visible until launch readiness is complete
 - `/plans?...&setup=genesis-protect-acute&tab=claims` must become the mounted Genesis operator claim queue, with summary cards, queue filters, selected-case detail, and only contextual action handoff into adjudication, reserve, impairment, or oracle follow-through
 - `/plans?...&setup=genesis-protect-acute&tab=treasury` must become the mounted Genesis reserve console, with per-lane reserve attribution, degraded-visibility warnings, and treasury actions scoped from the selected live funding lane
-- all mounted Genesis copy must describe a bounded launch-readiness posture: end-of-month mainnet target, not broadly live insurance today, and Phase 0 operator-backed claim review
+- all mounted Genesis copy must describe a bounded launch-readiness posture: Founder reservations pending activation, not broadly live insurance today, and Phase 0 operator-backed claim review
 - any later AI recommendation or decentralized review language must be explicitly framed as roadmap or next phase rather than current fact
 
 ##### Step 1: neutral plan root

--- a/docs/operations/founder-reservation-runbook.md
+++ b/docs/operations/founder-reservation-runbook.md
@@ -44,7 +44,9 @@ token account is available.
 4. Confirm `/v1/public/reservations/campaigns` returns both campaigns, the
    intended enabled rails, and the Travel cover fields
    `targetSeatCount=100`, `targetMaxBenefitUsd=250000`,
-   `capMode=reserve_indexed`, `capLadder`, and `activationTermsLabel`.
+   `capMode=reserve_indexed`, `capLadder`, and `activationTermsLabel`. The
+   current ladder includes the 2,000,000 USD reserve/backstop row that can lock
+   a 200,000 USD activation cap before the final 250,000 USD target row.
 5. Run a prepare-submit-confirm rehearsal for SOL and one SPL rail on the target
    cluster.
 6. Reconcile reservations by unique reference, not by payer memo.

--- a/docs/operations/founder-reservation-runbook.md
+++ b/docs/operations/founder-reservation-runbook.md
@@ -7,10 +7,15 @@ waitlist program is deployed for this flow.
 
 ## Products
 
-| Campaign id | Public lane | Price | Reservation window |
-|-------------|-------------|-------|--------------------|
-| `founder-event7` | Event cover | `$39` | 7 days |
-| `founder-travel30` | Travel cover | `$99` | 30 days |
+| Campaign id | Public lane | Price | Reservation window | Cap mode | Target seats |
+|-------------|-------------|-------|--------------------|----------|--------------|
+| `founder-event7` | Event cover | `$39` | 7 days | Fixed 3,000 USD cap once active terms are available | 100 |
+| `founder-travel30` | Travel cover Founder access | `$99` | 30 days | Reserve-indexed target up to 250,000 USD at activation | 100 |
+
+The Travel cover target is conditional. It is not active cover when the buyer
+reserves, and the target max benefit is not available until the posted
+claims-paying reserve/backstop reaches the required threshold and binding terms
+are published for activation.
 
 Accepted rails are USDC, PUSD, USDT, SOL, WBTC, WETH, and OMEGAX when the
 oracle service has a configured/fresh quote and the Squads vault recipient or
@@ -24,6 +29,8 @@ token account is available.
   memo or payment message.
 - Pending reservations are not active cover, not LP deposits, and not
   claims-paying reserve.
+- Prediction-market volume, waitlist deposits, and pending reservations never
+  count as claims-paying reserve.
 - Reserve only changes after a later activation/posting flow books funds through
   the normal reserve and premium controls.
 - Refunds are manual in v0 and recorded by the operator with a Squads refund
@@ -34,8 +41,10 @@ token account is available.
 1. Configure `PROTECT_RESERVATION_SQUADS_VAULT` in the protocol-oracle service.
 2. Pre-create Squads vault token accounts for every enabled SPL mint.
 3. Configure mint/decimals and price sources for volatile or project assets.
-4. Confirm `/v1/public/reservations/campaigns` returns both campaigns and the
-   intended enabled rails.
+4. Confirm `/v1/public/reservations/campaigns` returns both campaigns, the
+   intended enabled rails, and the Travel cover fields
+   `targetSeatCount=100`, `targetMaxBenefitUsd=250000`,
+   `capMode=reserve_indexed`, `capLadder`, and `activationTermsLabel`.
 5. Run a prepare-submit-confirm rehearsal for SOL and one SPL rail on the target
    cluster.
 6. Reconcile reservations by unique reference, not by payer memo.
@@ -47,3 +56,7 @@ rail is disabled, the Squads vault is missing, the SPL vault token account is
 missing, the quote is stale, or the selected asset has no fresh price. Confirm
 must reject underpayment, wrong recipient, wrong token, expired quote, duplicate
 signature, and transactions that do not include the reservation reference.
+
+If the Travel cover campaign cannot expose current reserve-indexed cap metadata
+or reserve/backstop status, public copy must fail closed: show reservation access
+only, never "live 250,000 USD coverage" or active claims-paying reserve.

--- a/docs/operations/release-v0.3.0.md
+++ b/docs/operations/release-v0.3.0.md
@@ -62,7 +62,7 @@ It is intentionally a hard-break devnet migration rather than a compatibility re
 - the oracle register/update flows now share the same full-page wizard grammar as `/plans/new`, including guarded bootstrap handling when live schema reads degrade
 - plan-control saves now preserve decoded numeric membership mode and gate-kind values instead of reconstructing them from display labels
 - the hosted frontend keeps the canonical `v0.3.0` surface while improving workbench readability, queue visibility, and operator-facing chrome for the public deployment
-- Genesis-facing console and metadata copy now align to the actual launch posture: bounded end-of-month mainnet target, Travel 30 primary / Event 7 fast-demo, and Phase 0 operator-backed claim review with later AI and decentralized review framed as roadmap
+- Genesis-facing console and metadata copy now align to the actual launch posture: Travel 30 Founder reservations pending activation, Event 7 fast-demo readiness, and Phase 0 operator-backed claim review with later AI and decentralized review framed as roadmap
 - publish the matching docs update alongside the frontend deployment so [docs.omegax.health](https://docs.omegax.health/docs) reflects the current console experience
 
 ## Operations release notes

--- a/frontend/components/genesis-protect-acute-setup-panel.tsx
+++ b/frontend/components/genesis-protect-acute-setup-panel.tsx
@@ -194,7 +194,7 @@ export function GenesisProtectAcuteSetupPanel(props: GenesisProtectAcuteSetupPan
 
         <p className="plans-card-body">
           The Genesis template creates the canonical two-SKU shell in place.
-          Current public posture: bounded end-of-month mainnet target, not broadly live insurance today, with Phase 0 operator-backed claim review while reserve, oracle, and pool controls finish operator sign-off.
+          Current public posture: Founder reservations pending activation, not broadly live insurance today, with Phase 0 operator-backed claim review while reserve, oracle, and pool controls finish operator sign-off.
         </p>
 
         <div className="plans-settings-grid">

--- a/frontend/components/plans-workbench.tsx
+++ b/frontend/components/plans-workbench.tsx
@@ -192,10 +192,18 @@ function GenesisPreBootstrapLanding(props: {
                   </div>
                   <div className="plans-settings-row">
                     <div>
-                      <span className="plans-settings-label">Payout cap</span>
-                      <span className="plans-settings-lane">Maximum visible member benefit</span>
+                      <span className="plans-settings-label">Benefit cap</span>
+                      <span className="plans-settings-lane">
+                        {sku.capMode === "reserve_indexed"
+                          ? "Reserve-indexed target; exact cap locks at activation"
+                          : "Maximum visible member benefit"}
+                      </span>
                     </div>
-                    <span className="plans-settings-address">${sku.payoutCapUsd.toLocaleString()}</span>
+                    <span className="plans-settings-address">
+                      {sku.capMode === "reserve_indexed" && sku.targetMaxBenefitUsd
+                        ? `Target up to $${sku.targetMaxBenefitUsd.toLocaleString()}`
+                        : `$${(sku.payoutCapUsd ?? 0).toLocaleString()}`}
+                    </span>
                   </div>
                 </div>
               </article>

--- a/frontend/lib/genesis-protect-acute.ts
+++ b/frontend/lib/genesis-protect-acute.ts
@@ -118,6 +118,7 @@ export const GENESIS_PROTECT_TRAVEL30_CAP_LADDER: GenesisProtectAcuteCapLadderSt
   { reserveBackstopUsd: 250_000, maxBenefitUsd: 25_000 },
   { reserveBackstopUsd: 750_000, maxBenefitUsd: 75_000 },
   { reserveBackstopUsd: 1_500_000, maxBenefitUsd: 150_000 },
+  { reserveBackstopUsd: 2_000_000, maxBenefitUsd: 200_000 },
   { reserveBackstopUsd: 2_500_000, maxBenefitUsd: 250_000 },
 ];
 

--- a/frontend/lib/genesis-protect-acute.ts
+++ b/frontend/lib/genesis-protect-acute.ts
@@ -28,13 +28,20 @@ export type GenesisProtectAcuteIssuanceControls = {
 };
 
 export type GenesisProtectAcuteLaunchTruth = {
-  publicStatus: "end_of_month_mainnet_target";
+  publicStatus: "founder_reservation_pending_activation";
   primaryLaunchSku: GenesisProtectAcuteSkuKey;
   fastDemoSku: GenesisProtectAcuteSkuKey;
   claimsTrustPhase: "operator_backed_oracle_phase0";
   broadlyLiveInsurance: false;
   predictionMarketsCountAsReserve: false;
   appMembershipBillingSeparate: true;
+};
+
+export type GenesisProtectAcuteCapMode = "fixed" | "reserve_indexed";
+
+export type GenesisProtectAcuteCapLadderStep = {
+  reserveBackstopUsd: number;
+  maxBenefitUsd: number;
 };
 
 export type GenesisProtectAcuteSkuDefinition = {
@@ -44,7 +51,12 @@ export type GenesisProtectAcuteSkuDefinition = {
   metadataUri: string;
   comparabilityKey: string;
   coverWindowDays: number;
-  payoutCapUsd: number;
+  capMode: GenesisProtectAcuteCapMode;
+  payoutCapUsd: number | null;
+  targetSeatCount?: number;
+  targetMaxBenefitUsd?: number;
+  capLadder?: GenesisProtectAcuteCapLadderStep[];
+  activationCapRule?: string;
   benefitStyle: "fixed_benefit_only" | "hybrid_fixed_plus_reimbursement";
   pricing: {
     retailUsd: number;
@@ -100,6 +112,14 @@ export const GENESIS_PROTECT_ACUTE_SENIOR_CLASS_ID = "genesis-senior-class";
 export const GENESIS_PROTECT_ACUTE_SENIOR_CLASS_DISPLAY_NAME = "Genesis Acute Senior Class";
 export const GENESIS_PROTECT_ACUTE_JUNIOR_CLASS_ID = "genesis-junior-class";
 export const GENESIS_PROTECT_ACUTE_JUNIOR_CLASS_DISPLAY_NAME = "Genesis Acute First-Loss Class";
+export const GENESIS_PROTECT_TRAVEL30_FOUNDER_SEAT_COUNT = 100;
+export const GENESIS_PROTECT_TRAVEL30_TARGET_MAX_BENEFIT_USD = 250_000;
+export const GENESIS_PROTECT_TRAVEL30_CAP_LADDER: GenesisProtectAcuteCapLadderStep[] = [
+  { reserveBackstopUsd: 250_000, maxBenefitUsd: 25_000 },
+  { reserveBackstopUsd: 750_000, maxBenefitUsd: 75_000 },
+  { reserveBackstopUsd: 1_500_000, maxBenefitUsd: 150_000 },
+  { reserveBackstopUsd: 2_500_000, maxBenefitUsd: 250_000 },
+];
 
 export const GENESIS_PROTECT_ACUTE_METADATA_URIS = {
   event7: "/metadata/protection/genesis-protect-acute-event-7-v1.json",
@@ -113,7 +133,7 @@ export const GENESIS_PROTECT_ACUTE_EVIDENCE_SCHEMA: GenesisProtectAcuteEvidenceS
 };
 
 export const GENESIS_PROTECT_ACUTE_LAUNCH_TRUTH: GenesisProtectAcuteLaunchTruth = {
-  publicStatus: "end_of_month_mainnet_target",
+  publicStatus: "founder_reservation_pending_activation",
   primaryLaunchSku: "travel30",
   fastDemoSku: "event7",
   claimsTrustPhase: "operator_backed_oracle_phase0",
@@ -130,6 +150,7 @@ export const GENESIS_PROTECT_ACUTE_SKUS: Record<GenesisProtectAcuteSkuKey, Genes
     metadataUri: GENESIS_PROTECT_ACUTE_METADATA_URIS.event7,
     comparabilityKey: "genesis-acute-event-7",
     coverWindowDays: 7,
+    capMode: "fixed",
     payoutCapUsd: 3_000,
     benefitStyle: "fixed_benefit_only",
     pricing: {
@@ -186,7 +207,7 @@ export const GENESIS_PROTECT_ACUTE_SKUS: Record<GenesisProtectAcuteSkuKey, Genes
     issuanceControls: {
       reserveAttribution: "Only posted capital, collected premiums, and explicit sponsor or backstop funds count as claims-paying reserve.",
       publicStatusRule:
-        "Keep Event 7 positioned as the fast-demo SKU for a bounded end-of-month mainnet launch target. Do not describe it as broadly live insurance today.",
+        "Keep Event 7 positioned as the fast-demo SKU for a bounded pending-activation launch target. Do not describe it as broadly live insurance today.",
       issueWhen: [
         "Event 7 reserve lanes are funded onchain or by explicit sponsor/backstop posting.",
         "Operator-backed claim review is staffed for the active issuance window.",
@@ -207,7 +228,13 @@ export const GENESIS_PROTECT_ACUTE_SKUS: Record<GenesisProtectAcuteSkuKey, Genes
     metadataUri: GENESIS_PROTECT_ACUTE_METADATA_URIS.travel30,
     comparabilityKey: "genesis-acute-travel-30",
     coverWindowDays: 30,
-    payoutCapUsd: 5_000,
+    capMode: "reserve_indexed",
+    payoutCapUsd: null,
+    targetSeatCount: GENESIS_PROTECT_TRAVEL30_FOUNDER_SEAT_COUNT,
+    targetMaxBenefitUsd: GENESIS_PROTECT_TRAVEL30_TARGET_MAX_BENEFIT_USD,
+    capLadder: GENESIS_PROTECT_TRAVEL30_CAP_LADDER,
+    activationCapRule:
+      "The exact Travel 30 cap locks only at activation from the posted claims-paying reserve/backstop snapshot, terms hash, waiting periods, exclusions, and quote expiry.",
     benefitStyle: "hybrid_fixed_plus_reimbursement",
     pricing: {
       retailUsd: 99,
@@ -236,8 +263,9 @@ export const GENESIS_PROTECT_ACUTE_SKUS: Record<GenesisProtectAcuteSkuKey, Genes
       },
     ],
     reimbursementTopUp: {
-      aggregateCapUsd: 5_000,
-      description: "Actual acute emergency medical spend above the fixed tier benefit, capped at the aggregate maximum.",
+      aggregateCapUsd: GENESIS_PROTECT_TRAVEL30_TARGET_MAX_BENEFIT_USD,
+      description:
+        "Target aggregate maximum for Founder access. The active reimbursement top-up cap is reserve-indexed and locks only at activation.",
     },
     waitingPeriods: {
       illnessDays: 7,
@@ -264,14 +292,15 @@ export const GENESIS_PROTECT_ACUTE_SKUS: Record<GenesisProtectAcuteSkuKey, Genes
     issuanceControls: {
       reserveAttribution: "Only posted capital, collected premiums, and explicit backstop funds count as claims-paying reserve.",
       publicStatusRule:
-        "Keep Travel 30 positioned as the primary SKU for a bounded end-of-month mainnet launch target. Do not describe it as broadly live insurance today.",
+        "Keep Travel 30 positioned as 99 USDC Founder access for the first 100-seat cohort, targeting reserve-indexed benefits up to 250,000 USDC only after posted reserve/backstop proof and final terms support activation. Do not describe it as broadly live insurance today.",
       issueWhen: [
-        "Travel 30 reserve lanes are funded onchain with published premium and liquidity support.",
+        "Travel 30 reserve lanes have posted claims-paying reserve/backstop that meets the published cap ladder threshold.",
+        "Activation quotes lock exact cap, reserve snapshot/hash, terms hash, waiting periods, exclusions, and quote expiry.",
         "Operator-backed claim review is staffed for the active issuance window.",
         "The shared public evidence schema stays aligned with the published metadata document.",
       ],
       pauseWhen: [
-        "Posted reserve no longer covers the marketed issuance window.",
+        "Posted reserve/backstop proof cannot support any published activation cap.",
         "Claims operator or oracle staffing falls below the required phase-0 review readiness.",
         "Schema, pricing, or benefit truth drifts from the published Genesis metadata.",
       ],

--- a/frontend/lib/genesis-protect-disclosures.ts
+++ b/frontend/lib/genesis-protect-disclosures.ts
@@ -43,7 +43,7 @@ export type GenesisProtectDisclosurePageContent = {
 const sharedLaunchFacts = [
   {
     label: "Launch posture",
-    value: "Bounded end-of-month mainnet target, not broadly live insurance today.",
+    value: "Founder reservations pending activation, not broadly live insurance today.",
   },
   {
     label: "Trust phase",
@@ -76,7 +76,7 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         eyebrow: "Launch posture",
         title: "Shared route, current launch reference",
         copy:
-          "This route is the shared public technical-terms destination for DeFi-native protection metadata on the protocol frontend. The current live reference implementation is Genesis Protect Acute: Travel 30 is the primary launch SKU, Event 7 is the fast demo SKU, and both stay inside the same bounded end-of-month mainnet target rather than a broad always-live insurance claim.",
+          "This route is the shared public technical-terms destination for DeFi-native protection metadata on the protocol frontend. The current reference implementation is Genesis Protect Acute: Travel 30 is the primary Founder reservation SKU, Event 7 is the fast demo SKU, and both stay inside the same bounded pending-activation launch posture rather than a broad always-live insurance claim.",
         facts: [...sharedLaunchFacts],
       },
       {
@@ -87,7 +87,7 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         facts: [
           {
             label: GENESIS_PROTECT_ACUTE_SKUS.travel30.displayName,
-            value: "30-day cover window, hybrid fixed plus reimbursement top-up, premium plus liquidity reserve lanes.",
+            value: "30-day Founder access for the first 100 seats, reserve-indexed target cap up to 250,000 USDC at activation, premium plus liquidity reserve lanes.",
           },
           {
             label: GENESIS_PROTECT_ACUTE_SKUS.event7.displayName,
@@ -103,10 +103,10 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         eyebrow: "Commercial layers",
         title: "Membership and protection are separate",
         copy:
-          "OmegaX Health app membership and Genesis Protect premiums remain two separate economic layers. Membership pays for the app experience and AI health support. The protection premium is the per-window charge that activates Travel 30 or Event 7 eligibility in the protocol.",
+          "OmegaX Health app membership and Genesis Protect premiums remain two separate economic layers. Membership pays for the app experience and AI health support. Founder reservation/access payments can hold a place and price, but active Travel 30 or Event 7 protection starts only after activation locks exact cap and terms.",
         bullets: [
-          "Membership does not itself activate coverage.",
-          "Protection premiums contribute to reserve economics; app membership does not.",
+          "Membership and reservations do not themselves activate coverage.",
+          "Only premiums or funds that satisfy the relevant posting rules can contribute to claims-paying reserve.",
           "Sponsor funding can support protection without collapsing the distinction between membership and protection premium.",
         ],
       },
@@ -163,9 +163,10 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         eyebrow: "Launch boundary",
         title: "Shared route, bounded launch reference",
         copy:
-          "This route can be referenced by generic DeFi-native protection metadata, so it should not pretend every product is Genesis Protect Acute. The current public launch reference is Genesis Protect Acute, and that launch remains bounded to Event 7 and Travel 30 with messaging tied to the current end-of-month mainnet target and Phase 0 AI-assisted review under operator oversight.",
+          "This route can be referenced by generic DeFi-native protection metadata, so it should not pretend every product is Genesis Protect Acute. The current public launch reference is Genesis Protect Acute, and that launch remains bounded to Event 7 plus Travel 30 Founder reservations with messaging tied to pending activation and Phase 0 AI-assisted review under operator oversight.",
         bullets: [
           "Do not read this launch as a promise of broad always-open global insurance availability.",
+          "Do not read a Travel 30 Founder reservation as active cover or a live 250,000 USDC cap.",
           "Do not read roadmap language about AI or decentralized review as current live fact.",
           "Retail-open issuance and sponsor-configured cohorts can both exist, but each live series still needs explicit public posture and reserve support.",
         ],
@@ -185,10 +186,10 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         eyebrow: "Coverage boundary risk",
         title: "Waiting periods and exclusions still matter",
         copy:
-          "Buying coverage does not remove waiting periods, exclusions, or evidence requirements. Event 7 and Travel 30 both keep a 7-day illness wait and 24-hour accident activation rule in the current launch truth, with sponsor-configured waiver behavior only where the published cohort terms explicitly allow it.",
+          "Activation does not remove waiting periods, exclusions, or evidence requirements. Event 7 and Travel 30 both keep a 7-day illness wait and 24-hour accident activation rule in the current launch truth, with sponsor-configured waiver behavior only where the published cohort terms explicitly allow it.",
         bullets: [
           "Event 7 remains fixed-benefit-only.",
-          "Travel 30 can add a reimbursement top-up only inside the published aggregate cap.",
+          "Travel 30 can add a reimbursement top-up only inside the exact aggregate cap locked at activation.",
           "Pre-existing, chronic, routine, elective, sanctions-excluded, fraudulent, and non-acute scenarios remain outside the marketed coverage boundary.",
         ],
       },
@@ -207,10 +208,10 @@ export const GENESIS_PROTECT_DISCLOSURE_PAGES: Record<"technicalTerms" | "riskDi
         eyebrow: "Economic separation",
         title: "Membership fees are not reserve",
         copy:
-          "OmegaX Health app membership remains commercially separate from Genesis Protect premiums. Membership fees should not be interpreted as claims-paying reserve, and sponsor support should not be described as making app membership itself into protection capital.",
+          "OmegaX Health app membership remains commercially separate from Genesis Protect premiums. Membership fees and pending reservations should not be interpreted as claims-paying reserve, and sponsor support should not be described as making app membership itself into protection capital.",
         bullets: [
           "App membership supports the app experience and AI health support.",
-          "Protection premiums activate the per-window protection lane.",
+          "Protection premiums activate the per-window protection lane only after the relevant posting and activation rules are satisfied.",
           "Sponsor-funded cohorts can fund protection while still preserving that separation.",
         ],
       },

--- a/frontend/public/metadata/plans/genesis-protect-acute-v1.json
+++ b/frontend/public/metadata/plans/genesis-protect-acute-v1.json
@@ -24,7 +24,7 @@
   "launchTruth": {
     "primaryLaunchSku": "travel30",
     "fastDemoSku": "event7",
-    "publicStatus": "end_of_month_mainnet_target",
+    "publicStatus": "founder_reservation_pending_activation",
     "claimsTrustPhase": "operator_backed_oracle_phase0",
     "broadlyLiveInsurance": false,
     "predictionMarketsCountAsReserve": false,

--- a/frontend/public/metadata/protection/genesis-protect-acute-event-7-v1.json
+++ b/frontend/public/metadata/protection/genesis-protect-acute-event-7-v1.json
@@ -16,6 +16,7 @@
     "coverWindowDays": 7,
     "currency": "USDC",
     "benefitStyle": "fixed_benefit_only",
+    "capMode": "fixed",
     "maxPayoutUsd": 3000
   },
   "pricing": {
@@ -105,7 +106,7 @@
   },
   "issuanceControls": {
     "reserveAttribution": "Only posted capital, collected premiums, and explicit sponsor or backstop funds count as claims-paying reserve.",
-    "publicStatusRule": "Keep Event 7 positioned as the fast-demo SKU for a bounded end-of-month mainnet launch target. Do not describe it as broadly live insurance today.",
+    "publicStatusRule": "Keep Event 7 positioned as the fast-demo SKU for a bounded pending-activation launch target. Do not describe it as broadly live insurance today.",
     "issueWhen": [
       "Event 7 reserve lanes are funded onchain or by explicit sponsor/backstop posting.",
       "Operator-backed claim review is staffed for the active issuance window.",
@@ -118,7 +119,7 @@
     ]
   },
   "launchTruth": {
-    "publicStatus": "end_of_month_mainnet_target",
+    "publicStatus": "founder_reservation_pending_activation",
     "primaryLaunchSku": "travel30",
     "fastDemoSku": "event7",
     "claimsTrustPhase": "operator_backed_oracle_phase0",

--- a/frontend/public/metadata/protection/genesis-protect-acute-travel-30-v1.json
+++ b/frontend/public/metadata/protection/genesis-protect-acute-travel-30-v1.json
@@ -16,7 +16,12 @@
     "coverWindowDays": 30,
     "currency": "USDC",
     "benefitStyle": "hybrid_fixed_plus_reimbursement",
-    "maxPayoutUsd": 5000
+    "capMode": "reserve_indexed",
+    "maxPayoutUsd": null,
+    "targetSeatCount": 100,
+    "targetMaxBenefitUsd": 250000,
+    "historicalFixedCapUsd": 5000,
+    "activationCapRule": "The exact Travel 30 cap locks only at activation from the posted claims-paying reserve/backstop snapshot, terms hash, waiting periods, exclusions, and quote expiry."
   },
   "pricing": {
     "retailUsd": 99,
@@ -46,10 +51,29 @@
       }
     ],
     "reimbursementTopUp": {
-      "aggregateCapUsd": 5000,
-      "description": "Actual acute emergency medical spend above the fixed tier benefit, capped at the aggregate maximum."
+      "aggregateCapUsd": 250000,
+      "capMode": "reserve_indexed",
+      "description": "Target aggregate maximum for Founder access. The active reimbursement top-up cap is reserve-indexed and locks only at activation."
     }
   },
+  "capLadder": [
+    {
+      "reserveBackstopUsd": 250000,
+      "maxBenefitUsd": 25000
+    },
+    {
+      "reserveBackstopUsd": 750000,
+      "maxBenefitUsd": 75000
+    },
+    {
+      "reserveBackstopUsd": 1500000,
+      "maxBenefitUsd": 150000
+    },
+    {
+      "reserveBackstopUsd": 2500000,
+      "maxBenefitUsd": 250000
+    }
+  ],
   "waitingPeriods": {
     "illnessDays": 7,
     "accidentHours": 24,
@@ -92,12 +116,12 @@
   },
   "commercialLayers": {
     "appMembership": "Separate OmegaX Health app subscription for AI health agent value and premium app features.",
-    "protectionPremium": "Per-window premium that activates Travel 30 protection eligibility in the protocol."
+    "protectionPremium": "Founder reservation/access payment holds a place and price for Travel 30. Active protection starts only after activation locks exact cap and terms."
   },
   "fundingLanes": {
     "premium": {
       "lineId": "genesis-travel30-premiums",
-      "reserveRole": "Collected premiums attributed to the Travel 30 protection reserve lane."
+      "reserveRole": "Collected premiums attributed to the Travel 30 protection reserve lane after the relevant activation/posting rules are satisfied."
     },
     "liquidity": {
       "lineId": "genesis-travel30-liquidity",
@@ -106,20 +130,21 @@
   },
   "issuanceControls": {
     "reserveAttribution": "Only posted capital, collected premiums, and explicit backstop funds count as claims-paying reserve.",
-    "publicStatusRule": "Keep Travel 30 positioned as the primary SKU for a bounded end-of-month mainnet launch target. Do not describe it as broadly live insurance today.",
+    "publicStatusRule": "Keep Travel 30 positioned as 99 USDC Founder access for the first 100-seat cohort, targeting reserve-indexed benefits up to 250,000 USDC only after posted reserve/backstop proof and final terms support activation. Do not describe it as broadly live insurance today.",
     "issueWhen": [
-      "Travel 30 reserve lanes are funded onchain with published premium and liquidity support.",
+      "Travel 30 reserve lanes have posted claims-paying reserve/backstop that meets the published cap ladder threshold.",
+      "Activation quotes lock exact cap, reserve snapshot/hash, terms hash, waiting periods, exclusions, and quote expiry.",
       "Operator-backed claim review is staffed for the active issuance window.",
       "The shared public evidence schema stays aligned with the published metadata document."
     ],
     "pauseWhen": [
-      "Posted reserve no longer covers the marketed issuance window.",
+      "Posted reserve/backstop proof cannot support any published activation cap.",
       "Claims operator or oracle staffing falls below the required phase-0 review readiness.",
       "Schema, pricing, or benefit truth drifts from the published Genesis metadata."
     ]
   },
   "launchTruth": {
-    "publicStatus": "end_of_month_mainnet_target",
+    "publicStatus": "founder_reservation_pending_activation",
     "primaryLaunchSku": "travel30",
     "fastDemoSku": "event7",
     "claimsTrustPhase": "operator_backed_oracle_phase0",

--- a/frontend/public/metadata/protection/genesis-protect-acute-travel-30-v1.json
+++ b/frontend/public/metadata/protection/genesis-protect-acute-travel-30-v1.json
@@ -70,6 +70,10 @@
       "maxBenefitUsd": 150000
     },
     {
+      "reserveBackstopUsd": 2000000,
+      "maxBenefitUsd": 200000
+    },
+    {
       "reserveBackstopUsd": 2500000,
       "maxBenefitUsd": 250000
     }

--- a/scripts/devnet_magicblock_claim_review_smoke.ts
+++ b/scripts/devnet_magicblock_claim_review_smoke.ts
@@ -121,6 +121,19 @@ const SEED_SESSION = Buffer.from("private_claim_review", "utf8");
 const BASE_RPC_DEFAULT = "https://api.devnet.solana.com";
 const TEE_RPC_DEFAULT = "https://devnet-tee.magicblock.app";
 const TEE_WS_DEFAULT = "wss://tee.magicblock.app";
+const MAX_SEND_ATTEMPTS = 4;
+const RETRYABLE_SEND_ERROR_PATTERNS = [
+  /block height exceeded/i,
+  /blockhash not found/i,
+  /expired/i,
+  /timed out/i,
+  /timeout/i,
+  /ETIMEDOUT/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /fetch failed/i,
+  /429/,
+];
 
 function parseArgs(args: string[]): CliOptions {
   const options: CliOptions = {
@@ -645,36 +658,76 @@ async function sendTransaction(params: {
   instructions: TransactionInstruction[];
   skipPreflight?: boolean;
 }): Promise<string> {
-  const latestBlockhash = await params.connection.getLatestBlockhash("confirmed");
-  const transaction = new Transaction();
-  transaction.feePayer = params.payer.publicKey;
-  transaction.recentBlockhash = latestBlockhash.blockhash;
-  transaction.add(...params.instructions);
-  transaction.sign(params.payer);
+  let lastSubmittedSignature: string | null = null;
+  for (let attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt += 1) {
+    let signature: string | null = null;
+    try {
+      const latestBlockhash = await params.connection.getLatestBlockhash("confirmed");
+      const transaction = new Transaction();
+      transaction.feePayer = params.payer.publicKey;
+      transaction.recentBlockhash = latestBlockhash.blockhash;
+      transaction.add(...params.instructions);
+      transaction.sign(params.payer);
 
-  let signature: string | null = null;
-  try {
-    signature = await params.connection.sendRawTransaction(transaction.serialize(), {
-      skipPreflight: params.skipPreflight ?? false,
-      maxRetries: 5,
-    });
-    const confirmation = await params.connection.confirmTransaction({
-      signature,
-      blockhash: latestBlockhash.blockhash,
-      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
-    }, "confirmed");
-    if (confirmation.value.err) {
-      throw new Error(JSON.stringify(confirmation.value.err));
+      signature = await params.connection.sendRawTransaction(transaction.serialize(), {
+        skipPreflight: params.skipPreflight ?? false,
+        maxRetries: 5,
+      });
+      lastSubmittedSignature = signature;
+      const confirmation = await params.connection.confirmTransaction({
+        signature,
+        blockhash: latestBlockhash.blockhash,
+        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+      }, "confirmed");
+      if (confirmation.value.err) {
+        throw new Error(JSON.stringify(confirmation.value.err));
+      }
+      console.log(`${params.label}: ${signature}`);
+      return signature;
+    } catch (cause) {
+      const logs = await logsFromSendError(params.connection, cause);
+      const detail = [
+        `${params.label} failed${signature ? ` (${signature})` : ""}: ${messageFromError(cause)}`,
+        logs.length > 0 ? logs.join("\n") : null,
+      ].filter(Boolean).join("\n");
+      if (lastSubmittedSignature && isAlreadyAppliedAfterRetry(params.label, detail)) {
+        console.warn(
+          `${params.label} observed an already-applied state after retry; treating prior signature as successful: ${lastSubmittedSignature}`,
+        );
+        return lastSubmittedSignature;
+      }
+      if (attempt >= MAX_SEND_ATTEMPTS || !isRetryableSendError(cause, logs)) {
+        throw new Error(detail);
+      }
+      console.warn(
+        `${params.label} attempt ${attempt}/${MAX_SEND_ATTEMPTS} hit a transient send failure; retrying with a fresh blockhash.`,
+      );
+      await sleep(1_000 * attempt);
     }
-    console.log(`${params.label}: ${signature}`);
-    return signature;
-  } catch (cause) {
-    const logs = await logsFromSendError(params.connection, cause);
-    throw new Error([
-      `${params.label} failed${signature ? ` (${signature})` : ""}: ${messageFromError(cause)}`,
-      logs.length > 0 ? logs.join("\n") : null,
-    ].filter(Boolean).join("\n"));
   }
+  throw new Error(`${params.label} failed after ${MAX_SEND_ATTEMPTS} attempts`);
+}
+
+function isRetryableSendError(cause: unknown, logs: string[]): boolean {
+  const text = `${messageFromError(cause)}\n${logs.join("\n")}`;
+  return RETRYABLE_SEND_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isAlreadyAppliedAfterRetry(label: string, detail: string): boolean {
+  if (
+    (label === "commit_and_close_review_session" ||
+      label === "finalize_committed_review_session") &&
+    /ReviewAlreadyCommitted/i.test(detail)
+  ) {
+    return true;
+  }
+  if (
+    label === "open_review_session" &&
+    /account.*already in use|already in use/i.test(detail)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 async function logsFromSendError(connection: Connection, cause: unknown): Promise<string[]> {
@@ -738,9 +791,13 @@ async function waitFor<T>(
     } catch (cause) {
       lastError = cause;
     }
-    await new Promise((resolveWait) => setTimeout(resolveWait, 2_000));
+    await sleep(2_000);
   }
   throw new Error(`Timed out waiting for ${label}${lastError ? `: ${messageFromError(lastError)}` : ""}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveWait) => setTimeout(resolveWait, ms));
 }
 
 async function readReviewSession(

--- a/scripts/genesis_actuarial_review.ts
+++ b/scripts/genesis_actuarial_review.ts
@@ -151,7 +151,10 @@ type PublicMetadata = {
     displayName: string;
     coverWindowDays: number;
     benefitStyle: string;
-    maxPayoutUsd: number;
+    capMode?: "fixed" | "reserve_indexed";
+    maxPayoutUsd: number | null;
+    historicalFixedCapUsd?: number;
+    targetMaxBenefitUsd?: number;
   };
   pricing: {
     retailUsd: number;
@@ -197,7 +200,13 @@ function validateMetadata(assumptions: Assumptions): void {
     assertEqual(metadata.product.displayName, sku.displayName, `${skuKey} displayName drift`);
     assertEqual(metadata.product.coverWindowDays, sku.coverWindowDays, `${skuKey} coverWindowDays drift`);
     assertEqual(metadata.product.benefitStyle, sku.benefitStyle, `${skuKey} benefitStyle drift`);
-    assertEqual(metadata.product.maxPayoutUsd, sku.maxPayoutUsd, `${skuKey} maxPayoutUsd drift`);
+    if (metadata.product.capMode === "reserve_indexed") {
+      assertEqual(metadata.product.maxPayoutUsd, null, `${skuKey} reserve-indexed active cap drift`);
+      assertEqual(metadata.product.historicalFixedCapUsd, sku.maxPayoutUsd, `${skuKey} historical cap drift`);
+      assertEqual(metadata.product.targetMaxBenefitUsd, 250_000, `${skuKey} target max benefit drift`);
+    } else {
+      assertEqual(metadata.product.maxPayoutUsd, sku.maxPayoutUsd, `${skuKey} maxPayoutUsd drift`);
+    }
     assertEqual(metadata.pricing.retailUsd, sku.retailPremiumUsd, `${skuKey} retail premium drift`);
     assertEqual(metadata.pricing.cohortUsdMin, sku.cohortPremiumUsdMin, `${skuKey} cohort min drift`);
     assertEqual(metadata.pricing.cohortUsdMax, sku.cohortPremiumUsdMax, `${skuKey} cohort max drift`);

--- a/tests/genesis_actuarial_review.test.ts
+++ b/tests/genesis_actuarial_review.test.ts
@@ -17,7 +17,13 @@ test("Genesis actuarial assumptions match public metadata", () => {
     const metadata = readJson<any>(join(process.cwd(), model.metadataPath));
     assert.equal(metadata.product.coverWindowDays, model.coverWindowDays, `${sku} cover window drift`);
     assert.equal(metadata.product.benefitStyle, model.benefitStyle, `${sku} benefit style drift`);
-    assert.equal(metadata.product.maxPayoutUsd, model.maxPayoutUsd, `${sku} max payout drift`);
+    if (metadata.product.capMode === "reserve_indexed") {
+      assert.equal(metadata.product.maxPayoutUsd, null, `${sku} reserve-indexed cap should not imply active cover`);
+      assert.equal(metadata.product.historicalFixedCapUsd, model.maxPayoutUsd, `${sku} historical cap drift`);
+      assert.equal(metadata.product.targetMaxBenefitUsd, 250_000, `${sku} target max benefit drift`);
+    } else {
+      assert.equal(metadata.product.maxPayoutUsd, model.maxPayoutUsd, `${sku} max payout drift`);
+    }
     assert.equal(metadata.pricing.retailUsd, model.retailPremiumUsd, `${sku} retail premium drift`);
     assert.equal(metadata.pricing.cohortUsdMin, model.cohortPremiumUsdMin, `${sku} cohort min drift`);
     assert.equal(metadata.pricing.cohortUsdMax, model.cohortPremiumUsdMax, `${sku} cohort max drift`);

--- a/tests/genesis_protect_acute_disclosures.test.ts
+++ b/tests/genesis_protect_acute_disclosures.test.ts
@@ -45,11 +45,13 @@ test("Genesis Protect disclosure pages keep canonical URLs and launch-truth lang
 
   assert.match(technicalTermsText, /shared public metadata route used by DeFi-native protection series/i);
   assert.match(riskDisclosuresText, /can be referenced by generic DeFi-native protection metadata/i);
-  assert.match(technicalTermsText, /Travel 30 is the primary launch SKU/i);
+  assert.match(technicalTermsText, /Travel 30 is the primary Founder reservation SKU/i);
   assert.match(technicalTermsText, /Event 7 is the fast demo SKU/i);
+  assert.match(technicalTermsText, /Founder reservations pending activation/i);
   assert.match(technicalTermsText, /Retail-open and sponsor-configured cohort issuance are both allowed in v1/i);
   assert.match(technicalTermsText, /Phase 0 AI-assisted review under operator oversight/i);
   assert.match(riskDisclosuresText, /membership remains commercially separate from Genesis Protect premiums/i);
+  assert.match(riskDisclosuresText, /Do not read a Travel 30 Founder reservation as active cover or a live 250,000 USDC cap/i);
   assert.match(riskDisclosuresText, /do not read roadmap language about AI or decentralized review as current live fact/i);
 
   assert.doesNotMatch(technicalTermsText, /AI-led review/i);

--- a/tests/genesis_protect_acute_launch.test.ts
+++ b/tests/genesis_protect_acute_launch.test.ts
@@ -19,6 +19,9 @@ const {
   GENESIS_PROTECT_ACUTE_SENIOR_CLASS_ID,
   GENESIS_PROTECT_ACUTE_SKUS,
   GENESIS_PROTECT_ACUTE_TECHNICAL_TERMS_URL,
+  GENESIS_PROTECT_TRAVEL30_CAP_LADDER,
+  GENESIS_PROTECT_TRAVEL30_FOUNDER_SEAT_COUNT,
+  GENESIS_PROTECT_TRAVEL30_TARGET_MAX_BENEFIT_USD,
 } = genesisCatalogModule as typeof import("../frontend/lib/genesis-protect-acute.ts");
 const { DEVNET_PROTOCOL_FIXTURE_STATE } = fixturesModule as typeof import("../frontend/lib/devnet-fixtures.ts");
 const { parseProtectionPosture } = planLaunchModule as typeof import("../frontend/lib/plan-launch.ts");
@@ -32,7 +35,12 @@ type GenesisProtectionMetadataDocument = {
     displayName: string;
     coverWindowDays: number;
     benefitStyle: string;
-    maxPayoutUsd: number;
+    capMode: "fixed" | "reserve_indexed";
+    maxPayoutUsd: number | null;
+    targetSeatCount?: number;
+    targetMaxBenefitUsd?: number;
+    historicalFixedCapUsd?: number;
+    activationCapRule?: string;
   };
   pricing: {
     retailUsd: number;
@@ -46,10 +54,15 @@ type GenesisProtectionMetadataDocument = {
       trigger: string;
     }>;
     reimbursementTopUp?: {
-      aggregateCapUsd: number;
+      aggregateCapUsd: number | null;
+      capMode?: "fixed" | "reserve_indexed";
       description: string;
     };
   };
+  capLadder?: Array<{
+    reserveBackstopUsd: number;
+    maxBenefitUsd: number;
+  }>;
   waitingPeriods: {
     illnessDays: number;
     accidentHours: number;
@@ -147,6 +160,7 @@ test("Genesis Protect Acute metadata documents encode the canonical Event 7 and 
   assert.equal(event7Document.product.sku, "Event 7");
   assert.equal(event7Document.product.coverWindowDays, GENESIS_PROTECT_ACUTE_SKUS.event7.coverWindowDays);
   assert.equal(event7Document.product.benefitStyle, GENESIS_PROTECT_ACUTE_SKUS.event7.benefitStyle);
+  assert.equal(event7Document.product.capMode, "fixed");
   assert.equal(event7Document.product.maxPayoutUsd, GENESIS_PROTECT_ACUTE_SKUS.event7.payoutCapUsd);
   assert.equal(event7Document.pricing.retailUsd, GENESIS_PROTECT_ACUTE_SKUS.event7.pricing.retailUsd);
   assert.deepEqual(
@@ -186,7 +200,13 @@ test("Genesis Protect Acute metadata documents encode the canonical Event 7 and 
   assert.equal(travel30Document.product.sku, "Travel 30");
   assert.equal(travel30Document.product.coverWindowDays, GENESIS_PROTECT_ACUTE_SKUS.travel30.coverWindowDays);
   assert.equal(travel30Document.product.benefitStyle, GENESIS_PROTECT_ACUTE_SKUS.travel30.benefitStyle);
-  assert.equal(travel30Document.product.maxPayoutUsd, GENESIS_PROTECT_ACUTE_SKUS.travel30.payoutCapUsd);
+  assert.equal(travel30Document.product.capMode, "reserve_indexed");
+  assert.equal(travel30Document.product.maxPayoutUsd, null);
+  assert.equal(travel30Document.product.targetSeatCount, GENESIS_PROTECT_TRAVEL30_FOUNDER_SEAT_COUNT);
+  assert.equal(travel30Document.product.targetMaxBenefitUsd, GENESIS_PROTECT_TRAVEL30_TARGET_MAX_BENEFIT_USD);
+  assert.equal(travel30Document.product.historicalFixedCapUsd, 5_000);
+  assert.match(travel30Document.product.activationCapRule ?? "", /exact Travel 30 cap locks only at activation/);
+  assert.deepEqual(travel30Document.capLadder, GENESIS_PROTECT_TRAVEL30_CAP_LADDER);
   assert.equal(travel30Document.pricing.retailUsd, GENESIS_PROTECT_ACUTE_SKUS.travel30.pricing.retailUsd);
   assert.deepEqual(
     travel30Document.benefitSchedule.tiers.map((tier) => tier.benefitUsd),
@@ -196,6 +216,7 @@ test("Genesis Protect Acute metadata documents encode the canonical Event 7 and 
     travel30Document.benefitSchedule.reimbursementTopUp?.aggregateCapUsd,
     GENESIS_PROTECT_ACUTE_SKUS.travel30.reimbursementTopUp?.aggregateCapUsd,
   );
+  assert.equal(travel30Document.benefitSchedule.reimbursementTopUp?.capMode, "reserve_indexed");
   assert.equal(travel30Document.waitingPeriods.illnessDays, GENESIS_PROTECT_ACUTE_SKUS.travel30.waitingPeriods.illnessDays);
   assert.equal(travel30Document.waitingPeriods.accidentHours, GENESIS_PROTECT_ACUTE_SKUS.travel30.waitingPeriods.accidentHours);
   assert.equal(travel30Document.waitingPeriods.sponsorCohortWaiverAllowed, true);
@@ -215,9 +236,9 @@ test("Genesis Protect Acute metadata documents encode the canonical Event 7 and 
     travel30Document.issuanceControls.publicStatusRule,
     GENESIS_PROTECT_ACUTE_SKUS.travel30.issuanceControls.publicStatusRule,
   );
-  assert.equal(travel30Document.issuanceControls.issueWhen.length, 3);
+  assert.equal(travel30Document.issuanceControls.issueWhen.length, 4);
   assert.equal(travel30Document.issuanceControls.pauseWhen.length, 3);
-  assert.equal(travel30Document.launchTruth.publicStatus, "end_of_month_mainnet_target");
+  assert.equal(travel30Document.launchTruth.publicStatus, "founder_reservation_pending_activation");
   assert.equal(travel30Document.launchTruth.primaryLaunchSku, "travel30");
   assert.equal(travel30Document.launchTruth.fastDemoSku, "event7");
   assert.equal(travel30Document.launchTruth.claimsTrustPhase, "operator_backed_oracle_phase0");


### PR DESCRIPTION
## Summary
- update Genesis Protect Travel 30 metadata with the 2,000,000 USD reserve/backstop -> 200,000 USD cap ladder step
- document the /protect/devnet 200k demo cap boundary as QA-only, not mainnet cover
- include the existing local MagicBlock devnet smoke hardening commit that was already ahead of origin/main

## Validation
- npm run test:node (287 tests passed)