### PR TITLE
[codex] Remediate ws advisory and RPC key hygiene

### DIFF
--- a/docs/operations/dependency-advisory-risk-acceptance.md
+++ b/docs/operations/dependency-advisory-risk-acceptance.md
@@ -1,6 +1,6 @@
 # Dependency Advisory Risk Acceptance
 
-Last reviewed: 2026-05-04
+Last reviewed: 2026-05-19
 
 This note records production dependency advisories that remain after the CSO remediation pass.
 It is intentionally narrow: only advisories still reported by `npm audit --omit=dev` after compatible

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,7 @@
 # The wallet connection settings expose three client-side RPC profiles:
 # - Solana Public always uses the canonical public Solana endpoints
-# - Helius uses the optional *_RPC_URL_WITH_KEY values below
+# - Helius uses the optional *_RPC_URL_WITH_KEY values below. These NEXT_PUBLIC values
+#   are bundled into the browser; only use browser-safe, origin-restricted Helius keys.
 # - Custom RPC is entered locally in the browser and is never stored in repo config
 # The legacy *_RPC_URL values remain available for compatibility if they already point at Helius.
 NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8483,9 +8483,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,9 +2292,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/scripts/check_public_repo_hygiene.mjs
+++ b/scripts/check_public_repo_hygiene.mjs
@@ -95,6 +95,16 @@ const sensitiveEnvKeys = new Set([
   'TURNSTILE_SECRET_KEY',
 ]);
 
+const publicRpcKeyEnvKeys = new Set([
+  'NEXT_PUBLIC_SOLANA_DEVNET_RPC_URL_WITH_KEY',
+  'NEXT_PUBLIC_SOLANA_MAINNET_RPC_URL_WITH_KEY',
+]);
+
+const allowedPublicRpcKeyPlaceholders = new Set([
+  'YOUR_HELIUS_API_KEY',
+  'REPLACE_WITH_BROWSER_SAFE_HELIUS_API_KEY',
+]);
+
 const appHostingSecretKeys = new Set([
   'FAUCET_INTERNAL_BASE_URL',
   'FAUCET_INTERNAL_BASE_URL_V2',
@@ -166,6 +176,42 @@ function collectSensitiveAssignmentIssues(path, content) {
 
     if (!allowedSensitiveValues.has(value)) {
       issues.push(`${path}:${index + 1} sensitive variable ${key} must be blank or use REPLACE_IN_SECRET_STORE.`);
+    }
+  }
+
+  return issues;
+}
+
+function collectPublicRpcKeyIssues(path, content) {
+  const issues = [];
+
+  for (const [index, rawLine] of content.split('\n').entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const envMatch = rawLine.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (!envMatch) {
+      continue;
+    }
+
+    const key = envMatch[1];
+    const value = normalizeEnvValue(envMatch[2] ?? '');
+    if (!key || !publicRpcKeyEnvKeys.has(key) || !value) {
+      continue;
+    }
+
+    let parsed;
+    try {
+      parsed = new URL(value);
+    } catch {
+      continue;
+    }
+
+    const apiKey = parsed.searchParams.get('api-key')?.trim();
+    if (apiKey && !allowedPublicRpcKeyPlaceholders.has(apiKey)) {
+      issues.push(`${path}:${index + 1} ${key} must not commit a real Helius API key in a NEXT_PUBLIC URL.`);
     }
   }
 
@@ -270,6 +316,10 @@ for (const file of files) {
   }
 
   for (const issue of collectSensitiveAssignmentIssues(file, content)) {
+    issues.push(issue);
+  }
+
+  for (const issue of collectPublicRpcKeyIssues(file, content)) {
     issues.push(issue);
   }
 


### PR DESCRIPTION
## Summary
- update the locked production ws resolution used through rpc-websockets to 8.20.1
- refresh the dependency advisory review date after the audit gate returns to the accepted Solana advisory set
- clarify that NEXT_PUBLIC Helius URLs must use browser-safe restricted keys
- extend public hygiene checks to block committed real Helius api-key values in NEXT_PUBLIC RPC URLs

## Validation
- npm run security:audit:deps
- npm run public:hygiene:check
- npm run test:node
- npm run frontend:build
- npm run license:audit
- npm audit --omit=dev in root and frontend now reports only the accepted 3 high Solana advisories

## Notes
- license:audit still skips the local Cargo license pass when cargo-license is not installed, matching the existing script behavior outside CI.
