### PR TITLE
Remove pumpfun curve wording

### DIFF
--- a/examples/nomad-protect-curve-poc/README.md
+++ b/examples/nomad-protect-curve-poc/README.md
@@ -36,7 +36,7 @@ The generator writes:
 
 ## Curve
 
-The PoC uses a pump.fun-style increasing quote curve over active issued coverage units:
+The PoC uses a monotonic increasing quote curve over active issued coverage units:
 
 ```text
 unit_price(u) = base_unit_premium * risk_multiplier * reserve_stress * (1 + u / curve_depth) ^ gamma


### PR DESCRIPTION
## Summary\n- removes the remaining pump.fun-style wording from the Nomad Protect curve PoC README\n\n## Validation\n- git diff --check\n- rg -n -i 'pump\.fun|pumpfun|4Aar9R14YMbEie6yh8WcH1gWXrBtfucoFjw6SpjXpump|\' .